### PR TITLE
Persist KYC onboarding and wait for participant activation

### DIFF
--- a/api/companies/verification/get-verification-status.ts
+++ b/api/companies/verification/get-verification-status.ts
@@ -7,6 +7,7 @@ import "zod-openapi/extend";
 import { zodValidator } from "@recommand/lib/zod-validator";
 import { describeRoute } from "hono-openapi";
 import { UserFacingError } from "@directory/utils/util";
+import { getArratechVerificationProgress } from "@peppol/data/at/kyc-onboarding-state";
 
 const server = new Server();
 
@@ -39,9 +40,10 @@ async function _getVerificationStatusImplementation(c: GetVerificationStatusCont
 
         return c.json(actionSuccess({
             status: verificationLog.status,
-            errorMessage: verificationLog.errorMessage,
+            errorMessage: verificationLog.arratechOnboarding ? null : verificationLog.errorMessage,
             companyName: company.name,
             companyId: company.id,
+            ...getArratechVerificationProgress(verificationLog.arratechOnboarding, company.isSmpRecipient, verificationLog.status),
         }));
     } catch (error) {
         console.error(error);

--- a/api/internal/didit-webhook.ts
+++ b/api/internal/didit-webhook.ts
@@ -122,8 +122,6 @@ server.post(
         return c.json(actionSuccess({ message: "Verification status not changed (already verified)" }), 200);
       }
 
-      // Arratech companies are only verified once Arratech accepts their KYC,
-      // which support confirms manually.
       if (isVerified && await requiresArratechKycReview(company)) {
         const kycReview = await startArratechKycReview({
           companyVerificationLogId: companyVerificationLogRecord.id,
@@ -134,7 +132,7 @@ server.post(
           actionSuccess({
             message:
               kycReview.status === "inReview"
-                ? "Verification is awaiting Arratech KYC acceptance"
+                ? "Verification is awaiting platform activation"
                 : "Verification status not changed (already finalized)",
           }),
           200

--- a/app/(public)/company-verification/[companyVerificationLogId]/status/page.tsx
+++ b/app/(public)/company-verification/[companyVerificationLogId]/status/page.tsx
@@ -23,6 +23,8 @@ type StatusData = {
     errorMessage: string | null;
     companyName: string;
     companyId: string;
+    activationPending?: boolean;
+    supportReviewPending?: boolean;
 };
 
 function DashboardLink() {
@@ -68,6 +70,8 @@ export default function Page() {
                 errorMessage: string | null;
                 companyName: string;
                 companyId: string;
+                activationPending?: boolean;
+                supportReviewPending?: boolean;
             };
 
             const status = data.status;
@@ -77,7 +81,7 @@ export default function Page() {
                 return;
             }
 
-            setStatusData({ status, errorMessage: data.errorMessage, companyName: data.companyName, companyId: data.companyId });
+            setStatusData({ ...data, status });
             setIsLoading(false);
 
             if ((FINAL_STATUSES as readonly string[]).includes(status) && intervalRef.current) {
@@ -217,8 +221,12 @@ export default function Page() {
                     <StatusHero
                         tone="info"
                         icon={Clock}
-                        title={t`Verification Under Review`}
-                        description={t`Your identity verification for ${statusData.companyName} is being reviewed manually. This page will update automatically once the review is complete.`}
+                        title={statusData.activationPending ? t`Company activation in progress` : t`Verification Under Review`}
+                        description={statusData.supportReviewPending
+                            ? t`Your request is being processed by our support team. You will receive a message when there is an update.`
+                            : statusData.activationPending
+                            ? t`Your identity has been verified. We are completing your company's network registration. This page will update automatically when activation is complete.`
+                            : t`Your identity verification for ${statusData.companyName} is being reviewed manually. This page will update automatically once the review is complete.`}
                     />
 
                     <Card>
@@ -226,7 +234,7 @@ export default function Page() {
                             <div className="flex items-center gap-3">
                                 <Clock className="h-5 w-5 text-muted-foreground shrink-0" />
                                 <div>
-                                    <p className="text-sm font-medium">{t`Manual review in progress`}</p>
+                                    <p className="text-sm font-medium">{statusData.activationPending ? t`Company activation in progress` : t`Manual review in progress`}</p>
                                     <p className="text-xs text-muted-foreground">{t`This may take some time. You can safely close this page and check back later.`}</p>
                                 </div>
                             </div>

--- a/data/at/kyc-onboarding-client.ts
+++ b/data/at/kyc-onboarding-client.ts
@@ -1,0 +1,99 @@
+import { createHash } from 'node:crypto';
+
+export type KycRecord = {
+  status: string;
+  jurisdiction: string;
+  metaData: { siren?: string; siret?: string };
+  documents: string[];
+  rejectionReason?: string;
+};
+
+export class KycOnboardingError extends Error {
+  constructor(
+    message: string,
+    readonly retryable = false,
+  ) {
+    super(message);
+  }
+}
+
+type Request = (path: string, options: RequestInit) => Promise<Response>;
+
+export async function readKycResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const message = await response.text();
+    throw new KycOnboardingError(
+      `Arratech HTTP ${response.status}: ${message}`,
+      response.status >= 500 || response.status === 429 || response.status === 408,
+    );
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function ensureApprovedKyc({
+  request,
+  path,
+  siren,
+  siret,
+  mandate,
+  fileName,
+}: {
+  request: Request;
+  path: string;
+  siren: string;
+  siret: string;
+  mandate: Buffer;
+  fileName: string;
+}): Promise<void> {
+  let response = await request(path, { method: 'GET' });
+  if (response.status === 404) {
+    const error = (await response.clone().json()) as { code?: string };
+    if (error.code !== 'AT-7001') await readKycResponse(response);
+    const created = await request(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jurisdiction: 'FR', metaData: { siren, siret } }),
+    });
+    if (created.status !== 409) await readKycResponse(created);
+    response = await request(path, { method: 'GET' });
+  }
+  const kyc = await readKycResponse<KycRecord>(response);
+  if (kyc.jurisdiction !== 'FR' || kyc.metaData?.siren !== siren || kyc.metaData?.siret !== siret) {
+    throw new KycOnboardingError(
+      'KYC identity does not match the signed mandate; review the SIREN and SIRET.',
+    );
+  }
+  if (kyc.status === 'APPROVED') return;
+  if (kyc.status !== 'PENDING') {
+    throw new KycOnboardingError(
+      `KYC is ${kyc.status}: ${kyc.rejectionReason ?? 'manual review required'}`,
+    );
+  }
+  const hash = (value: Buffer) => createHash('sha256').update(value).digest('hex');
+  const mandateHash = hash(mandate);
+  let uploaded = false;
+  for (const docId of kyc.documents ?? []) {
+    const document = await request(`${path}/documents/${encodeURIComponent(docId)}`, {
+      method: 'GET',
+    });
+    if (!document.ok) await readKycResponse(document);
+    if (hash(Buffer.from(await document.arrayBuffer())) === mandateHash) {
+      uploaded = true;
+      break;
+    }
+  }
+  if (!uploaded) {
+    const form = new FormData();
+    form.append('file', new Blob([new Uint8Array(mandate)], { type: 'application/pdf' }), fileName);
+    await readKycResponse(await request(`${path}/documents`, { method: 'POST', body: form }));
+  }
+  const approval = await request(`${path}/approve`, { method: 'POST' });
+  if (approval.status !== 409) await readKycResponse(approval);
+  const verified = await readKycResponse<KycRecord>(await request(path, { method: 'GET' }));
+  if (verified.status !== 'APPROVED') {
+    throw new KycOnboardingError(
+      `KYC approval not confirmed (${verified.status})`,
+      verified.status === 'PENDING',
+    );
+  }
+}

--- a/data/at/kyc-onboarding-state.ts
+++ b/data/at/kyc-onboarding-state.ts
@@ -1,0 +1,28 @@
+export type ArratechOnboarding = {
+  phase: 'submit' | 'activation' | 'support' | 'complete' | 'blocked';
+  supportNotifiedAt?: string;
+  attempts: number;
+  nextAttemptAt: string;
+  startedAt: string;
+  filing?: {
+    siren: string;
+    siret: string;
+    addresses: string[];
+    mandateBase64: string;
+    fileName: string;
+  };
+};
+
+export function getArratechVerificationProgress(
+  state: ArratechOnboarding | null | undefined,
+  isSmpRecipient: boolean,
+  status: string,
+) {
+  const pending = status === 'inReview' && !!state;
+  return {
+    activationPending:
+      pending && isSmpRecipient && (state.phase === 'submit' || state.phase === 'activation'),
+    supportReviewPending:
+      pending && (!isSmpRecipient || state.phase === 'support' || state.phase === 'blocked'),
+  };
+}

--- a/data/at/kyc-onboarding.ts
+++ b/data/at/kyc-onboarding.ts
@@ -1,0 +1,357 @@
+import { audit, writeAuditEvent } from '@core/lib/audit';
+import type { Context } from '@recommand/lib/api';
+import { type Company, getCompanyById } from '@peppol/data/companies';
+import { getCompanyIdentifiers } from '@peppol/data/company-identifiers';
+import {
+  finalizeCompanyVerification,
+  getCompanyVerificationLog,
+  isFinalVerificationStatus,
+} from '@peppol/data/company-verification';
+import { publishCompanyVerificationEvent } from '@peppol/data/company-verification-webhooks';
+import { sendArratechKycReviewEmail } from '@peppol/data/send-arratech-kyc-review-email';
+import {
+  sendManualVerificationEmail,
+  sendManualVerificationDeclinedEmail,
+} from '@peppol/data/send-manual-verification-email';
+import { getTeamExtension } from '@peppol/data/teams';
+import { companyVerificationLog } from '@peppol/db/schema';
+import { db } from '@recommand/db';
+import type { Logger } from '@recommand/lib/logger';
+import { Cron } from 'croner';
+import { and, eq, isNotNull, sql } from 'drizzle-orm';
+import { fetchArratech, getArratechConfig } from '@peppol/data/at/client';
+import { buildArratechKycFiling } from '@peppol/data/at/kyc';
+import {
+  ensureApprovedKyc,
+  KycOnboardingError,
+  type KycRecord,
+  readKycResponse,
+} from '@peppol/data/at/kyc-onboarding-client';
+import type { ArratechOnboarding } from '@peppol/data/at/kyc-onboarding-state';
+import { getParticipantByIdentifier, upsertCompanyRegistrations } from '@peppol/data/at/smp';
+
+export class VerificationBusyError extends KycOnboardingError {
+  constructor() {
+    super('Verification is already being processed; retry shortly.', true);
+  }
+}
+
+export async function withArratechVerificationLock<T>(
+  id: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    const result = await tx.execute(
+      sql`select pg_try_advisory_xact_lock(hashtextextended(${`arratech-kyc:${id}`}, 0)) as acquired`,
+    );
+    if (!result.rows[0]?.acquired) {
+      throw new VerificationBusyError();
+    }
+    return action();
+  });
+}
+
+function request(path: string, options: RequestInit) {
+  return fetchArratech(path, {
+    ...options,
+    useTestNetwork: false,
+    signal: AbortSignal.timeout(30_000),
+  });
+}
+
+export async function assertArratechCompanyActive(companyId: string): Promise<void> {
+  const identifiers = await getCompanyIdentifiers(companyId);
+  if (!identifiers.length) throw new KycOnboardingError('Company has no participant identifiers.');
+  const config = getArratechConfig(false);
+  for (const identifier of identifiers) {
+    const participant = await getParticipantByIdentifier({ identifier, useTestNetwork: false });
+    if (!participant || participant.status !== 'ACTIVE') {
+      throw new KycOnboardingError(
+        `Participant ${identifier.scheme}:${identifier.identifier} is ${participant?.status ?? 'missing'}; waiting for Arratech activation.`,
+        true,
+      );
+    }
+    if (identifier.scheme === '0225') {
+      const kyc = await readKycResponse<KycRecord>(
+        await request(`/orgs/${config.orgId}/participants/${participant.id}/kyc`, {
+          method: 'GET',
+        }),
+      );
+      if (kyc.status !== 'APPROVED')
+        throw new KycOnboardingError(
+          `KYC is ${kyc.status}; approval is required before completion.`,
+        );
+    }
+  }
+}
+
+async function saveState(
+  id: string,
+  state: ArratechOnboarding,
+  errorMessage: string | null = null,
+) {
+  await db
+    .update(companyVerificationLog)
+    .set({ arratechOnboarding: state, errorMessage })
+    .where(eq(companyVerificationLog.id, id));
+}
+
+export async function notifyVerificationCompletion(
+  id: string,
+  company: Company,
+  state: ArratechOnboarding | null | undefined,
+  status: 'verified' | 'rejected' = 'verified',
+  context?: Context,
+) {
+  if (state?.phase === 'complete') return;
+  await publishCompanyVerificationEvent({
+    verificationEventId: id,
+    teamId: company.teamId,
+    companyId: company.id,
+    status,
+  });
+  const event = {
+    action: 'update',
+    subsystem: context ? 'admin.company_verification' : 'peppol.company_verification',
+    objectType: 'peppol.company',
+    objectId: company.id,
+    teamId: company.teamId,
+    after: { verificationStatus: status },
+    metadata: {
+      verificationLogId: id,
+      reason: context ? 'external_kyc_review' : 'arratech_activation',
+    },
+  };
+  if (context) await audit(context, event);
+  else await writeAuditEvent(event);
+  if (state) {
+    state.phase = 'complete';
+    delete state.filing;
+    await saveState(id, state);
+  }
+  try {
+    const sendEmail =
+      status === 'verified' ? sendManualVerificationEmail : sendManualVerificationDeclinedEmail;
+    await sendEmail({ teamId: company.teamId, companyName: company.name });
+  } catch (error) {
+    console.error(`Could not send verification email for ${id}:`, error);
+  }
+}
+
+async function notifySendOnlySupport(id: string, company: Company, state: ArratechOnboarding) {
+  if (state.supportNotifiedAt) return;
+  await sendArratechKycReviewEmail({
+    companyId: company.id,
+    companyName: company.name,
+    verificationLogId: id,
+    jurisdiction: company.country,
+    useTestNetwork: false,
+    sendOnly: true,
+    submissionError:
+      'This onboarding request requires manual review. Keep the verification pending until support completes the review.',
+  });
+  state.supportNotifiedAt = new Date().toISOString();
+  await saveState(id, state);
+}
+
+export async function processArratechOnboarding(id: string): Promise<void> {
+  await withArratechVerificationLock(id, async () => {
+    const log = await getCompanyVerificationLog(id);
+    if (!log?.arratechOnboarding) return;
+    const state = log.arratechOnboarding;
+    if (state.phase === 'complete' || state.phase === 'blocked') return;
+    const company = await getCompanyById(log.companyId);
+    if (!company) return;
+    if (log.status === 'verified') {
+      await notifyVerificationCompletion(id, company, state);
+      return;
+    }
+    if (isFinalVerificationStatus(log.status)) return;
+    if (state.phase === 'support') {
+      await notifySendOnlySupport(id, company, state);
+      return;
+    }
+    try {
+      const team = await getTeamExtension(company.teamId);
+      if (
+        company.country !== 'FR' ||
+        company.smpProvider !== 'at-shared-smp-fr' ||
+        team?.useTestNetwork ||
+        team?.isPlayground ||
+        team?.verificationRequirements !== 'strict'
+      ) {
+        throw new KycOnboardingError(
+          'Company settings changed; onboarding requires manual review.',
+        );
+      }
+      if (!company.isSmpRecipient) {
+        state.phase = 'support';
+        await saveState(id, state);
+        await notifySendOnlySupport(id, company, state);
+        return;
+      }
+      if (
+        !log.mandateAcceptedAt ||
+        !log.verificationProofReference ||
+        !log.firstName ||
+        !log.lastName
+      ) {
+        throw new KycOnboardingError(
+          'A signed mandate and completed identity verification are required.',
+        );
+      }
+      if (
+        log.enterpriseNumber !== company.enterpriseNumber ||
+        log.companyName !== company.name ||
+        log.country !== company.country ||
+        log.address !== company.address ||
+        log.postalCode !== company.postalCode ||
+        log.city !== company.city
+      ) {
+        throw new KycOnboardingError(
+          'Company details changed since the mandate was signed; start a new verification.',
+        );
+      }
+      const identifiers = await getCompanyIdentifiers(company.id);
+      if (!identifiers.length || identifiers.some((identifier) => identifier.scheme !== '0225')) {
+        throw new KycOnboardingError(
+          'Automatic French onboarding requires 0225 participant identifiers.',
+        );
+      }
+      if (!state.filing) {
+        const filing = await buildArratechKycFiling({
+          company,
+          signatory: { firstName: log.firstName, lastName: log.lastName },
+          signedAt: log.mandateAcceptedAt,
+          proofReference: log.verificationProofReference,
+          reference: log.id,
+        });
+        if (
+          filing.identity.notes.length ||
+          !filing.identity.metaData?.siret ||
+          !filing.identity.metaData?.siren
+        ) {
+          throw new KycOnboardingError(
+            `An explicit SIRET is required for automatic approval. ${filing.identity.notes.join(' ')}`,
+          );
+        }
+        state.filing = {
+          siren: filing.identity.metaData.siren,
+          siret: filing.identity.metaData.siret,
+          addresses: filing.electronicAddresses,
+          mandateBase64: filing.mandate.toString('base64'),
+          fileName: filing.mandateFileName,
+        };
+        await saveState(id, state);
+      }
+      const filing = state.filing;
+      const addresses = identifiers
+        .map((identifier) => `${identifier.scheme}:${identifier.identifier}`)
+        .sort();
+      if (JSON.stringify(addresses) !== JSON.stringify([...filing.addresses].sort())) {
+        throw new KycOnboardingError(
+          'Participant identifiers changed since the mandate was prepared.',
+        );
+      }
+      if (state.phase === 'submit') {
+        await upsertCompanyRegistrations({
+          companyId: company.id,
+          useTestNetwork: false,
+          includeCapabilities: false,
+          siret: filing.siret,
+        });
+        const config = getArratechConfig(false);
+        for (const identifier of identifiers) {
+          const participant = await getParticipantByIdentifier({
+            identifier,
+            useTestNetwork: false,
+          });
+          if (!participant)
+            throw new KycOnboardingError('Participant creation was not confirmed.', true);
+          await ensureApprovedKyc({
+            request,
+            path: `/orgs/${config.orgId}/participants/${participant.id}/kyc`,
+            siren: filing.siren,
+            siret: filing.siret,
+            mandate: Buffer.from(filing.mandateBase64, 'base64'),
+            fileName: filing.fileName,
+          });
+        }
+        state.phase = 'activation';
+        state.attempts = 0;
+        await saveState(id, state);
+      }
+      await assertArratechCompanyActive(company.id);
+      await upsertCompanyRegistrations({ companyId: company.id, useTestNetwork: false });
+      const current = await getCompanyVerificationLog(id);
+      if (!current || isFinalVerificationStatus(current.status)) return;
+      const result = await finalizeCompanyVerification({
+        companyVerificationLogId: id,
+        company,
+        status: 'verified',
+        verificationProofReference: log.verificationProofReference,
+      });
+      if (result.status !== 'verified')
+        throw new KycOnboardingError(result.errorMessage ?? 'Company activation failed.');
+      await notifyVerificationCompletion(id, company, state);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const retryable = !(error instanceof KycOnboardingError) || error.retryable;
+      state.attempts++;
+      const expired = Date.now() - Date.parse(state.startedAt) > 72 * 60 * 60 * 1000;
+      if (!retryable || expired || (state.phase === 'submit' && state.attempts >= 12)) {
+        state.phase = 'blocked';
+        await saveState(id, state, message);
+        await sendArratechKycReviewEmail({
+          companyId: company.id,
+          companyName: company.name,
+          verificationLogId: id,
+          jurisdiction: company.country,
+          useTestNetwork: false,
+          submissionError: message,
+          mandate: state.filing ? Buffer.from(state.filing.mandateBase64, 'base64') : undefined,
+          mandateFileName: state.filing?.fileName,
+        });
+      } else {
+        state.nextAttemptAt = new Date(
+          Date.now() + Math.min(30, 2 ** Math.min(state.attempts, 5)) * 60_000,
+        ).toISOString();
+        await saveState(id, state, message);
+      }
+    }
+  });
+}
+
+export function initializeArratechOnboardingCron(logger: Logger): void {
+  if (process.env.RUN_CRON !== 'true') return;
+  new Cron('* * * * *', { name: 'peppol.arratech-onboarding', protect: true }, async () => {
+    try {
+      const logs = await db
+        .select({ id: companyVerificationLog.id })
+        .from(companyVerificationLog)
+        .where(
+          and(
+            isNotNull(companyVerificationLog.arratechOnboarding),
+            sql`(${companyVerificationLog.arratechOnboarding}->>'phase' in ('submit', 'activation') or (${companyVerificationLog.arratechOnboarding}->>'phase' = 'support' and ${companyVerificationLog.arratechOnboarding}->>'supportNotifiedAt' is null))`,
+            sql`${companyVerificationLog.arratechOnboarding}->>'nextAttemptAt' <= ${new Date().toISOString()}`,
+            sql`${companyVerificationLog.status} in ('inReview', 'verified')`,
+          ),
+        )
+        .orderBy(sql`${companyVerificationLog.arratechOnboarding}->>'nextAttemptAt'`)
+        .limit(25);
+      for (const log of logs) {
+        try {
+          await processArratechOnboarding(log.id);
+        } catch (error) {
+          logger.error(
+            `Arratech onboarding ${log.id}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+    } catch (error) {
+      logger.error(
+        `Arratech onboarding worker failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  });
+}

--- a/data/at/kyc-review.ts
+++ b/data/at/kyc-review.ts
@@ -1,6 +1,6 @@
 import { companyVerificationLog } from "@peppol/db/schema";
 import { db } from "@recommand/db";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, inArray } from "drizzle-orm";
 import type { Company } from "@peppol/data/companies";
 import {
   getCompanyVerificationLog,
@@ -19,11 +19,6 @@ import {
   type ArratechKycFiling,
 } from "./kyc";
 
-/**
- * Files the company's KYC with Arratech and parks the verification session in
- * review. The mandate is signed by the representative whose identity Didit just
- * verified, and support is emailed to follow the acceptance up with Arratech.
- */
 export async function startArratechKycReview({
   companyVerificationLogId,
   company,
@@ -40,6 +35,17 @@ export async function startArratechKycReview({
   if (isFinalVerificationStatus(existingLog.status)) {
     return { status: existingLog.status };
   }
+  const teamExtension = await getTeamExtension(company.teamId);
+  if (company.country === "FR" && company.smpProvider === "at-shared-smp-fr" && !teamExtension?.useTestNetwork && !teamExtension?.isPlayground) {
+    const now = new Date().toISOString();
+    await db.update(companyVerificationLog).set({
+      status: "inReview", verificationProofReference, errorMessage: null,
+      arratechOnboarding: { phase: "submit", attempts: 0, startedAt: now, nextAttemptAt: now },
+    }).where(and(eq(companyVerificationLog.id, companyVerificationLogId),
+      isNull(companyVerificationLog.arratechOnboarding),
+      inArray(companyVerificationLog.status, ["opened", "idVerificationRequested", "inReview"])));
+    return { status: (await getCompanyVerificationLog(companyVerificationLogId))!.status };
+  }
   // The same identity verification must not be filed with Arratech twice.
   if (
     existingLog.status === "inReview" &&
@@ -48,7 +54,6 @@ export async function startArratechKycReview({
     return { status: existingLog.status };
   }
 
-  const teamExtension = await getTeamExtension(company.teamId);
   const useTestNetwork = teamExtension?.useTestNetwork ?? false;
   const smpStateBase = {
     isPlayground: teamExtension?.isPlayground,
@@ -79,11 +84,6 @@ export async function startArratechKycReview({
       );
     }
 
-    // Arratech attaches the KYC to a participant, so the company has to exist on
-    // their SMP before we can file it. Arratech only lets the participant operate
-    // once they accept that KYC, which is what keeps this short of a verification.
-    // On production, document types and Peppol Directory publish wait until that
-    // KYC is accepted. The test network still publishes them immediately.
     if (!isRegistered && shouldBeRegistered) {
       await upsertCompanyRegistrations({
         companyId: company.id,

--- a/data/at/kyc.ts
+++ b/data/at/kyc.ts
@@ -12,11 +12,6 @@ import {
   type MandateInput,
 } from "./mandate";
 
-/**
- * Companies on the Arratech SMP are only verified once Arratech accepts their
- * KYC, and that KYC is filed with a mandate the representative signs. Playground
- * teams never reach Arratech, so they neither sign nor get filed.
- */
 export async function requiresArratechKycReview(company: Company): Promise<boolean> {
   if (company.smpProvider !== "at-shared-smp-fr") {
     return false;
@@ -178,10 +173,6 @@ export async function buildArratechKycFiling({
   };
 }
 
-/**
- * Files the KYC and its mandate against every Arratech participant of the
- * company. Arratech reviews it before the participant can operate.
- */
 export async function submitArratechCompanyKyc({
   companyId,
   filing,

--- a/data/at/mandate.ts
+++ b/data/at/mandate.ts
@@ -14,7 +14,6 @@ export type CompanyKycIdentity = {
   rows: CompanyIdentityRow[];
   /** The jurisdiction specific payload Arratech's KYC expects, when defined. */
   metaData?: Record<string, string>;
-  /** Caveats support should know about before Arratech reviews the file. */
   notes: string[];
 };
 

--- a/data/at/smp.ts
+++ b/data/at/smp.ts
@@ -31,6 +31,7 @@ type ArratechBusinessCard = {
 
 type ArratechParticipant = {
   id: string;
+  status?: string;
   name: string;
   participantIdentifier: string;
   environment?: "PROD" | "TEST";
@@ -187,6 +188,7 @@ export async function getParticipantByIdentifier({
     {
       method: "GET",
       useTestNetwork,
+      signal: AbortSignal.timeout(30_000),
     }
   );
 
@@ -218,6 +220,7 @@ async function updateSupportedDocumentTypes({
       method: "PUT",
       body: JSON.stringify({ supportedDocumentTypes: documentTypes }),
       useTestNetwork,
+      signal: AbortSignal.timeout(30_000),
     }
   );
 }
@@ -235,6 +238,7 @@ async function getSupportedDocumentTypes({
     {
       method: "GET",
       useTestNetwork,
+      signal: AbortSignal.timeout(30_000),
     },
   );
 }
@@ -253,6 +257,7 @@ async function publishParticipant({
       method: "POST",
       body: JSON.stringify({ ids: [participantId] }),
       useTestNetwork,
+      signal: AbortSignal.timeout(30_000),
     }
   );
 }
@@ -285,12 +290,14 @@ async function registerCompanyIdentifier({
   documentTypes,
   useTestNetwork,
   includeCapabilities = true,
+  siret,
 }: {
   company: Company | InsertCompany;
   identifier: MinimalCompanyIdentifier;
   documentTypes: CompanyDocumentType[];
   useTestNetwork: boolean;
   includeCapabilities?: boolean;
+  siret?: string;
 }) {
   if (!company.isSmpRecipient || !company.id) {
     return;
@@ -309,11 +316,19 @@ async function registerCompanyIdentifier({
     useTestNetwork,
   });
 
+  if (existingParticipant && siret && existingParticipant.status !== "ACTIVE") {
+    if (includeCapabilities) {
+      throw new UserFacingError(`Arratech participant is not active (${existingParticipant.status})`);
+    }
+    return;
+  }
+
   const participant = existingParticipant
     ? await fetchArratechJson<ArratechParticipant>(
       `/orgs/${config.orgId}/participants/${existingParticipant.id}`,
       {
         method: "PUT",
+        signal: AbortSignal.timeout(30_000),
         body: JSON.stringify({
           name: company.name,
           businessCard: businessCard(company),
@@ -325,9 +340,11 @@ async function registerCompanyIdentifier({
       `/orgs/${config.orgId}/participants`,
       {
         method: "POST",
+        signal: AbortSignal.timeout(30_000),
         body: JSON.stringify({
           name: company.name,
           participantIdentifier: peppolIdentifier,
+          ...(siret && identifier.scheme === "0225" ? { siret } : {}),
           smpRef: config.smpRef,
           apRef: config.apRef,
           transportProfile: "peppol-transport-as4-v2_0",
@@ -364,10 +381,12 @@ export async function upsertCompanyRegistrations({
   companyId,
   useTestNetwork,
   includeCapabilities = true,
+  siret,
 }: {
   companyId: string;
   useTestNetwork: boolean;
   includeCapabilities?: boolean;
+  siret?: string;
 }) {
   const company = await getCompanyById(companyId);
   if (company && !company.isSmpRecipient) {
@@ -381,7 +400,7 @@ export async function upsertCompanyRegistrations({
   }
 
   for (const identifier of identifiers) {
-    await registerCompanyIdentifier({ company, identifier, documentTypes, useTestNetwork, includeCapabilities });
+    await registerCompanyIdentifier({ company, identifier, documentTypes, useTestNetwork, includeCapabilities, siret });
   }
 }
 

--- a/data/send-arratech-kyc-review-email.ts
+++ b/data/send-arratech-kyc-review-email.ts
@@ -7,10 +7,6 @@ import React from "react";
 
 const SUPPORT_EMAIL_ADDRESS = "support@recommand.eu";
 
-/**
- * Tells support that a company is waiting for Arratech to accept its KYC, so
- * the verification session can be completed manually afterwards.
- */
 export async function sendArratechKycReviewEmail({
   companyName,
   companyId,
@@ -24,6 +20,7 @@ export async function sendArratechKycReviewEmail({
   mandate,
   mandateFileName,
   submissionError,
+  sendOnly = false,
 }: {
   companyName: string;
   companyId: string;
@@ -37,11 +34,12 @@ export async function sendArratechKycReviewEmail({
   mandate?: Buffer;
   mandateFileName?: string;
   submissionError?: string | null;
+  sendOnly?: boolean;
 }): Promise<void> {
   try {
     await sendEmail({
       to: SUPPORT_EMAIL_ADDRESS,
-      subject: kycReviewSubject({ companyName, submissionError }),
+      subject: sendOnly ? `French send-only onboarding requires support: ${companyName}` : kycReviewSubject({ companyName, submissionError }),
       email: React.createElement(ArratechKycReviewNotification, {
         companyName,
         companyId,
@@ -53,6 +51,7 @@ export async function sendArratechKycReviewEmail({
         signatoryName,
         network: useTestNetwork ? "test" : "production",
         submissionError,
+        sendOnly,
       }),
       attachments:
         mandate && mandateFileName
@@ -71,5 +70,6 @@ export async function sendArratechKycReviewEmail({
       `Failed to send Arratech KYC review email for company ${companyId}:`,
       error
     );
+    if (sendOnly) throw error;
   }
 }

--- a/db/drizzle/20260904203902_curved_viper.sql
+++ b/db/drizzle/20260904203902_curved_viper.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "company_verification_log" ADD COLUMN "arratech_onboarding" jsonb;

--- a/db/drizzle/meta/20260904203902_snapshot.json
+++ b/db/drizzle/meta/20260904203902_snapshot.json
@@ -1,0 +1,2672 @@
+{
+  "id": "bcaeee7a-0389-416f-bcf5-9446d4862475",
+  "prevId": "f253465c-2190-43ad-9f14-798d57eedb09",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activated_integrations": {
+      "name": "activated_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activated_integrations_team_id_idx": {
+          "name": "activated_integrations_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activated_integrations_team_id_teams_id_fk": {
+          "name": "activated_integrations_team_id_teams_id_fk",
+          "tableFrom": "activated_integrations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activated_integrations_company_id_peppol_companies_id_fk": {
+          "name": "activated_integrations_company_id_peppol_companies_id_fk",
+          "tableFrom": "activated_integrations",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_billing_profiles": {
+      "name": "peppol_billing_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mollie_customer_id": {
+          "name": "mollie_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_payment_id": {
+          "name": "first_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_payment_status": {
+          "name": "first_payment_status",
+          "type": "peppol_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "is_mandate_validated": {
+          "name": "is_mandate_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile_standing": {
+          "name": "profile_standing",
+          "type": "peppol_profile_standing",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "grace_started_at": {
+          "name": "grace_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_reason": {
+          "name": "grace_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_peppol_address": {
+          "name": "billing_peppol_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_manually_billed": {
+          "name": "is_manually_billed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "peppol_billing_profiles_team_id_unique": {
+          "name": "peppol_billing_profiles_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_companies": {
+      "name": "peppol_companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enterprise_number_scheme": {
+          "name": "enterprise_number_scheme",
+          "type": "peppol_valid_iso_icd_scheme_identifiers",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_smp_recipient": {
+          "name": "is_smp_recipient",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_point_provider": {
+          "name": "access_point_provider",
+          "type": "peppol_access_point_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-ap1'"
+        },
+        "smp_provider": {
+          "name": "smp_provider",
+          "type": "peppol_smp_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-smp1'"
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_proof_reference": {
+          "name": "verification_proof_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_companies_team_id_teams_id_fk": {
+          "name": "peppol_companies_team_id_teams_id_fk",
+          "tableFrom": "peppol_companies",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_document_types": {
+      "name": "peppol_company_document_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type_id": {
+          "name": "doc_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_document_types_unique": {
+          "name": "peppol_company_document_types_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doc_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "process_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_document_types_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_document_types_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_document_types",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_identifiers": {
+      "name": "peppol_company_identifiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_identifiers_unique": {
+          "name": "peppol_company_identifiers_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"scheme\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"identifier\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_identifiers_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_identifiers_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_identifiers",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_notification_email_addresses": {
+      "name": "peppol_company_notification_email_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notify_incoming": {
+          "name": "notify_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_outgoing": {
+          "name": "notify_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_auto_generated_pdf_incoming": {
+          "name": "include_auto_generated_pdf_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_auto_generated_pdf_outgoing": {
+          "name": "include_auto_generated_pdf_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_document_json_incoming": {
+          "name": "include_document_json_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_document_json_outgoing": {
+          "name": "include_document_json_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_notification_email_addresses_unique": {
+          "name": "peppol_company_notification_email_addresses_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_notification_email_addresses_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_notification_email_addresses_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_notification_email_addresses",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_verification_log": {
+      "name": "company_verification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opened'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_proof_reference": {
+          "name": "verification_proof_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mandate_accepted_at": {
+          "name": "mandate_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arratech_onboarding": {
+          "name": "arratech_onboarding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_verification_log_company_id_peppol_companies_id_fk": {
+          "name": "company_verification_log_company_id_peppol_companies_id_fk",
+          "tableFrom": "company_verification_log",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enterprise_data_cache": {
+      "name": "enterprise_data_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "begin_date": {
+          "name": "begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_code": {
+          "name": "juridical_form_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_description": {
+          "name": "juridical_form_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_begin_date": {
+          "name": "juridical_form_begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_code": {
+          "name": "denomination_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_description": {
+          "name": "denomination_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_begin_date": {
+          "name": "denomination_begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "enterprise_data_cache_unique": {
+          "name": "enterprise_data_cache_unique",
+          "columns": [
+            {
+              "expression": "enterprise_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_task_logs": {
+      "name": "integration_task_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integration_task_logs_integration_id_activated_integrations_id_fk": {
+          "name": "integration_task_logs_integration_id_activated_integrations_id_fk",
+          "tableFrom": "integration_task_logs",
+          "tableTo": "activated_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_outgoing_envelope_claims": {
+      "name": "peppol_outgoing_envelope_claims",
+      "schema": "",
+      "columns": {
+        "instance_identifier": {
+          "name": "instance_identifier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_outgoing_envelope_claims_created_at_idx": {
+          "name": "peppol_outgoing_envelope_claims_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_payment_failure_reminders": {
+      "name": "peppol_payment_failure_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_event_id": {
+          "name": "billing_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_addresses": {
+          "name": "email_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_payment_failure_reminders_billing_event_id_peppol_subscription_billing_events_id_fk": {
+          "name": "peppol_payment_failure_reminders_billing_event_id_peppol_subscription_billing_events_id_fk",
+          "tableFrom": "peppol_payment_failure_reminders",
+          "tableTo": "peppol_subscription_billing_events",
+          "columnsFrom": [
+            "billing_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_s3_deletions": {
+      "name": "pending_s3_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_s3_deletions_claim_idx": {
+          "name": "pending_s3_deletions_claim_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscription_billing_event_lines": {
+      "name": "peppol_subscription_billing_event_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_billing_event_id": {
+          "name": "subscription_billing_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_start_date": {
+          "name": "subscription_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_end_date": {
+          "name": "subscription_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_last_billed_at": {
+          "name": "subscription_last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_config": {
+          "name": "billing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included_monthly_documents": {
+          "name": "included_monthly_documents",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_document_overage_price": {
+          "name": "incoming_document_overage_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outgoing_document_overage_price": {
+          "name": "outgoing_document_overage_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty": {
+          "name": "used_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_incoming": {
+          "name": "used_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_outgoing": {
+          "name": "used_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_incoming": {
+          "name": "overage_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_outgoing": {
+          "name": "overage_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_excl": {
+          "name": "total_amount_excl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_subscription_billing_event_lines_subscription_billing_event_id_peppol_subscription_billing_events_id_fk": {
+          "name": "peppol_subscription_billing_event_lines_subscription_billing_event_id_peppol_subscription_billing_events_id_fk",
+          "tableFrom": "peppol_subscription_billing_event_lines",
+          "tableTo": "peppol_subscription_billing_events",
+          "columnsFrom": [
+            "subscription_billing_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscription_billing_events": {
+      "name": "peppol_subscription_billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_profile_id": {
+          "name": "billing_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_date": {
+          "name": "billing_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_start": {
+          "name": "billing_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_end": {
+          "name": "billing_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_excl": {
+          "name": "total_amount_excl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_amount": {
+          "name": "vat_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_category": {
+          "name": "vat_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_percentage": {
+          "name": "vat_percentage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_incl": {
+          "name": "total_amount_incl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty": {
+          "name": "used_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_incoming": {
+          "name": "used_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_outgoing": {
+          "name": "used_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_incoming": {
+          "name": "overage_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_outgoing": {
+          "name": "overage_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_due": {
+          "name": "amount_due",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "peppol_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_reference": {
+          "name": "invoice_reference",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_subscription_billing_events_billing_profile_id_peppol_billing_profiles_id_fk": {
+          "name": "peppol_subscription_billing_events_billing_profile_id_peppol_billing_profiles_id_fk",
+          "tableFrom": "peppol_subscription_billing_events",
+          "tableTo": "peppol_billing_profiles",
+          "columnsFrom": [
+            "billing_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "peppol_subscription_billing_events_invoice_id_unique": {
+          "name": "peppol_subscription_billing_events_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_id"
+          ]
+        },
+        "peppol_subscription_billing_events_invoice_reference_unique": {
+          "name": "peppol_subscription_billing_events_invoice_reference_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_reference"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscriptions": {
+      "name": "peppol_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_config": {
+          "name": "billing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_billed_at": {
+          "name": "last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_team_extensions": {
+      "name": "peppol_team_extensions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_playground": {
+          "name": "is_playground",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_test_network": {
+          "name": "use_test_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_requirements": {
+          "name": "verification_requirements",
+          "type": "verification_requirements",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lax'"
+        },
+        "company_verification_extension_until": {
+          "name": "company_verification_extension_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_email_address": {
+          "name": "support_email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_team_extensions_id_teams_id_fk": {
+          "name": "peppol_team_extensions_id_teams_id_fk",
+          "tableFrom": "peppol_team_extensions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transfer_events": {
+      "name": "peppol_transfer_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "peppol_transfer_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'peppol'"
+        },
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "peppol_transfer_event_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transmitted_document_labels": {
+      "name": "peppol_transmitted_document_labels",
+      "schema": "",
+      "columns": {
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_transmitted_document_labels_transmitted_document_id_peppol_transmitted_documents_id_fk": {
+          "name": "peppol_transmitted_document_labels_transmitted_document_id_peppol_transmitted_documents_id_fk",
+          "tableFrom": "peppol_transmitted_document_labels",
+          "tableTo": "peppol_transmitted_documents",
+          "columnsFrom": [
+            "transmitted_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_transmitted_document_labels_label_id_peppol_labels_id_fk": {
+          "name": "peppol_transmitted_document_labels_label_id_peppol_labels_id_fk",
+          "tableFrom": "peppol_transmitted_document_labels",
+          "tableTo": "peppol_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "peppol_transmitted_document_labels_pkey": {
+          "name": "peppol_transmitted_document_labels_pkey",
+          "columns": [
+            "transmitted_document_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transmitted_documents": {
+      "name": "peppol_transmitted_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "peppol_transfer_event_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_type_id": {
+          "name": "doc_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_c1": {
+          "name": "country_c1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_point_provider": {
+          "name": "access_point_provider",
+          "type": "peppol_access_point_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-ap1'"
+        },
+        "smp_provider": {
+          "name": "smp_provider",
+          "type": "peppol_smp_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-smp1'"
+        },
+        "xml": {
+          "name": "xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_location": {
+          "name": "xml_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'db'"
+        },
+        "attachments_location": {
+          "name": "attachments_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'db'"
+        },
+        "original_payload_location": {
+          "name": "original_payload_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "original_payload_container_format": {
+          "name": "original_payload_container_format",
+          "type": "peppol_original_payload_container_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "s3_key_prefix": {
+          "name": "s3_key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offload_claimed_at": {
+          "name": "offload_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_over_peppol": {
+          "name": "sent_over_peppol",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sent_over_email": {
+          "name": "sent_over_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_recipients": {
+          "name": "email_recipients",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "type": {
+          "name": "type",
+          "type": "peppol_supported_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "parsed": {
+          "name": "parsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation": {
+          "name": "validation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_name": {
+          "name": "receiver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peppol_message_id": {
+          "name": "peppol_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peppol_conversation_id": {
+          "name": "peppol_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_peppol_signal_message": {
+          "name": "received_peppol_signal_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envelope_id": {
+          "name": "envelope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ap_transaction_id": {
+          "name": "ap_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_reference_id": {
+          "name": "external_reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_transmitted_documents_offload_idx": {
+          "name": "peppol_transmitted_documents_offload_idx",
+          "columns": [
+            {
+              "expression": "xml_location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "offload_claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_transmitted_documents_ap_transaction_id_idx": {
+          "name": "peppol_transmitted_documents_ap_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "ap_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"peppol_transmitted_documents\".\"ap_transaction_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_transmitted_documents_team_id_teams_id_fk": {
+          "name": "peppol_transmitted_documents_team_id_teams_id_fk",
+          "tableFrom": "peppol_transmitted_documents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_transmitted_documents_company_id_peppol_companies_id_fk": {
+          "name": "peppol_transmitted_documents_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_transmitted_documents",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_webhooks": {
+      "name": "peppol_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_webhooks_team_id_teams_id_fk": {
+          "name": "peppol_webhooks_team_id_teams_id_fk",
+          "tableFrom": "peppol_webhooks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_webhooks_company_id_peppol_companies_id_fk": {
+          "name": "peppol_webhooks_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_webhooks",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.peppol_access_point_provider": {
+      "name": "peppol_access_point_provider",
+      "schema": "public",
+      "values": [
+        "recommand-ap1",
+        "at-shared-ap-fr"
+      ]
+    },
+    "public.peppol_original_payload_container_format": {
+      "name": "peppol_original_payload_container_format",
+      "schema": "public",
+      "values": [
+        "none",
+        "pdf"
+      ]
+    },
+    "public.peppol_payload_location": {
+      "name": "peppol_payload_location",
+      "schema": "public",
+      "values": [
+        "none",
+        "db",
+        "s3"
+      ]
+    },
+    "public.peppol_payment_status": {
+      "name": "peppol_payment_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "open",
+        "pending",
+        "authorized",
+        "paid",
+        "canceled",
+        "expired",
+        "failed"
+      ]
+    },
+    "public.peppol_profile_standing": {
+      "name": "peppol_profile_standing",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "grace",
+        "suspended"
+      ]
+    },
+    "public.peppol_smp_provider": {
+      "name": "peppol_smp_provider",
+      "schema": "public",
+      "values": [
+        "recommand-smp1",
+        "at-shared-smp-fr"
+      ]
+    },
+    "public.peppol_supported_document_type": {
+      "name": "peppol_supported_document_type",
+      "schema": "public",
+      "values": [
+        "invoice",
+        "creditNote",
+        "selfBillingInvoice",
+        "selfBillingCreditNote",
+        "messageLevelResponse",
+        "frenchInvoicingCdar",
+        "frenchB2CSalesReport",
+        "frenchB2CPaymentReport",
+        "frenchB2BiInvoiceReport",
+        "frenchB2BiPaymentReport",
+        "unknown"
+      ]
+    },
+    "public.peppol_transfer_event_direction": {
+      "name": "peppol_transfer_event_direction",
+      "schema": "public",
+      "values": [
+        "incoming",
+        "outgoing"
+      ]
+    },
+    "public.peppol_transfer_event_type": {
+      "name": "peppol_transfer_event_type",
+      "schema": "public",
+      "values": [
+        "peppol",
+        "email",
+        "reporting"
+      ]
+    },
+    "public.peppol_valid_country_codes": {
+      "name": "peppol_valid_country_codes",
+      "schema": "public",
+      "values": [
+        "AU",
+        "AT",
+        "BE",
+        "BG",
+        "CA",
+        "HR",
+        "DK",
+        "EE",
+        "FI",
+        "FR",
+        "DE",
+        "GR",
+        "HK",
+        "HU",
+        "IS",
+        "IE",
+        "IT",
+        "JP",
+        "LV",
+        "LU",
+        "MY",
+        "NL",
+        "NZ",
+        "NO",
+        "PL",
+        "PT",
+        "RO",
+        "SG",
+        "SK",
+        "SI",
+        "ES",
+        "SE",
+        "AE",
+        "GB",
+        "US"
+      ]
+    },
+    "public.peppol_valid_iso_icd_scheme_identifiers": {
+      "name": "peppol_valid_iso_icd_scheme_identifiers",
+      "schema": "public",
+      "values": [
+        "0002",
+        "0003",
+        "0004",
+        "0005",
+        "0006",
+        "0007",
+        "0008",
+        "0009",
+        "0010",
+        "0011",
+        "0012",
+        "0013",
+        "0014",
+        "0015",
+        "0016",
+        "0017",
+        "0018",
+        "0019",
+        "0020",
+        "0021",
+        "0022",
+        "0023",
+        "0024",
+        "0025",
+        "0026",
+        "0027",
+        "0028",
+        "0029",
+        "0030",
+        "0031",
+        "0032",
+        "0033",
+        "0034",
+        "0035",
+        "0036",
+        "0037",
+        "0038",
+        "0039",
+        "0040",
+        "0041",
+        "0042",
+        "0043",
+        "0044",
+        "0045",
+        "0046",
+        "0047",
+        "0048",
+        "0049",
+        "0050",
+        "0051",
+        "0052",
+        "0053",
+        "0054",
+        "0055",
+        "0056",
+        "0057",
+        "0058",
+        "0059",
+        "0060",
+        "0061",
+        "0062",
+        "0063",
+        "0064",
+        "0065",
+        "0066",
+        "0067",
+        "0068",
+        "0069",
+        "0070",
+        "0071",
+        "0072",
+        "0073",
+        "0074",
+        "0075",
+        "0076",
+        "0077",
+        "0078",
+        "0079",
+        "0080",
+        "0081",
+        "0082",
+        "0083",
+        "0084",
+        "0085",
+        "0086",
+        "0087",
+        "0088",
+        "0089",
+        "0090",
+        "0091",
+        "0093",
+        "0094",
+        "0095",
+        "0096",
+        "0097",
+        "0098",
+        "0099",
+        "0100",
+        "0101",
+        "0102",
+        "0104",
+        "0105",
+        "0106",
+        "0107",
+        "0108",
+        "0109",
+        "0110",
+        "0111",
+        "0112",
+        "0113",
+        "0114",
+        "0115",
+        "0116",
+        "0117",
+        "0118",
+        "0119",
+        "0120",
+        "0121",
+        "0122",
+        "0123",
+        "0124",
+        "0125",
+        "0126",
+        "0127",
+        "0128",
+        "0129",
+        "0130",
+        "0131",
+        "0132",
+        "0133",
+        "0134",
+        "0135",
+        "0136",
+        "0137",
+        "0138",
+        "0139",
+        "0140",
+        "0141",
+        "0142",
+        "0143",
+        "0144",
+        "0145",
+        "0146",
+        "0147",
+        "0148",
+        "0149",
+        "0150",
+        "0151",
+        "0152",
+        "0153",
+        "0154",
+        "0155",
+        "0156",
+        "0157",
+        "0158",
+        "0159",
+        "0160",
+        "0161",
+        "0162",
+        "0163",
+        "0164",
+        "0165",
+        "0166",
+        "0167",
+        "0168",
+        "0169",
+        "0170",
+        "0171",
+        "0172",
+        "0173",
+        "0174",
+        "0175",
+        "0176",
+        "0177",
+        "0178",
+        "0179",
+        "0180",
+        "0183",
+        "0184",
+        "0185",
+        "0186",
+        "0187",
+        "0188",
+        "0189",
+        "0190",
+        "0191",
+        "0192",
+        "0193",
+        "0194",
+        "0195",
+        "0196",
+        "0197",
+        "0198",
+        "0199",
+        "0200",
+        "0201",
+        "0202",
+        "0203",
+        "0204",
+        "0205",
+        "0206",
+        "0207",
+        "0208",
+        "0209",
+        "0210",
+        "0211",
+        "0212",
+        "0213",
+        "0214",
+        "0215",
+        "0216",
+        "0217",
+        "0218",
+        "0219",
+        "0220",
+        "0221",
+        "0222",
+        "0223",
+        "0224",
+        "0225",
+        "0226",
+        "0227",
+        "0228",
+        "0229",
+        "0230",
+        "0231",
+        "0232",
+        "0233",
+        "0234",
+        "0235",
+        "0236",
+        "0237",
+        "0238",
+        "0239",
+        "0240"
+      ]
+    },
+    "public.peppol_validation_result": {
+      "name": "peppol_validation_result",
+      "schema": "public",
+      "values": [
+        "valid",
+        "invalid",
+        "not_supported",
+        "error"
+      ]
+    },
+    "public.verification_requirements": {
+      "name": "verification_requirements",
+      "schema": "public",
+      "values": [
+        "strict",
+        "trusted",
+        "lax"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "opened",
+        "idVerificationRequested",
+        "inReview",
+        "verified",
+        "rejected",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/drizzle/meta/_journal.json
+++ b/db/drizzle/meta/_journal.json
@@ -708,6 +708,13 @@
       "when": 1788203961793,
       "tag": "20260831191921_overrated_menace",
       "breakpoints": true
+    },
+    {
+      "idx": 101,
+      "version": "7",
+      "when": 1788554342765,
+      "tag": "20260904203902_curved_viper",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,5 @@
 import type { BillingConfig } from "../data/plans";
+import type { ArratechOnboarding } from "@peppol/data/at/kyc-onboarding-state";
 import { teams } from "@core/db/schema";
 import {
   timestamp,
@@ -316,6 +317,7 @@ export const companyVerificationLog = pgTable(
     // When the representative signed the mandate that is filed with the KYC.
     mandateAcceptedAt: timestamp("mandate_accepted_at", { withTimezone: true }),
     errorMessage: text("error_message"),
+    arratechOnboarding: jsonb("arratech_onboarding").$type<ArratechOnboarding>(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),

--- a/emails/arratech-kyc-review-notification.tsx
+++ b/emails/arratech-kyc-review-notification.tsx
@@ -17,6 +17,7 @@ interface ArratechKycReviewNotificationProps {
   signatoryName?: string;
   network: "production" | "test";
   submissionError?: string | null;
+  sendOnly?: boolean;
 }
 
 export const ArratechKycReviewNotification = ({
@@ -30,15 +31,16 @@ export const ArratechKycReviewNotification = ({
   signatoryName,
   network = "production",
   submissionError = null,
+  sendOnly = false,
 }: ArratechKycReviewNotificationProps) => (
-  <EmailLayout preview={`${companyName} is waiting for Arratech to accept its KYC`}>
-    <EmailHeading>Arratech KYC awaiting acceptance</EmailHeading>
+  <EmailLayout preview={`${companyName} requires onboarding review`}>
+    <EmailHeading>Arratech onboarding requires review</EmailHeading>
     <Text className="mb-4">Hello,</Text>
     {submissionError ? (
       <Text className={`mb-4 text-[${DANGER}]`}>
         The identity of a representative of <strong>{companyName}</strong> was
-        verified, but filing its KYC with Arratech failed. The mandate is
-        attached to this email and has to be filed manually.
+        verified, but its platform onboarding needs attention. Review the error
+        below and any attached mandate before taking action.
       </Text>
     ) : (
       <Text className="mb-4">
@@ -47,11 +49,16 @@ export const ArratechKycReviewNotification = ({
         been filed with Arratech.
       </Text>
     )}
-    <Text className="mb-4">
-      The verification session stays under review until Arratech accepts the
-      company. Once they confirm, complete the session through the admin API so
-      the company is marked as verified.
-    </Text>
+    {sendOnly ? <Text className="mb-4">
+      This send-only request needs manual follow-up with Arratech. Keep the session
+      under review and inform the customer when there is an update. Do not enable
+      receiving or approve KYC as a workaround.
+    </Text> : <Text className="mb-4">
+      Check the KYC metadata and signed mandate. An organisation admin can approve
+      pending KYC via POST /kyc/approve. Arratech then completes Annuaire registration.
+      Wait for the participant to become ACTIVE before completing the session
+      through the admin API. An approved KYC alone is not sufficient.
+    </Text>}
     <InfoSection>
       <Text className="my-1 text-sm">
         <strong>Company:</strong> {companyName} ({companyId})
@@ -92,13 +99,13 @@ export const ArratechKycReviewNotification = ({
         </Text>
       ) : null}
     </InfoSection>
-    <Text className="mb-4 text-sm">
+    {!sendOnly && <Text className="mb-4 text-sm">
       Complete the session with{" "}
       <code>
         POST /api/admin/companies/verification/{verificationLogId}/complete
       </code>{" "}
       and a status of <code>verified</code> or <code>rejected</code>.
-    </Text>
+    </Text>}
   </EmailLayout>
 );
 
@@ -108,9 +115,7 @@ ArratechKycReviewNotification.PreviewProps = {
   verificationLogId: "cvl_01JX",
   jurisdiction: "FR",
   identityRows: [{ label: "SIREN", value: "303265045" }],
-  identityNotes: [
-    "SIRET 30326504500001 assumed to be the head office, the company only gave us its SIREN",
-  ],
+  identityNotes: ["Confirm the establishment identifier before completing the review."],
   electronicAddresses: ["0225:303265045"],
   signatoryName: "Jeanne Durand",
   network: "production",
@@ -124,5 +129,5 @@ export const subject = (props: {
   submissionError?: string | null;
 }) =>
   props.submissionError
-    ? `Arratech KYC submission failed for ${props.companyName}`
-    : `Arratech KYC awaiting acceptance for ${props.companyName}`;
+    ? `Arratech onboarding needs attention for ${props.companyName}`
+    : `Arratech onboarding review for ${props.companyName}`;

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,7 @@ import { initializeIntegrationCronJobs } from "./data/integrations/cron";
 import { initializeOffloadCronJobs } from "./data/offload/cron";
 import { initializeProviderSentCronJobs } from "./data/provider-sent/cron";
 import { initializeS3DeletionCronJobs } from "./data/s3-deletion/cron";
+import { initializeArratechOnboardingCron } from "./data/at/kyc-onboarding";
 import { createMarkdownFromOpenApi } from "@scalar/openapi-to-markdown";
 import { onTeamCreated, onTeamBeforeDelete } from "./lib/backend-events";
 import { addBackendEventListener, CORE_BACKEND_EVENTS } from "@core/lib/backend-events";
@@ -58,6 +59,7 @@ export async function init(app: RecommandApp, server: Server) {
   initializeOffloadCronJobs(logger);
   initializeProviderSentCronJobs(logger);
   initializeS3DeletionCronJobs(logger);
+  initializeArratechOnboardingCron(logger);
 
   initializeMetricsServer(logger);
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "db:generate": "drizzle-kit generate",
     "test": "bun test ./test/*.test.ts",
-    "test:unit": "SKIP_E2E=1 bun test ./test/*.test.ts",
+    "test:unit": "SKIP_E2E=1 bun test ./test/*.test.ts && SKIP_E2E=1 bun test ./test/arratech/onboarding.test.ts",
     "test:e2e": "bun test --timeout 120000 ./test/e2e/",
     "test:regression": "bun test --timeout 120000 --only-failures --max-concurrency 20 ./test/regression/",
     "email:dev": "email dev --port 3002"

--- a/test/arratech-kyc-client.test.ts
+++ b/test/arratech-kyc-client.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  ensureApprovedKyc,
+  KycOnboardingError,
+  type KycRecord,
+} from '../data/at/kyc-onboarding-client';
+
+const mandate = Buffer.from('%PDF-1.7 signed mandate');
+const path = '/orgs/org/participants/participant/kyc';
+const input = {
+  path,
+  siren: '830905253',
+  siret: '83090525300015',
+  mandate,
+  fileName: 'mandate.pdf',
+};
+
+function server(initial: Partial<KycRecord> = {}, missing = false) {
+  const calls: string[] = [];
+  const kyc: KycRecord = {
+    status: 'PENDING',
+    jurisdiction: 'FR',
+    metaData: { siren: input.siren, siret: input.siret },
+    documents: [],
+    ...initial,
+  };
+  let exists = !missing;
+  let failAfterUpload = false;
+  let failAfterApprove = false;
+  const documents = new Map<string, Buffer>();
+  const request = async (url: string, options: RequestInit) => {
+    const call = `${options.method} ${url}`;
+    calls.push(call);
+    if (url === path && options.method === 'GET')
+      return exists ? Response.json(kyc) : Response.json({ code: 'AT-7001' }, { status: 404 });
+    if (url === path && options.method === 'POST') {
+      exists = true;
+      return Response.json(kyc, { status: 201 });
+    }
+    if (url === `${path}/documents` && options.method === 'POST') {
+      const file = (options.body as FormData).get('file') as File;
+      expect(file.type).toBe('application/pdf');
+      documents.set('mandate', Buffer.from(await file.arrayBuffer()));
+      kyc.documents.push('mandate');
+      if (failAfterUpload) {
+        failAfterUpload = false;
+        throw new Error('Connection lost after upload');
+      }
+      return Response.json({ docId: 'mandate' }, { status: 201 });
+    }
+    if (url === `${path}/approve`) {
+      expect(kyc.documents.length).toBeGreaterThan(0);
+      kyc.status = 'APPROVED';
+      if (failAfterApprove) {
+        failAfterApprove = false;
+        throw new Error('Connection lost after approval');
+      }
+      return Response.json(kyc);
+    }
+    const docId = url.split('/').at(-1)!;
+    if (documents.has(docId)) return new Response(new Uint8Array(documents.get(docId)!));
+    throw new Error(`Unexpected request ${call}`);
+  };
+  return {
+    request,
+    calls,
+    kyc,
+    documents,
+    failUpload: () => {
+      failAfterUpload = true;
+    },
+    failApprove: () => {
+      failAfterApprove = true;
+    },
+  };
+}
+
+describe('Arratech KYC onboarding', () => {
+  it('uploads and approves an automatically created KYC without creating it again', async () => {
+    const api = server();
+    await ensureApprovedKyc({ ...input, request: api.request });
+    expect(api.calls).toEqual([
+      `GET ${path}`,
+      `POST ${path}/documents`,
+      `POST ${path}/approve`,
+      `GET ${path}`,
+    ]);
+  });
+
+  it('opens a missing legacy KYC before uploading', async () => {
+    const api = server({}, true);
+    await ensureApprovedKyc({ ...input, request: api.request });
+    expect(api.calls.slice(0, 3)).toEqual([`GET ${path}`, `POST ${path}`, `GET ${path}`]);
+    expect(api.kyc.status).toBe('APPROVED');
+  });
+
+  it('recovers a lost upload response by matching the actual mandate bytes', async () => {
+    const api = server();
+    api.failUpload();
+    await expect(ensureApprovedKyc({ ...input, request: api.request })).rejects.toThrow(
+      'Connection lost',
+    );
+    await ensureApprovedKyc({ ...input, request: api.request });
+    expect(api.calls.filter((call) => call === `POST ${path}/documents`)).toHaveLength(1);
+    expect(api.kyc.status).toBe('APPROVED');
+  });
+
+  it('does not mistake another attached document for the signed mandate', async () => {
+    const api = server({ documents: ['other'] });
+    api.documents.set('other', Buffer.from('some other document'));
+    await ensureApprovedKyc({ ...input, request: api.request });
+    expect(api.calls).toContain(`POST ${path}/documents`);
+  });
+
+  it('recovers a lost approval response without a second approval', async () => {
+    const api = server();
+    api.failApprove();
+    await expect(ensureApprovedKyc({ ...input, request: api.request })).rejects.toThrow(
+      'Connection lost',
+    );
+    await ensureApprovedKyc({ ...input, request: api.request });
+    expect(api.calls.filter((call) => call === `POST ${path}/approve`)).toHaveLength(1);
+  });
+
+  it('does not approve mismatching metadata', async () => {
+    const api = server({ metaData: { siren: 'wrong', siret: input.siret } });
+    await expect(ensureApprovedKyc({ ...input, request: api.request })).rejects.toThrow(
+      'does not match',
+    );
+    expect(api.calls).toEqual([`GET ${path}`]);
+  });
+
+  it('leaves rejected KYC for review', async () => {
+    const api = server({ status: 'REJECTED', rejectionReason: 'Invalid mandate' });
+    await expect(ensureApprovedKyc({ ...input, request: api.request })).rejects.toThrow(
+      'Invalid mandate',
+    );
+    expect(api.calls).toHaveLength(1);
+  });
+
+  it('handles a concurrent approval conflict by re-reading the record', async () => {
+    const api = server();
+    const request = async (url: string, options: RequestInit) => {
+      if (url.endsWith('/approve')) {
+        api.kyc.status = 'APPROVED';
+        return Response.json({ code: 'AT-7016' }, { status: 409 });
+      }
+      return api.request(url, options);
+    };
+    await ensureApprovedKyc({ ...input, request });
+    expect(api.kyc.status).toBe('APPROVED');
+  });
+
+  it('does not create KYC when the participant itself is missing', async () => {
+    const calls: string[] = [];
+    await expect(
+      ensureApprovedKyc({
+        ...input,
+        request: async (_url, options) => {
+          calls.push(options.method!);
+          return Response.json({ code: 'AT-1057' }, { status: 404 });
+        },
+      }),
+    ).rejects.toBeInstanceOf(KycOnboardingError);
+    expect(calls).toEqual(['GET']);
+  });
+});

--- a/test/arratech-kyc-progress.test.ts
+++ b/test/arratech-kyc-progress.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'bun:test';
+import {
+  getArratechVerificationProgress,
+  type ArratechOnboarding,
+} from '@peppol/data/at/kyc-onboarding-state';
+
+const state = (phase: ArratechOnboarding['phase']): ArratechOnboarding => ({
+  phase,
+  attempts: 0,
+  startedAt: '',
+  nextAttemptAt: '',
+});
+
+test('send-only shows support processing even before the worker runs', () => {
+  expect(getArratechVerificationProgress(state('submit'), false, 'inReview')).toEqual({
+    activationPending: false,
+    supportReviewPending: true,
+  });
+});
+
+test('receiving shows activation only while automatic processing is pending', () => {
+  expect(getArratechVerificationProgress(state('activation'), true, 'inReview')).toEqual({
+    activationPending: true,
+    supportReviewPending: false,
+  });
+  expect(getArratechVerificationProgress(state('blocked'), true, 'inReview')).toEqual({
+    activationPending: false,
+    supportReviewPending: true,
+  });
+});
+
+test('ordinary reviews and completed sessions have no pending platform state', () => {
+  expect(getArratechVerificationProgress(null, true, 'inReview')).toEqual({
+    activationPending: false,
+    supportReviewPending: false,
+  });
+  expect(getArratechVerificationProgress(state('support'), false, 'verified')).toEqual({
+    activationPending: false,
+    supportReviewPending: false,
+  });
+});

--- a/test/arratech/onboarding.test.ts
+++ b/test/arratech/onboarding.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { ArratechOnboarding } from '../../data/at/kyc-onboarding-state';
+
+const events: string[] = [];
+let log: any;
+let participantStatus: string;
+let kycStatus: string;
+let company: any;
+let team: any;
+let acquired: boolean;
+let failSync: boolean;
+let failEmail: boolean;
+let failSupport: boolean;
+let mandateNotes: string[];
+const state = (): ArratechOnboarding => ({
+  phase: 'submit',
+  attempts: 0,
+  nextAttemptAt: new Date().toISOString(),
+  startedAt: new Date().toISOString(),
+});
+
+mock.module('@recommand/db', () => ({
+  db: {
+    transaction: async (fn: any) => fn({ execute: async () => ({ rows: [{ acquired }] }) }),
+    update: () => ({
+      set: (patch: any) => ({
+        where: async () => {
+          Object.assign(log, structuredClone(patch));
+        },
+      }),
+    }),
+  },
+}));
+mock.module('@peppol/data/companies', () => ({ getCompanyById: async () => company }));
+mock.module('@peppol/data/teams', () => ({ getTeamExtension: async () => team }));
+mock.module('@peppol/data/company-identifiers', () => ({
+  getCompanyIdentifiers: async () => [{ scheme: '0225', identifier: '830905253' }],
+}));
+mock.module('@peppol/data/company-verification', () => ({
+  getCompanyVerificationLog: async () => structuredClone(log),
+  isFinalVerificationStatus: (status: string) => ['verified', 'rejected', 'error'].includes(status),
+  finalizeCompanyVerification: async () => {
+    events.push('finalize');
+    log.status = 'verified';
+    return { status: 'verified', errorMessage: null };
+  },
+}));
+mock.module('@core/lib/audit', () => ({
+  audit: async () => {
+    events.push('audit');
+  },
+  writeAuditEvent: async () => {
+    events.push('audit');
+  },
+}));
+mock.module('@peppol/data/company-verification-webhooks', () => ({
+  publishCompanyVerificationEvent: async () => {},
+}));
+mock.module('@peppol/data/send-manual-verification-email', () => ({
+  sendManualVerificationEmail: async () => {
+    events.push('email');
+    if (failEmail) throw new Error('Mail unavailable');
+  },
+  sendManualVerificationDeclinedEmail: async () => {
+    events.push('declined-email');
+  },
+}));
+mock.module('@peppol/data/send-arratech-kyc-review-email', () => ({
+  sendArratechKycReviewEmail: async () => {
+    events.push('support');
+    if (failSupport) throw new Error('Support mail unavailable');
+  },
+}));
+mock.module('@peppol/data/at/kyc', () => ({
+  buildArratechKycFiling: async () => ({
+    identity: { metaData: { siren: '830905253', siret: '83090525300015' }, notes: mandateNotes },
+    electronicAddresses: ['0225:830905253'],
+    mandate: Buffer.from('%PDF signed'),
+    mandateFileName: 'mandate.pdf',
+  }),
+}));
+mock.module('@peppol/data/at/smp', () => ({
+  getParticipantByIdentifier: async () => ({ id: 'participant', status: participantStatus }),
+  upsertCompanyRegistrations: async (options: any) => {
+    if (options.includeCapabilities === false) {
+      expect(options.siret).toBe('83090525300015');
+      events.push('register');
+    } else {
+      events.push('sync');
+      if (failSync) throw new Error('SMP temporarily unavailable');
+    }
+  },
+}));
+mock.module('@peppol/data/at/client', () => ({
+  getArratechConfig: () => ({ orgId: 'org' }),
+  fetchArratech: async (path: string, options: RequestInit) => {
+    if (path.endsWith('/approve')) {
+      events.push('approve');
+      kycStatus = 'APPROVED';
+    } else if (path.endsWith('/documents')) {
+      events.push('upload');
+      return Response.json({ docId: 'doc' }, { status: 201 });
+    } else expect(options.method).toBe('GET');
+    return Response.json({
+      status: kycStatus,
+      jurisdiction: 'FR',
+      metaData: { siren: '830905253', siret: '83090525300015' },
+      documents: [],
+    });
+  },
+}));
+
+const { processArratechOnboarding, notifyVerificationCompletion, VerificationBusyError } =
+  await import('../../data/at/kyc-onboarding');
+
+beforeEach(() => {
+  events.length = 0;
+  log = {
+    id: 'verification',
+    companyId: 'company',
+    status: 'inReview',
+    firstName: 'Jean',
+    lastName: 'Dupont',
+    companyName: 'Company',
+    enterpriseNumber: '83090525300015',
+    country: 'FR',
+    address: 'Street',
+    postalCode: '75001',
+    city: 'Paris',
+    mandateAcceptedAt: new Date(),
+    verificationProofReference: 'didit-session',
+    arratechOnboarding: state(),
+  };
+  company = {
+    id: 'company',
+    teamId: 'team',
+    country: 'FR',
+    smpProvider: 'at-shared-smp-fr',
+    isSmpRecipient: true,
+    name: log.companyName,
+    enterpriseNumber: log.enterpriseNumber,
+    address: log.address,
+    postalCode: log.postalCode,
+    city: log.city,
+  };
+  team = { verificationRequirements: 'strict', useTestNetwork: false, isPlayground: false };
+  participantStatus = 'PENDING_TAX_REGISTRATION';
+  kycStatus = 'PENDING';
+  acquired = true;
+  failSync = false;
+  failEmail = false;
+  failSupport = false;
+  mandateNotes = [];
+});
+
+describe('durable Arratech onboarding', () => {
+  it('routes send-only to support once without registration or approval', async () => {
+    company.isSmpRecipient = false;
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['support']);
+    expect(log.status).toBe('inReview');
+    expect(log.errorMessage).toBeNull();
+    expect(log.arratechOnboarding.phase).toBe('support');
+    expect(log.arratechOnboarding.supportNotifiedAt).toBeDefined();
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['support']);
+    expect(company.isSmpRecipient).toBe(false);
+  });
+
+  it('retries a failed send-only support notification without provider writes', async () => {
+    company.isSmpRecipient = false;
+    failSupport = true;
+    await processArratechOnboarding(log.id);
+    expect(log.arratechOnboarding.supportNotifiedAt).toBeUndefined();
+    failSupport = false;
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['support', 'support']);
+    expect(log.arratechOnboarding.supportNotifiedAt).toBeDefined();
+  });
+
+  it('keeps completion and audit when the success email fails', async () => {
+    participantStatus = 'ACTIVE';
+    failEmail = true;
+    await processArratechOnboarding(log.id);
+    expect(log.status).toBe('verified');
+    expect(log.arratechOnboarding.phase).toBe('complete');
+    expect(events.slice(-2)).toEqual(['audit', 'email']);
+    await processArratechOnboarding(log.id);
+    expect(events.filter((e) => e === 'email')).toHaveLength(1);
+  });
+
+  it('uses the same completion cleanup and audit for an admin rejection', async () => {
+    await notifyVerificationCompletion(
+      log.id,
+      company,
+      log.arratechOnboarding,
+      'rejected',
+      {} as any,
+    );
+    expect(log.arratechOnboarding.phase).toBe('complete');
+    expect(events).toEqual(['audit', 'declined-email']);
+  });
+  it('approves then waits for ACTIVE before syncing or finalizing', async () => {
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['register', 'upload', 'approve']);
+    expect(log.status).toBe('inReview');
+    expect(log.arratechOnboarding.phase).toBe('activation');
+    participantStatus = 'ACTIVE';
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['register', 'upload', 'approve', 'sync', 'finalize', 'audit', 'email']);
+    expect(log.status).toBe('verified');
+    await processArratechOnboarding(log.id);
+    expect(events.filter((event) => event === 'email')).toHaveLength(1);
+  });
+
+  it('retries a capability synchronization failure without approving again', async () => {
+    await processArratechOnboarding(log.id);
+    participantStatus = 'ACTIVE';
+    failSync = true;
+    await processArratechOnboarding(log.id);
+    expect(log.status).toBe('inReview');
+    failSync = false;
+    await processArratechOnboarding(log.id);
+    expect(log.status).toBe('verified');
+    expect(events.filter((event) => event === 'approve')).toHaveLength(1);
+  });
+
+  it('does no work when another worker owns the verification', async () => {
+    acquired = false;
+    await expect(processArratechOnboarding(log.id)).rejects.toThrow('already being processed');
+    await expect(processArratechOnboarding(log.id)).rejects.toBeInstanceOf(VerificationBusyError);
+    expect(events).toEqual([]);
+  });
+
+  it('keeps an assumed SIRET for manual review before any provider writes', async () => {
+    mandateNotes = ['SIRET assumed'];
+    await processArratechOnboarding(log.id);
+    expect(log.arratechOnboarding.phase).toBe('blocked');
+    expect(events).toEqual(['support']);
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['support']);
+  });
+
+  it('requires the actual mandate acceptance timestamp', async () => {
+    log.mandateAcceptedAt = null;
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['support']);
+    expect(log.errorMessage).toContain('signed mandate');
+  });
+
+  it('does not process test or non-French companies', async () => {
+    team.useTestNetwork = true;
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['support']);
+  });
+
+  it('does not act on a revoked verification', async () => {
+    log.status = 'rejected';
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual([]);
+  });
+
+  it('does not finalize active participants whose KYC is rejected', async () => {
+    await processArratechOnboarding(log.id);
+    kycStatus = 'REJECTED';
+    participantStatus = 'ACTIVE';
+    await processArratechOnboarding(log.id);
+    expect(log.status).toBe('inReview');
+    expect(events).not.toContain('finalize');
+    expect(log.arratechOnboarding.phase).toBe('blocked');
+  });
+});

--- a/translations/de.csv
+++ b/translations/de.csv
@@ -955,3 +955,6 @@ to resolve this issue.,um dieses Problem zu lösen.
 {0} was removed from {1} {2},{0} wurde von {1} {2} entfernt
 {0} sent successfully to {1},Dokument erfolgreich an {1} gesendet: {0}
 {0} filed successfully with {1},Dokument erfolgreich bei {1} eingereicht: {0}
+Company activation in progress,Unternehmensaktivierung läuft
+Your identity has been verified. We are completing your company's network registration. This page will update automatically when activation is complete.,Ihre Identität wurde verifiziert. Wir schließen die Netzwerkregistrierung Ihres Unternehmens ab. Diese Seite wird nach Abschluss der Aktivierung automatisch aktualisiert.
+Your request is being processed by our support team. You will receive a message when there is an update.,Unser Supportteam bearbeitet Ihre Anfrage. Sie erhalten eine Nachricht sobald es Neuigkeiten gibt.

--- a/translations/fr.csv
+++ b/translations/fr.csv
@@ -955,3 +955,6 @@ to resolve this issue.,pour résoudre ce problème.
 {0} was removed from {1} {2},{0} a été retiré de {1} {2}
 {0} sent successfully to {1},Document envoyé avec succès à {1} : {0}
 {0} filed successfully with {1},Document déposé avec succès auprès de {1} : {0}
+Company activation in progress,Activation de l'entreprise en cours
+Your identity has been verified. We are completing your company's network registration. This page will update automatically when activation is complete.,Votre identité a été vérifiée. Nous finalisons l'inscription de votre entreprise sur le réseau. Cette page sera automatiquement mise à jour une fois l'activation terminée.
+Your request is being processed by our support team. You will receive a message when there is an update.,Notre équipe d’assistance traite votre demande. Vous recevrez un message dès qu’une mise à jour sera disponible.

--- a/translations/nl.csv
+++ b/translations/nl.csv
@@ -955,3 +955,6 @@ to resolve this issue.,om dit op te lossen.
 {0} was removed from {1} {2},{0} is verwijderd van {1} {2}
 {0} sent successfully to {1},Document succesvol verzonden naar {1}: {0}
 {0} filed successfully with {1},Document succesvol ingediend bij {1}: {0}
+Company activation in progress,Bedrijfsactivatie wordt verwerkt
+Your request is being processed by our support team. You will receive a message when there is an update.,Je aanvraag wordt verwerkt door ons supportteam. Je ontvangt bericht zodra er een update is.
+Your identity has been verified. We are completing your company's network registration. This page will update automatically when activation is complete.,Je identiteit is geverifieerd. We ronden de netwerkregistratie van je bedrijf af. Deze pagina wordt automatisch bijgewerkt zodra de activatie voltooid is.


### PR DESCRIPTION
## Summary

- Persist onboarding progress and resume submission and activation checks across retries.
- Reuse existing KYC records and mandate uploads, confirm approval, and wait for active participants before completing verification.
- Route requests requiring manual review to support with separate customer-facing progress messages.
- Share completion notifications and coordinate background processing with manual completion.

## Validation

- Full unit test command passed with access to the XML validation service.
- TypeScript checks passed.
- Targeted tests cover retries, activation, manual review, locking and completion notifications.

## Operational notes

The migration adds a nullable arratech_onboarding JSONB column to company_verification_log. The background worker requires RUN_CRON=true. Existing records are not automatically enrolled in the new worker.