### PR TITLE
Grant playground creators team management access

### DIFF
--- a/data/playground/create-playground-team.ts
+++ b/data/playground/create-playground-team.ts
@@ -1,0 +1,61 @@
+import { teamMembers, teams, userPermissions } from '@core/db/schema';
+import { getTeamCreationPermissions } from '@core/lib/permissions';
+import { teamExtensions } from '@peppol/db/schema';
+import type { ExtractTablesWithRelations } from 'drizzle-orm';
+import type { NodePgQueryResultHKT } from 'drizzle-orm/node-postgres';
+import type { PgTransaction } from 'drizzle-orm/pg-core';
+import type { ExtendedTeam } from '../teams';
+
+type Transaction = PgTransaction<
+  NodePgQueryResultHKT,
+  Record<string, never>,
+  ExtractTablesWithRelations<Record<string, never>>
+>;
+
+export async function createPlaygroundTeam(
+  tx: Transaction,
+  userId: string,
+  teamName: string,
+  teamDescription: string = 'Playground',
+  useTestNetwork: boolean = false,
+): Promise<ExtendedTeam> {
+  const [newTeam] = await tx
+    .insert(teams)
+    .values({
+      name: teamName,
+      teamDescription,
+    })
+    .returning();
+
+  await tx.insert(teamMembers).values({
+    userId,
+    teamId: newTeam.id,
+  });
+
+  const creationPermissions = getTeamCreationPermissions();
+  if (creationPermissions.length > 0) {
+    await tx.insert(userPermissions).values(
+      creationPermissions.map((permission) => ({
+        userId,
+        teamId: newTeam.id,
+        permissionId: permission.id,
+        grantedByUserId: null,
+      })),
+    );
+  }
+
+  const [newExtension] = await tx
+    .insert(teamExtensions)
+    .values({
+      id: newTeam.id,
+      isPlayground: true,
+      useTestNetwork,
+      verificationRequirements: 'strict',
+    })
+    .returning();
+
+  return {
+    ...newTeam,
+    ...newExtension,
+  };
+}

--- a/data/playground/playgrounds.ts
+++ b/data/playground/playgrounds.ts
@@ -1,13 +1,12 @@
-import { completeOnboardingStep } from "@core/data/onboarding";
-import { teamMembers, teams } from "@core/db/schema";
-import { teamExtensions } from "@peppol/db/schema";
-import { db } from "@recommand/db";
-import { and, eq } from "drizzle-orm";
-import type { ExtendedTeam } from "../teams";
+import { completeOnboardingStep } from '@core/data/onboarding';
+import { teams } from '@core/db/schema';
+import { teamExtensions } from '@peppol/db/schema';
+import { db } from '@recommand/db';
+import { and, eq } from 'drizzle-orm';
+import type { ExtendedTeam } from '../teams';
+import { createPlaygroundTeam } from './create-playground-team';
 
-export async function getPlayground(
-  teamId: string
-): Promise<ExtendedTeam | null> {
+export async function getPlayground(teamId: string): Promise<ExtendedTeam | null> {
   const playgrounds = await db
     .select()
     .from(teams)
@@ -25,43 +24,16 @@ export async function getPlayground(
 export async function createPlayground(
   userId: string,
   teamName: string,
-  teamDescription: string = "Playground",
-  useTestNetwork: boolean = false
+  teamDescription: string = 'Playground',
+  useTestNetwork: boolean = false,
 ): Promise<ExtendedTeam> {
-  const res = await db.transaction(async (tx) => {
-    // Create a new team
-    const [newTeam] = await tx
-      .insert(teams)
-      .values({
-        name: teamName,
-        teamDescription,
-      })
-      .returning();
+  const res = await db.transaction((tx) =>
+    createPlaygroundTeam(tx, userId, teamName, teamDescription, useTestNetwork),
+  );
 
-    // Add the user as a member
-    await tx.insert(teamMembers).values({
-      userId,
-      teamId: newTeam.id,
-    });
-
-    // Create a new playground extension
-    const [newExtension] = await tx.insert(teamExtensions).values({
-      id: newTeam.id,
-      isPlayground: true,
-      useTestNetwork,
-      verificationRequirements: "strict",
-    }).returning();
-
-    
-    return {
-      ...newTeam,
-      ...newExtension,
-    };
-  });
-  
   // Complete the peppol.billing and peppol.subscription onboarding steps as we don't need to bill or subscribe to anything for playgrounds
-  await completeOnboardingStep(userId, res.id, "peppol.billing");
-  await completeOnboardingStep(userId, res.id, "peppol.subscription");
+  await completeOnboardingStep(userId, res.id, 'peppol.billing');
+  await completeOnboardingStep(userId, res.id, 'peppol.subscription');
 
   return res;
 }

--- a/test/playground-team-permissions.test.ts
+++ b/test/playground-team-permissions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test';
+import { teamMembers, teams, userPermissions } from '@core/db/schema';
+import { teamExtensions } from '@peppol/db/schema';
+import { createPlaygroundTeam } from '../data/playground/create-playground-team';
+
+type Insert = {
+  table: unknown;
+  values: unknown;
+};
+
+const inserts: Insert[] = [];
+
+const transaction = {
+  insert(table: unknown) {
+    return {
+      values(values: unknown) {
+        inserts.push({ table, values });
+
+        if (table === teams) {
+          return {
+            returning: async () => [
+              {
+                id: 'team_playground',
+                name: 'Playground',
+                teamDescription: 'Playground',
+              },
+            ],
+          };
+        }
+
+        if (table === teamExtensions) {
+          return {
+            returning: async () => [
+              {
+                id: 'team_playground',
+                isPlayground: true,
+                useTestNetwork: false,
+                verificationRequirements: 'strict',
+              },
+            ],
+          };
+        }
+
+        return Promise.resolve();
+      },
+    };
+  },
+};
+
+describe('playground team creation', () => {
+  it('grants the creator permission to manage the new team', async () => {
+    inserts.length = 0;
+
+    await createPlaygroundTeam(transaction as never, 'user_creator', 'Playground');
+
+    expect(inserts).toContainEqual({
+      table: teamMembers,
+      values: {
+        userId: 'user_creator',
+        teamId: 'team_playground',
+      },
+    });
+    const permissionInsert = inserts.find((insert) => insert.table === userPermissions);
+    expect(permissionInsert?.values).toEqual(
+      expect.arrayContaining([
+        {
+          userId: 'user_creator',
+          teamId: 'team_playground',
+          permissionId: 'core.team.manage',
+          grantedByUserId: null,
+        },
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- grant new playground creators the standard team-creation permissions
- keep team, membership, permissions, and playground extension creation atomic
- add regression coverage for core.team.manage

## Verification
- SKIP_E2E=1 bun test ./test/playground-team-permissions.test.ts
- bun run test:unit (353 passed)
- bun run build from packages/framework
- Biome check on changed TypeScript files