### PR TITLE
Capture establishment data in verification submissions

### DIFF
--- a/api/companies/verification/get-mandate-draft.ts
+++ b/api/companies/verification/get-mandate-draft.ts
@@ -9,6 +9,7 @@ import "zod-openapi/extend";
 import { zodValidator } from "@recommand/lib/zod-validator";
 import { describeRoute } from "hono-openapi";
 import { UserFacingError } from "@directory/utils/util";
+import { verificationCountrySpecificSchema, validateVerificationCountrySpecific, getVerificationCountryRequirements } from '@peppol/types/verification-country-specific';
 
 const server = new Server();
 
@@ -19,6 +20,7 @@ const getMandateDraftParamSchema = z.object({
 const getMandateDraftJsonBodySchema = z.object({
     firstName: z.string().trim().min(1),
     lastName: z.string().trim().min(1),
+    countrySpecific: verificationCountrySpecificSchema.nullish(),
 });
 
 type GetMandateDraftContext = Context<Record<string, never>, string, { in: { param: z.input<typeof getMandateDraftParamSchema>, json: z.input<typeof getMandateDraftJsonBodySchema> }, out: { param: z.infer<typeof getMandateDraftParamSchema>, json: z.infer<typeof getMandateDraftJsonBodySchema> } }>;
@@ -34,7 +36,7 @@ const _getMandateDraft = server.post(
 async function _getMandateDraftImplementation(c: GetMandateDraftContext) {
     try {
         const { companyVerificationLogId } = c.req.valid("param");
-        const { firstName, lastName } = c.req.valid("json");
+        const { firstName, lastName, countrySpecific } = c.req.valid("json");
 
         const verificationLog = await getCompanyVerificationLog(companyVerificationLogId);
         if (!verificationLog) {
@@ -56,6 +58,8 @@ async function _getMandateDraftImplementation(c: GetMandateDraftContext) {
         const pdf = await renderMandatePdf(
             await buildMandateInput({
                 company,
+                countrySpecific: validateVerificationCountrySpecific(company, countrySpecific,
+                    getVerificationCountryRequirements(company.country, true, company.isSmpRecipient)?.required),
                 signatory: { firstName, lastName },
                 signedAt: new Date(),
                 // Nothing signs the draft yet; the identity verification does.

--- a/api/companies/verification/get-verification-context.ts
+++ b/api/companies/verification/get-verification-context.ts
@@ -11,6 +11,7 @@ import "zod-openapi/extend";
 import { zodValidator } from "@recommand/lib/zod-validator";
 import { describeRoute } from "hono-openapi";
 import { UserFacingError } from "@directory/utils/util";
+import { getVerificationCountryRequirements } from '@peppol/types/verification-country-specific';
 
 const server = new Server();
 
@@ -75,12 +76,14 @@ async function _getVerificationContextImplementation(c: GetVerificationContextCo
             company: {
                 id: company.id,
                 name: company.name,
+                country: company.country,
                 enterpriseNumber: company.enterpriseNumber,
             },
             isRepresentativeSelectionRequired,
             representatives,
             isPlayground: teamIsPlayground,
             isMandateRequired,
+            countryRequirements: getVerificationCountryRequirements(company.country, isMandateRequired, company.isSmpRecipient),
             // The signatory reads the mandate under the name the document
             // itself carries, which differs per jurisdiction.
             mandateTitle: isMandateRequired

--- a/api/companies/verification/submit-identity-form.ts
+++ b/api/companies/verification/submit-identity-form.ts
@@ -7,6 +7,7 @@ import "zod-openapi/extend";
 import { zodValidator } from "@recommand/lib/zod-validator";
 import { UserFacingError } from "@directory/utils/util";
 import { describeRoute } from "hono-openapi";
+import { verificationCountrySpecificSchema } from '@peppol/types/verification-country-specific';
 
 const server = new Server();
 
@@ -18,6 +19,7 @@ const submitIdentityFormJsonBodySchema = z.object({
     firstName: z.string().trim().min(1),
     lastName: z.string().trim().min(1),
     mandateAccepted: z.boolean().default(false),
+    countrySpecific: verificationCountrySpecificSchema.nullish(),
 });
 
 type SubmitIdentityFormContext = Context<Record<string, never>, string, { in: { param: z.input<typeof submitIdentityFormParamSchema>, json: z.input<typeof submitIdentityFormJsonBodySchema> }, out: { param: z.infer<typeof submitIdentityFormParamSchema>, json: z.infer<typeof submitIdentityFormJsonBodySchema> } }>;
@@ -33,7 +35,7 @@ const _submitIdentityForm = server.post(
 async function _submitIdentityFormImplementation(c: SubmitIdentityFormContext) {
     try {
         const { companyVerificationLogId } = c.req.valid("param");
-        const { firstName, lastName, mandateAccepted } = c.req.valid("json");
+        const { firstName, lastName, mandateAccepted, countrySpecific } = c.req.valid("json");
 
         const verificationLog = await getCompanyVerificationLog(companyVerificationLogId);
         if (!verificationLog) {
@@ -45,7 +47,7 @@ async function _submitIdentityFormImplementation(c: SubmitIdentityFormContext) {
             return c.json(actionFailure("Company not found"), 404);
         }
 
-        const verificationUrl = await submitIdentityForm(companyVerificationLogId, verificationLog, company, firstName, lastName, mandateAccepted);
+        const verificationUrl = await submitIdentityForm(companyVerificationLogId, verificationLog, company, firstName, lastName, mandateAccepted, countrySpecific);
         return c.json(actionSuccess({ verificationUrl }));
     } catch (error) {
         console.error(error);

--- a/app/(public)/company-verification/[companyVerificationLogId]/verify/country-specific-fields.tsx
+++ b/app/(public)/company-verification/[companyVerificationLogId]/verify/country-specific-fields.tsx
@@ -1,0 +1,24 @@
+import { Input } from '@core/components/ui/input';
+import { Label } from '@core/components/ui/label';
+import { Card, CardContent } from '@core/components/ui/card';
+import { useTranslation } from '@core/hooks/use-translation';
+import type { VerificationCountrySpecific, VerificationCountryRequirements } from '@peppol/types/verification-country-specific';
+
+export function CountrySpecificFields({ requirements, value, onChange }: {
+  requirements: VerificationCountryRequirements;
+  value: VerificationCountrySpecific | null;
+  onChange: (value: VerificationCountrySpecific | null) => void;
+}) {
+  const { t } = useTranslation();
+  if (requirements?.country !== 'FR') return null;
+  return (
+    <Card>
+      <CardContent className="pt-6 space-y-2">
+        <Label htmlFor="verification-siret">{requirements.required ? t`Establishment SIRET` : t`Establishment SIRET (Optional)`}</Label>
+        <Input id="verification-siret" inputMode="numeric" value={value?.siret ?? ''}
+          onChange={event => onChange(event.target.value ? { country: 'FR', siret: event.target.value } : null)} />
+        <p className="text-sm text-muted-foreground">{t`The 14 digit SIRET identifies the establishment for verification. It does not add a receiving address.`}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(public)/company-verification/[companyVerificationLogId]/verify/mandate-section.tsx
+++ b/app/(public)/company-verification/[companyVerificationLogId]/verify/mandate-section.tsx
@@ -8,6 +8,7 @@ import { StatusMessage } from "@recommand/components/status-feedback";
 import { stringifyActionFailure } from "@recommand/lib/utils";
 import { AlertCircle, ArrowLeft, Download, FileText, Loader2, PenLine, ShieldCheck } from "lucide-react";
 import { useTranslation } from "@core/hooks/use-translation";
+import type { VerificationCountrySpecific } from '@peppol/types/verification-country-specific';
 
 const client = rc<Companies>("v1");
 
@@ -18,6 +19,7 @@ type MandateSectionProps = {
     mandateTitle: string | null;
     firstName: string;
     lastName: string;
+    countrySpecific?: VerificationCountrySpecific | null;
     isSigning: boolean;
     signError: string | null;
     onBack: () => void;
@@ -30,6 +32,7 @@ export function MandateSection({
     mandateTitle,
     firstName,
     lastName,
+    countrySpecific,
     isSigning,
     signError,
     onBack,
@@ -55,7 +58,7 @@ export function MandateSection({
             setDownloadError(null);
             const response = await client["companies"]["verification"][":companyVerificationLogId"]["mandate-draft"].$post({
                 param: { companyVerificationLogId },
-                json: { firstName, lastName },
+                json: { firstName, lastName, countrySpecific },
             });
             if (!response.ok) {
                 const json = (await response.json().catch(() => null)) as { errors?: unknown } | null;
@@ -90,6 +93,7 @@ export function MandateSection({
                     </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
+                    {countrySpecific?.country === 'FR' && <p className="text-sm">{t`Establishment SIRET`}: {countrySpecific.siret}</p>}
                     <div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-4">
                         <FileText className="h-8 w-8 shrink-0 text-muted-foreground" />
                         <div className="min-w-0 flex-1">

--- a/app/(public)/company-verification/[companyVerificationLogId]/verify/page.tsx
+++ b/app/(public)/company-verification/[companyVerificationLogId]/verify/page.tsx
@@ -14,6 +14,8 @@ import { Loader2, AlertCircle, ShieldCheck, RefreshCw, XCircle, FileSignature } 
 import { ForwardSection } from "./forward-section";
 import { MandateSection } from "./mandate-section";
 import { useTranslation } from "@core/hooks/use-translation";
+import { CountrySpecificFields } from './country-specific-fields';
+import { validateVerificationCountrySpecific, type VerificationCountrySpecific, type VerificationCountryRequirements } from '@peppol/types/verification-country-specific';
 
 const client = rc<Companies>("v1");
 const VERIFICATION_ALREADY_SUBMITTED_ERROR = "This verification has already been submitted.";
@@ -38,12 +40,14 @@ type VerificationContext = {
         id: string;
         name: string;
         enterpriseNumber: string | null;
+        country: string;
     };
     isRepresentativeSelectionRequired: boolean;
     representatives: Representative[];
     isPlayground: boolean;
     isMandateRequired: boolean;
     mandateTitle: string | null;
+    countryRequirements: VerificationCountryRequirements;
 };
 
 type VerificationStep = "details" | "mandate";
@@ -59,6 +63,7 @@ export default function Page() {
     const [selectedRepresentativeIndex, setSelectedRepresentativeIndex] = useState<string | null>(null);
     const [firstName, setFirstName] = useState("");
     const [lastName, setLastName] = useState("");
+    const [countrySpecific, setCountrySpecific] = useState<VerificationCountrySpecific | null>(null);
     const [acceptTerms, setAcceptTerms] = useState(false);
     const [confirmPermission, setConfirmPermission] = useState(false);
 
@@ -92,7 +97,8 @@ export default function Page() {
         effectiveFirstName.trim() !== "" &&
         effectiveLastName.trim() !== "" &&
         acceptTerms &&
-        confirmPermission;
+        confirmPermission &&
+        (!context?.countryRequirements?.required || !!countrySpecific?.siret.trim());
 
     const statusPageUrl = companyVerificationLogId ? `/company-verification/${companyVerificationLogId}/status` : null;
 
@@ -149,6 +155,12 @@ export default function Page() {
 
     const handleContinue = () => {
         if (!isFormComplete) return;
+        try {
+            setCountrySpecific(validateVerificationCountrySpecific(context!.company, countrySpecific, context?.countryRequirements?.required));
+        } catch (error) {
+            setSubmitError(error instanceof Error ? error.message : t`Invalid verification details`);
+            return;
+        }
 
         // Companies filed with Arratech sign a mandate first; the identity check
         // they are sent to next is what signs it.
@@ -175,6 +187,7 @@ export default function Page() {
                     firstName: effectiveFirstName,
                     lastName: effectiveLastName,
                     mandateAccepted,
+                    countrySpecific,
                 },
             });
             const json = await response.json();
@@ -421,6 +434,7 @@ export default function Page() {
                         mandateTitle={context.mandateTitle}
                         firstName={effectiveFirstName}
                         lastName={effectiveLastName}
+                        countrySpecific={countrySpecific}
                         isSigning={isSubmitting}
                         signError={submitError}
                         onBack={() => setStep("details")}
@@ -428,6 +442,7 @@ export default function Page() {
                     />
                 ) : (
                     <>
+                        <CountrySpecificFields requirements={context.countryRequirements} value={countrySpecific} onChange={setCountrySpecific} />
                         {noRepresentativesFound ? (
                             <Card>
                                 <CardHeader>

--- a/components/company-form-fields.tsx
+++ b/components/company-form-fields.tsx
@@ -149,7 +149,7 @@ export function CompanyIdentityFields({
                             className="flex-1"
                         />
                     </div>
-                    {country === "FR" && <p className="text-xs text-pretty text-muted-foreground">{t`For French businesses, the enterprise number is the 9 digit SIREN. A SIRET can be added as an extra Peppol identifier.`}</p>}
+                    {country === "FR" && <p className="text-xs text-pretty text-muted-foreground">{t`For French businesses, enter the 9 digit SIREN. The establishment SIRET is requested during verification.`}</p>}
                     {showDutchEnterpriseNumberSchemeAlert && country === "NL" && enterpriseNumberScheme !== "0106" && enterpriseNumberScheme !== "0190" && enterpriseNumber.trim() && (
                         <StatusMessage
                             tone="warning"

--- a/data/at/kyc-onboarding-state.ts
+++ b/data/at/kyc-onboarding-state.ts
@@ -1,9 +1,18 @@
+import type { VerificationCountrySpecific } from '@peppol/types/verification-country-specific';
+
 export type ArratechOnboarding = {
   phase: 'submit' | 'activation' | 'support' | 'complete' | 'blocked';
   supportNotifiedAt?: string;
   attempts: number;
   nextAttemptAt: string;
   startedAt: string;
+  identitySupplement?: {
+    countrySpecific: VerificationCountrySpecific;
+    source: string;
+    reviewedBy: string;
+    reviewedAt: string;
+    verificationLogId: string;
+  };
   filing?: {
     siren: string;
     siret: string;

--- a/data/at/kyc-onboarding.ts
+++ b/data/at/kyc-onboarding.ts
@@ -18,6 +18,7 @@ import { companyVerificationLog } from '@peppol/db/schema';
 import { db } from '@recommand/db';
 import type { Logger } from '@recommand/lib/logger';
 import { Cron } from 'croner';
+import { UserFacingError } from '@directory/utils/util';
 import { and, eq, isNotNull, sql } from 'drizzle-orm';
 import { fetchArratech, getArratechConfig } from '@peppol/data/at/client';
 import { buildArratechKycFiling } from '@peppol/data/at/kyc';
@@ -28,6 +29,7 @@ import {
   readKycResponse,
 } from '@peppol/data/at/kyc-onboarding-client';
 import type { ArratechOnboarding } from '@peppol/data/at/kyc-onboarding-state';
+import { validateVerificationCountrySpecific } from '@peppol/types/verification-country-specific';
 import { getParticipantByIdentifier, upsertCompanyRegistrations } from '@peppol/data/at/smp';
 
 export class VerificationBusyError extends KycOnboardingError {
@@ -202,6 +204,7 @@ export async function processArratechOnboarding(id: string): Promise<void> {
       }
       if (
         log.enterpriseNumber !== company.enterpriseNumber ||
+        (state.identitySupplement && state.identitySupplement.verificationLogId !== log.id) ||
         log.companyName !== company.name ||
         log.country !== company.country ||
         log.address !== company.address ||
@@ -213,6 +216,14 @@ export async function processArratechOnboarding(id: string): Promise<void> {
         );
       }
       const identifiers = await getCompanyIdentifiers(company.id);
+      const countrySpecific = validateVerificationCountrySpecific(
+        company, log.countrySpecific ?? state.identitySupplement?.countrySpecific, true,
+      )!;
+      if (state.identitySupplement &&
+        (state.identitySupplement.countrySpecific.country !== countrySpecific.country ||
+          state.identitySupplement.countrySpecific.siret !== countrySpecific.siret)) {
+        throw new KycOnboardingError('Reviewed establishment data conflicts with the submitted verification.');
+      }
       if (!identifiers.length || identifiers.some((identifier) => identifier.scheme !== '0225')) {
         throw new KycOnboardingError(
           'Automatic French onboarding requires 0225 participant identifiers.',
@@ -221,6 +232,7 @@ export async function processArratechOnboarding(id: string): Promise<void> {
       if (!state.filing) {
         const filing = await buildArratechKycFiling({
           company,
+          countrySpecific,
           signatory: { firstName: log.firstName, lastName: log.lastName },
           signedAt: log.mandateAcceptedAt,
           proofReference: log.verificationProofReference,
@@ -245,6 +257,9 @@ export async function processArratechOnboarding(id: string): Promise<void> {
         await saveState(id, state);
       }
       const filing = state.filing;
+      if (filing.siret !== countrySpecific.siret) {
+        throw new KycOnboardingError('Establishment SIRET changed since the mandate was prepared.');
+      }
       const addresses = identifiers
         .map((identifier) => `${identifier.scheme}:${identifier.identifier}`)
         .sort();
@@ -296,7 +311,7 @@ export async function processArratechOnboarding(id: string): Promise<void> {
       await notifyVerificationCompletion(id, company, state);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      const retryable = !(error instanceof KycOnboardingError) || error.retryable;
+      const retryable = !(error instanceof UserFacingError) && (!(error instanceof KycOnboardingError) || error.retryable);
       state.attempts++;
       const expired = Date.now() - Date.parse(state.startedAt) > 72 * 60 * 60 * 1000;
       if (!retryable || expired || (state.phase === 'submit' && state.attempts >= 12)) {

--- a/data/at/kyc-review.ts
+++ b/data/at/kyc-review.ts
@@ -94,6 +94,7 @@ export async function startArratechKycReview({
 
     filing = await buildArratechKycFiling({
       company,
+      countrySpecific: existingLog.countrySpecific,
       signatory: {
         firstName: existingLog.firstName,
         lastName: existingLog.lastName,

--- a/data/at/kyc.ts
+++ b/data/at/kyc.ts
@@ -4,6 +4,7 @@ import { getTeamExtension } from "@peppol/data/teams";
 import { UserFacingError } from "@directory/utils/util";
 import { fetchArratech, fetchArratechJson, getArratechConfig } from "./client";
 import { getParticipantByIdentifier } from "./smp";
+import type { VerificationCountrySpecific } from '@peppol/types/verification-country-specific';
 import {
   getMandateDocument,
   renderMandatePdf,
@@ -27,12 +28,14 @@ export async function requiresArratechKycReview(company: Company): Promise<boole
  */
 export async function buildMandateInput({
   company,
+  countrySpecific,
   signatory,
   signedAt,
   proofReference,
   reference,
 }: {
   company: Company;
+  countrySpecific?: VerificationCountrySpecific | null;
   signatory: { firstName: string; lastName: string; role?: string };
   signedAt: Date;
   proofReference: string | null;
@@ -49,7 +52,7 @@ export async function buildMandateInput({
     reference,
     company,
     identifiers,
-    identity: resolveCompanyKycIdentity(company, identifiers),
+    identity: resolveCompanyKycIdentity(company, identifiers, countrySpecific),
     signatory: {
       firstName: signatory.firstName,
       lastName: signatory.lastName,
@@ -139,6 +142,7 @@ export type ArratechKycFiling = {
  */
 export async function buildArratechKycFiling({
   company,
+  countrySpecific,
   signatory,
   signedAt,
   proofReference,
@@ -149,9 +153,11 @@ export async function buildArratechKycFiling({
   signedAt: Date;
   proofReference: string;
   reference: string;
+  countrySpecific?: VerificationCountrySpecific | null;
 }): Promise<ArratechKycFiling> {
   const input = await buildMandateInput({
     company,
+    countrySpecific,
     signatory,
     signedAt,
     proofReference,
@@ -183,6 +189,9 @@ export async function submitArratechCompanyKyc({
   useTestNetwork: boolean;
 }): Promise<void> {
   const identifiers = await getCompanyIdentifiers(companyId);
+  if (filing.jurisdiction === 'FR' && (!filing.identity.metaData?.siret || filing.identity.notes.length)) {
+    throw new UserFacingError('An explicit establishment SIRET is required before submitting KYC');
+  }
 
   for (const identifier of identifiers) {
     const participant = await getParticipantByIdentifier({

--- a/data/at/mandate.ts
+++ b/data/at/mandate.ts
@@ -3,6 +3,7 @@ import type { CompanyIdentifier } from "@peppol/data/company-identifiers";
 import { renderTailwindTemplate } from "@peppol/utils/tailwind-pdf";
 import { DEFAULT_MANDATE_DOCUMENT } from "./mandates/default";
 import { FRENCH_MANDATE_DOCUMENT } from "./mandates/france";
+import { validateVerificationCountrySpecific, type VerificationCountrySpecific } from '@peppol/types/verification-country-specific';
 
 export type CompanyIdentityRow = {
   label: string;
@@ -63,6 +64,7 @@ export type MandateDocument = {
   resolveIdentity(
     company: CompanyIdentitySource,
     identifiers: Pick<CompanyIdentifier, "scheme" | "identifier">[],
+    countrySpecific?: VerificationCountrySpecific | null,
   ): CompanyKycIdentity;
   /** Mustache template rendered to the PDF that is filed with the KYC. */
   template: string;
@@ -83,8 +85,10 @@ export function getMandateDocument(
 export function resolveCompanyKycIdentity(
   company: CompanyIdentitySource,
   identifiers: Pick<CompanyIdentifier, "scheme" | "identifier">[],
+  countrySpecific?: VerificationCountrySpecific | null,
 ): CompanyKycIdentity {
-  return getMandateDocument(company.country).resolveIdentity(company, identifiers);
+  const verifiedData = validateVerificationCountrySpecific(company, countrySpecific);
+  return getMandateDocument(company.country).resolveIdentity(company, identifiers, verifiedData);
 }
 
 export async function renderMandatePdf(input: MandateInput): Promise<Buffer> {

--- a/data/at/mandates/france.ts
+++ b/data/at/mandates/france.ts
@@ -3,6 +3,7 @@ import type { CompanyIdentifier } from "@peppol/data/company-identifiers";
 import { FRENCH_MANDATE_TEMPLATE } from "@peppol/templates/mandate-fr";
 import { isSiren, isSiret } from "@peppol/utils/identifier-validation";
 import { UserFacingError } from "@directory/utils/util";
+import type { VerificationCountrySpecific } from '@peppol/types/verification-country-specific';
 import { formatMandateDate, MANDATARY, OPERATOR } from "./shared";
 import {
   type CompanyIdentityRow,
@@ -52,15 +53,15 @@ function frenchNumber(value: string | null | undefined): string | null {
  * have to be well formed and agree with each other, since a wrong one ends up
  * in a filing towards the French administration.
  *
- * The one thing it does assume is the head office SIRET when the company only
- * ever gave us its SIREN, which it notes for support.
  */
 export function resolveFrenchCompanyIdentity(
   company: Pick<CompanyIdentitySource, "enterpriseNumber" | "vatNumber">,
   identifiers: Pick<CompanyIdentifier, "scheme" | "identifier">[],
+  countrySpecific?: VerificationCountrySpecific | null,
 ): CompanyKycIdentity {
   const sources: FrenchNumberSource[] = [
     { label: "enterprise number", value: company.enterpriseNumber },
+    { label: "establishment SIRET", value: countrySpecific?.siret ?? null },
     ...identifiers
       .filter((identifier) => FRENCH_IDENTIFIER_SCHEMES.has(identifier.scheme))
       .map((identifier) => ({
@@ -108,14 +109,10 @@ export function resolveFrenchCompanyIdentity(
   }
 
   const siren = sirens[0];
-  const siret = sirets[0] ?? `${siren}00001`;
-  const isSiretAssumed = sirets.length === 0;
+  const siret = sirets[0];
 
-  // An assumed head office SIRET has no place in the mandate; the SIREN, the
-  // legal name and the address identify the company on their own. Arratech does
-  // need one, so support is told it was assumed.
   const rows: CompanyIdentityRow[] = [{ label: "SIREN", value: siren }];
-  if (!isSiretAssumed) {
+  if (siret) {
     rows.push({ label: "SIRET", value: siret });
   }
   if (company.vatNumber) {
@@ -124,10 +121,10 @@ export function resolveFrenchCompanyIdentity(
 
   return {
     rows,
-    metaData: { siren, siret },
-    notes: isSiretAssumed
+    metaData: { siren, ...(siret ? { siret } : {}) },
+    notes: !siret
       ? [
-          `SIRET ${siret} assumed to be the head office, the company only gave us its SIREN`,
+          "An explicit establishment SIRET is required before submitting KYC",
         ]
       : [],
   };

--- a/data/company-verification.ts
+++ b/data/company-verification.ts
@@ -11,6 +11,8 @@ import { getTeamExtension } from "./teams";
 import { shouldRegisterWithSmp } from "@peppol/utils/playground";
 import { unregisterCompanyRegistrations, upsertCompanyRegistrations } from "./smp-providers";
 import { publishCompanyVerificationEvent } from "./company-verification-webhooks";
+import type { VerificationCountrySpecific } from '@peppol/types/verification-country-specific';
+import { submitVerificationIdentity } from '@peppol/data/verification-submission';
 
 export type CompanyVerificationLog = typeof companyVerificationLog.$inferSelect;
 export type CompanyVerificationStatus = CompanyVerificationLog["status"];
@@ -289,7 +291,8 @@ export async function submitIdentityForm(
   company: Company,
   firstName: string,
   lastName: string,
-  mandateAccepted: boolean
+  mandateAccepted: boolean,
+  countrySpecific?: VerificationCountrySpecific | null,
 ): Promise<string> {
   if (log.status !== "opened") {
     throw new UserFacingError("This verification has already been submitted.");
@@ -332,24 +335,26 @@ export async function submitIdentityForm(
     }
   }
 
-  const verificationUrl = await createIdVerificationUrl(companyVerificationLogId, company, {
+  return submitVerificationIdentity({
+    company,
     firstName: effectiveFirstName,
     lastName: effectiveLastName,
-  });
-
-  await db
-    .update(companyVerificationLog)
-    .set({
+    mandateRequired,
+    mandateAccepted,
+    countrySpecific,
+  }, {
+    claimOpenedSubmission: async snapshot => {
+      const rows = await db.update(companyVerificationLog)
+        .set({ ...snapshot, status: 'idVerificationRequested' })
+        .where(and(eq(companyVerificationLog.id, companyVerificationLogId), eq(companyVerificationLog.status, 'opened')))
+        .returning({ id: companyVerificationLog.id });
+      return rows.length === 1;
+    },
+    startIdentityVerification: () => createIdVerificationUrl(companyVerificationLogId, company, {
       firstName: effectiveFirstName,
       lastName: effectiveLastName,
-      status: "idVerificationRequested",
-      mandateAcceptedAt: mandateRequired ? new Date() : null,
-    })
-    .where(eq(companyVerificationLog.id, companyVerificationLogId))
-    .returning()
-    .then((rows) => rows[0]);
-
-  return verificationUrl;
+    }),
+  });
 }
 
 export async function submitPlaygroundVerification(

--- a/data/verification-submission.ts
+++ b/data/verification-submission.ts
@@ -1,0 +1,35 @@
+import { UserFacingError } from '@directory/utils/util';
+import { getVerificationCountryRequirements, validateVerificationCountrySpecific, type VerificationCountrySpecific } from '@peppol/types/verification-country-specific';
+
+export type VerificationSubmission = {
+  firstName: string;
+  lastName: string;
+  mandateAcceptedAt: Date | null;
+  countrySpecific: VerificationCountrySpecific | null;
+};
+
+export async function submitVerificationIdentity(input: {
+  company: { country: string; enterpriseNumber: string | null; isSmpRecipient: boolean };
+  firstName: string;
+  lastName: string;
+  mandateRequired: boolean;
+  mandateAccepted: boolean;
+  countrySpecific?: VerificationCountrySpecific | null;
+}, dependencies: {
+  claimOpenedSubmission: (snapshot: VerificationSubmission) => Promise<boolean>;
+  startIdentityVerification: () => Promise<string>;
+}): Promise<string> {
+  if (input.mandateRequired && !input.mandateAccepted) {
+    throw new UserFacingError('The mandate has to be signed before the identity check can start.');
+  }
+  const requirements = getVerificationCountryRequirements(input.company.country, input.mandateRequired, input.company.isSmpRecipient);
+  const countrySpecific = validateVerificationCountrySpecific(input.company, input.countrySpecific, requirements?.required);
+  const claimed = await dependencies.claimOpenedSubmission({
+    firstName: input.firstName,
+    lastName: input.lastName,
+    mandateAcceptedAt: input.mandateRequired ? new Date() : null,
+    countrySpecific,
+  });
+  if (!claimed) throw new UserFacingError('This verification has already been submitted.');
+  return dependencies.startIdentityVerification();
+}

--- a/db/drizzle/20260905092050_verification_country_specific.sql
+++ b/db/drizzle/20260905092050_verification_country_specific.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "company_verification_log" ADD COLUMN "country_specific" jsonb;

--- a/db/drizzle/meta/20260905092050_snapshot.json
+++ b/db/drizzle/meta/20260905092050_snapshot.json
@@ -1,0 +1,2678 @@
+{
+  "id": "3163e641-8644-4df1-862f-cd5ea99eb675",
+  "prevId": "bcaeee7a-0389-416f-bcf5-9446d4862475",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activated_integrations": {
+      "name": "activated_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activated_integrations_team_id_idx": {
+          "name": "activated_integrations_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activated_integrations_team_id_teams_id_fk": {
+          "name": "activated_integrations_team_id_teams_id_fk",
+          "tableFrom": "activated_integrations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activated_integrations_company_id_peppol_companies_id_fk": {
+          "name": "activated_integrations_company_id_peppol_companies_id_fk",
+          "tableFrom": "activated_integrations",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_billing_profiles": {
+      "name": "peppol_billing_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mollie_customer_id": {
+          "name": "mollie_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_payment_id": {
+          "name": "first_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_payment_status": {
+          "name": "first_payment_status",
+          "type": "peppol_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "is_mandate_validated": {
+          "name": "is_mandate_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile_standing": {
+          "name": "profile_standing",
+          "type": "peppol_profile_standing",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "grace_started_at": {
+          "name": "grace_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_reason": {
+          "name": "grace_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_peppol_address": {
+          "name": "billing_peppol_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_manually_billed": {
+          "name": "is_manually_billed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "peppol_billing_profiles_team_id_unique": {
+          "name": "peppol_billing_profiles_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_companies": {
+      "name": "peppol_companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enterprise_number_scheme": {
+          "name": "enterprise_number_scheme",
+          "type": "peppol_valid_iso_icd_scheme_identifiers",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_smp_recipient": {
+          "name": "is_smp_recipient",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_point_provider": {
+          "name": "access_point_provider",
+          "type": "peppol_access_point_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-ap1'"
+        },
+        "smp_provider": {
+          "name": "smp_provider",
+          "type": "peppol_smp_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-smp1'"
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_proof_reference": {
+          "name": "verification_proof_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_companies_team_id_teams_id_fk": {
+          "name": "peppol_companies_team_id_teams_id_fk",
+          "tableFrom": "peppol_companies",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_document_types": {
+      "name": "peppol_company_document_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type_id": {
+          "name": "doc_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_document_types_unique": {
+          "name": "peppol_company_document_types_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doc_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "process_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_document_types_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_document_types_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_document_types",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_identifiers": {
+      "name": "peppol_company_identifiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_identifiers_unique": {
+          "name": "peppol_company_identifiers_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"scheme\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"identifier\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_identifiers_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_identifiers_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_identifiers",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_notification_email_addresses": {
+      "name": "peppol_company_notification_email_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notify_incoming": {
+          "name": "notify_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_outgoing": {
+          "name": "notify_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_auto_generated_pdf_incoming": {
+          "name": "include_auto_generated_pdf_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_auto_generated_pdf_outgoing": {
+          "name": "include_auto_generated_pdf_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_document_json_incoming": {
+          "name": "include_document_json_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_document_json_outgoing": {
+          "name": "include_document_json_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_notification_email_addresses_unique": {
+          "name": "peppol_company_notification_email_addresses_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_notification_email_addresses_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_notification_email_addresses_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_notification_email_addresses",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_verification_log": {
+      "name": "company_verification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opened'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_specific": {
+          "name": "country_specific",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_proof_reference": {
+          "name": "verification_proof_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mandate_accepted_at": {
+          "name": "mandate_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arratech_onboarding": {
+          "name": "arratech_onboarding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_verification_log_company_id_peppol_companies_id_fk": {
+          "name": "company_verification_log_company_id_peppol_companies_id_fk",
+          "tableFrom": "company_verification_log",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enterprise_data_cache": {
+      "name": "enterprise_data_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "begin_date": {
+          "name": "begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_code": {
+          "name": "juridical_form_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_description": {
+          "name": "juridical_form_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_begin_date": {
+          "name": "juridical_form_begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_code": {
+          "name": "denomination_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_description": {
+          "name": "denomination_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_begin_date": {
+          "name": "denomination_begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "enterprise_data_cache_unique": {
+          "name": "enterprise_data_cache_unique",
+          "columns": [
+            {
+              "expression": "enterprise_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_task_logs": {
+      "name": "integration_task_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integration_task_logs_integration_id_activated_integrations_id_fk": {
+          "name": "integration_task_logs_integration_id_activated_integrations_id_fk",
+          "tableFrom": "integration_task_logs",
+          "tableTo": "activated_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_outgoing_envelope_claims": {
+      "name": "peppol_outgoing_envelope_claims",
+      "schema": "",
+      "columns": {
+        "instance_identifier": {
+          "name": "instance_identifier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_outgoing_envelope_claims_created_at_idx": {
+          "name": "peppol_outgoing_envelope_claims_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_payment_failure_reminders": {
+      "name": "peppol_payment_failure_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_event_id": {
+          "name": "billing_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_addresses": {
+          "name": "email_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_payment_failure_reminders_billing_event_id_peppol_subscription_billing_events_id_fk": {
+          "name": "peppol_payment_failure_reminders_billing_event_id_peppol_subscription_billing_events_id_fk",
+          "tableFrom": "peppol_payment_failure_reminders",
+          "tableTo": "peppol_subscription_billing_events",
+          "columnsFrom": [
+            "billing_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_s3_deletions": {
+      "name": "pending_s3_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_s3_deletions_claim_idx": {
+          "name": "pending_s3_deletions_claim_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscription_billing_event_lines": {
+      "name": "peppol_subscription_billing_event_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_billing_event_id": {
+          "name": "subscription_billing_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_start_date": {
+          "name": "subscription_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_end_date": {
+          "name": "subscription_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_last_billed_at": {
+          "name": "subscription_last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_config": {
+          "name": "billing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included_monthly_documents": {
+          "name": "included_monthly_documents",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_document_overage_price": {
+          "name": "incoming_document_overage_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outgoing_document_overage_price": {
+          "name": "outgoing_document_overage_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty": {
+          "name": "used_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_incoming": {
+          "name": "used_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_outgoing": {
+          "name": "used_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_incoming": {
+          "name": "overage_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_outgoing": {
+          "name": "overage_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_excl": {
+          "name": "total_amount_excl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_subscription_billing_event_lines_subscription_billing_event_id_peppol_subscription_billing_events_id_fk": {
+          "name": "peppol_subscription_billing_event_lines_subscription_billing_event_id_peppol_subscription_billing_events_id_fk",
+          "tableFrom": "peppol_subscription_billing_event_lines",
+          "tableTo": "peppol_subscription_billing_events",
+          "columnsFrom": [
+            "subscription_billing_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscription_billing_events": {
+      "name": "peppol_subscription_billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_profile_id": {
+          "name": "billing_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_date": {
+          "name": "billing_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_start": {
+          "name": "billing_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_end": {
+          "name": "billing_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_excl": {
+          "name": "total_amount_excl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_amount": {
+          "name": "vat_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_category": {
+          "name": "vat_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_percentage": {
+          "name": "vat_percentage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_incl": {
+          "name": "total_amount_incl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty": {
+          "name": "used_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_incoming": {
+          "name": "used_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_outgoing": {
+          "name": "used_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_incoming": {
+          "name": "overage_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_outgoing": {
+          "name": "overage_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_due": {
+          "name": "amount_due",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "peppol_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_reference": {
+          "name": "invoice_reference",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_subscription_billing_events_billing_profile_id_peppol_billing_profiles_id_fk": {
+          "name": "peppol_subscription_billing_events_billing_profile_id_peppol_billing_profiles_id_fk",
+          "tableFrom": "peppol_subscription_billing_events",
+          "tableTo": "peppol_billing_profiles",
+          "columnsFrom": [
+            "billing_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "peppol_subscription_billing_events_invoice_id_unique": {
+          "name": "peppol_subscription_billing_events_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_id"
+          ]
+        },
+        "peppol_subscription_billing_events_invoice_reference_unique": {
+          "name": "peppol_subscription_billing_events_invoice_reference_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_reference"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscriptions": {
+      "name": "peppol_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_config": {
+          "name": "billing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_billed_at": {
+          "name": "last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_team_extensions": {
+      "name": "peppol_team_extensions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_playground": {
+          "name": "is_playground",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_test_network": {
+          "name": "use_test_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_requirements": {
+          "name": "verification_requirements",
+          "type": "verification_requirements",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lax'"
+        },
+        "company_verification_extension_until": {
+          "name": "company_verification_extension_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_email_address": {
+          "name": "support_email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_team_extensions_id_teams_id_fk": {
+          "name": "peppol_team_extensions_id_teams_id_fk",
+          "tableFrom": "peppol_team_extensions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transfer_events": {
+      "name": "peppol_transfer_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "peppol_transfer_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'peppol'"
+        },
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "peppol_transfer_event_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transmitted_document_labels": {
+      "name": "peppol_transmitted_document_labels",
+      "schema": "",
+      "columns": {
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_transmitted_document_labels_transmitted_document_id_peppol_transmitted_documents_id_fk": {
+          "name": "peppol_transmitted_document_labels_transmitted_document_id_peppol_transmitted_documents_id_fk",
+          "tableFrom": "peppol_transmitted_document_labels",
+          "tableTo": "peppol_transmitted_documents",
+          "columnsFrom": [
+            "transmitted_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_transmitted_document_labels_label_id_peppol_labels_id_fk": {
+          "name": "peppol_transmitted_document_labels_label_id_peppol_labels_id_fk",
+          "tableFrom": "peppol_transmitted_document_labels",
+          "tableTo": "peppol_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "peppol_transmitted_document_labels_pkey": {
+          "name": "peppol_transmitted_document_labels_pkey",
+          "columns": [
+            "transmitted_document_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transmitted_documents": {
+      "name": "peppol_transmitted_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "peppol_transfer_event_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_type_id": {
+          "name": "doc_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_c1": {
+          "name": "country_c1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_point_provider": {
+          "name": "access_point_provider",
+          "type": "peppol_access_point_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-ap1'"
+        },
+        "smp_provider": {
+          "name": "smp_provider",
+          "type": "peppol_smp_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-smp1'"
+        },
+        "xml": {
+          "name": "xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_location": {
+          "name": "xml_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'db'"
+        },
+        "attachments_location": {
+          "name": "attachments_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'db'"
+        },
+        "original_payload_location": {
+          "name": "original_payload_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "original_payload_container_format": {
+          "name": "original_payload_container_format",
+          "type": "peppol_original_payload_container_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "s3_key_prefix": {
+          "name": "s3_key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offload_claimed_at": {
+          "name": "offload_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_over_peppol": {
+          "name": "sent_over_peppol",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sent_over_email": {
+          "name": "sent_over_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_recipients": {
+          "name": "email_recipients",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "type": {
+          "name": "type",
+          "type": "peppol_supported_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "parsed": {
+          "name": "parsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation": {
+          "name": "validation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_name": {
+          "name": "receiver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peppol_message_id": {
+          "name": "peppol_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peppol_conversation_id": {
+          "name": "peppol_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_peppol_signal_message": {
+          "name": "received_peppol_signal_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envelope_id": {
+          "name": "envelope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ap_transaction_id": {
+          "name": "ap_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_reference_id": {
+          "name": "external_reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_transmitted_documents_offload_idx": {
+          "name": "peppol_transmitted_documents_offload_idx",
+          "columns": [
+            {
+              "expression": "xml_location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "offload_claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_transmitted_documents_ap_transaction_id_idx": {
+          "name": "peppol_transmitted_documents_ap_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "ap_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"peppol_transmitted_documents\".\"ap_transaction_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_transmitted_documents_team_id_teams_id_fk": {
+          "name": "peppol_transmitted_documents_team_id_teams_id_fk",
+          "tableFrom": "peppol_transmitted_documents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_transmitted_documents_company_id_peppol_companies_id_fk": {
+          "name": "peppol_transmitted_documents_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_transmitted_documents",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_webhooks": {
+      "name": "peppol_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_webhooks_team_id_teams_id_fk": {
+          "name": "peppol_webhooks_team_id_teams_id_fk",
+          "tableFrom": "peppol_webhooks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_webhooks_company_id_peppol_companies_id_fk": {
+          "name": "peppol_webhooks_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_webhooks",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.peppol_access_point_provider": {
+      "name": "peppol_access_point_provider",
+      "schema": "public",
+      "values": [
+        "recommand-ap1",
+        "at-shared-ap-fr"
+      ]
+    },
+    "public.peppol_original_payload_container_format": {
+      "name": "peppol_original_payload_container_format",
+      "schema": "public",
+      "values": [
+        "none",
+        "pdf"
+      ]
+    },
+    "public.peppol_payload_location": {
+      "name": "peppol_payload_location",
+      "schema": "public",
+      "values": [
+        "none",
+        "db",
+        "s3"
+      ]
+    },
+    "public.peppol_payment_status": {
+      "name": "peppol_payment_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "open",
+        "pending",
+        "authorized",
+        "paid",
+        "canceled",
+        "expired",
+        "failed"
+      ]
+    },
+    "public.peppol_profile_standing": {
+      "name": "peppol_profile_standing",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "grace",
+        "suspended"
+      ]
+    },
+    "public.peppol_smp_provider": {
+      "name": "peppol_smp_provider",
+      "schema": "public",
+      "values": [
+        "recommand-smp1",
+        "at-shared-smp-fr"
+      ]
+    },
+    "public.peppol_supported_document_type": {
+      "name": "peppol_supported_document_type",
+      "schema": "public",
+      "values": [
+        "invoice",
+        "creditNote",
+        "selfBillingInvoice",
+        "selfBillingCreditNote",
+        "messageLevelResponse",
+        "frenchInvoicingCdar",
+        "frenchB2CSalesReport",
+        "frenchB2CPaymentReport",
+        "frenchB2BiInvoiceReport",
+        "frenchB2BiPaymentReport",
+        "unknown"
+      ]
+    },
+    "public.peppol_transfer_event_direction": {
+      "name": "peppol_transfer_event_direction",
+      "schema": "public",
+      "values": [
+        "incoming",
+        "outgoing"
+      ]
+    },
+    "public.peppol_transfer_event_type": {
+      "name": "peppol_transfer_event_type",
+      "schema": "public",
+      "values": [
+        "peppol",
+        "email",
+        "reporting"
+      ]
+    },
+    "public.peppol_valid_country_codes": {
+      "name": "peppol_valid_country_codes",
+      "schema": "public",
+      "values": [
+        "AU",
+        "AT",
+        "BE",
+        "BG",
+        "CA",
+        "HR",
+        "DK",
+        "EE",
+        "FI",
+        "FR",
+        "DE",
+        "GR",
+        "HK",
+        "HU",
+        "IS",
+        "IE",
+        "IT",
+        "JP",
+        "LV",
+        "LU",
+        "MY",
+        "NL",
+        "NZ",
+        "NO",
+        "PL",
+        "PT",
+        "RO",
+        "SG",
+        "SK",
+        "SI",
+        "ES",
+        "SE",
+        "AE",
+        "GB",
+        "US"
+      ]
+    },
+    "public.peppol_valid_iso_icd_scheme_identifiers": {
+      "name": "peppol_valid_iso_icd_scheme_identifiers",
+      "schema": "public",
+      "values": [
+        "0002",
+        "0003",
+        "0004",
+        "0005",
+        "0006",
+        "0007",
+        "0008",
+        "0009",
+        "0010",
+        "0011",
+        "0012",
+        "0013",
+        "0014",
+        "0015",
+        "0016",
+        "0017",
+        "0018",
+        "0019",
+        "0020",
+        "0021",
+        "0022",
+        "0023",
+        "0024",
+        "0025",
+        "0026",
+        "0027",
+        "0028",
+        "0029",
+        "0030",
+        "0031",
+        "0032",
+        "0033",
+        "0034",
+        "0035",
+        "0036",
+        "0037",
+        "0038",
+        "0039",
+        "0040",
+        "0041",
+        "0042",
+        "0043",
+        "0044",
+        "0045",
+        "0046",
+        "0047",
+        "0048",
+        "0049",
+        "0050",
+        "0051",
+        "0052",
+        "0053",
+        "0054",
+        "0055",
+        "0056",
+        "0057",
+        "0058",
+        "0059",
+        "0060",
+        "0061",
+        "0062",
+        "0063",
+        "0064",
+        "0065",
+        "0066",
+        "0067",
+        "0068",
+        "0069",
+        "0070",
+        "0071",
+        "0072",
+        "0073",
+        "0074",
+        "0075",
+        "0076",
+        "0077",
+        "0078",
+        "0079",
+        "0080",
+        "0081",
+        "0082",
+        "0083",
+        "0084",
+        "0085",
+        "0086",
+        "0087",
+        "0088",
+        "0089",
+        "0090",
+        "0091",
+        "0093",
+        "0094",
+        "0095",
+        "0096",
+        "0097",
+        "0098",
+        "0099",
+        "0100",
+        "0101",
+        "0102",
+        "0104",
+        "0105",
+        "0106",
+        "0107",
+        "0108",
+        "0109",
+        "0110",
+        "0111",
+        "0112",
+        "0113",
+        "0114",
+        "0115",
+        "0116",
+        "0117",
+        "0118",
+        "0119",
+        "0120",
+        "0121",
+        "0122",
+        "0123",
+        "0124",
+        "0125",
+        "0126",
+        "0127",
+        "0128",
+        "0129",
+        "0130",
+        "0131",
+        "0132",
+        "0133",
+        "0134",
+        "0135",
+        "0136",
+        "0137",
+        "0138",
+        "0139",
+        "0140",
+        "0141",
+        "0142",
+        "0143",
+        "0144",
+        "0145",
+        "0146",
+        "0147",
+        "0148",
+        "0149",
+        "0150",
+        "0151",
+        "0152",
+        "0153",
+        "0154",
+        "0155",
+        "0156",
+        "0157",
+        "0158",
+        "0159",
+        "0160",
+        "0161",
+        "0162",
+        "0163",
+        "0164",
+        "0165",
+        "0166",
+        "0167",
+        "0168",
+        "0169",
+        "0170",
+        "0171",
+        "0172",
+        "0173",
+        "0174",
+        "0175",
+        "0176",
+        "0177",
+        "0178",
+        "0179",
+        "0180",
+        "0183",
+        "0184",
+        "0185",
+        "0186",
+        "0187",
+        "0188",
+        "0189",
+        "0190",
+        "0191",
+        "0192",
+        "0193",
+        "0194",
+        "0195",
+        "0196",
+        "0197",
+        "0198",
+        "0199",
+        "0200",
+        "0201",
+        "0202",
+        "0203",
+        "0204",
+        "0205",
+        "0206",
+        "0207",
+        "0208",
+        "0209",
+        "0210",
+        "0211",
+        "0212",
+        "0213",
+        "0214",
+        "0215",
+        "0216",
+        "0217",
+        "0218",
+        "0219",
+        "0220",
+        "0221",
+        "0222",
+        "0223",
+        "0224",
+        "0225",
+        "0226",
+        "0227",
+        "0228",
+        "0229",
+        "0230",
+        "0231",
+        "0232",
+        "0233",
+        "0234",
+        "0235",
+        "0236",
+        "0237",
+        "0238",
+        "0239",
+        "0240"
+      ]
+    },
+    "public.peppol_validation_result": {
+      "name": "peppol_validation_result",
+      "schema": "public",
+      "values": [
+        "valid",
+        "invalid",
+        "not_supported",
+        "error"
+      ]
+    },
+    "public.verification_requirements": {
+      "name": "verification_requirements",
+      "schema": "public",
+      "values": [
+        "strict",
+        "trusted",
+        "lax"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "opened",
+        "idVerificationRequested",
+        "inReview",
+        "verified",
+        "rejected",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/drizzle/meta/_journal.json
+++ b/db/drizzle/meta/_journal.json
@@ -715,6 +715,13 @@
       "when": 1788554342765,
       "tag": "20260904203902_curved_viper",
       "breakpoints": true
+    },
+    {
+      "idx": 102,
+      "version": "7",
+      "when": 1788600050898,
+      "tag": "20260905092050_verification_country_specific",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,5 +1,6 @@
 import type { BillingConfig } from "../data/plans";
 import type { ArratechOnboarding } from "@peppol/data/at/kyc-onboarding-state";
+import type { VerificationCountrySpecific } from '@peppol/types/verification-country-specific';
 import { teams } from "@core/db/schema";
 import {
   timestamp,
@@ -309,6 +310,7 @@ export const companyVerificationLog = pgTable(
     lastName: text("last_name"),
     companyName: text("company_name"),
     enterpriseNumber: text("enterprise_number"),
+    countrySpecific: jsonb('country_specific').$type<VerificationCountrySpecific>(),
     address: text("address"),
     postalCode: text("postal_code"),
     city: text("city"),

--- a/test/arratech-kyc-client.test.ts
+++ b/test/arratech-kyc-client.test.ts
@@ -9,8 +9,8 @@ const mandate = Buffer.from('%PDF-1.7 signed mandate');
 const path = '/orgs/org/participants/participant/kyc';
 const input = {
   path,
-  siren: '830905253',
-  siret: '83090525300015',
+  siren: '000000018',
+  siret: '00000001800002',
   mandate,
   fileName: 'mandate.pdf',
 };

--- a/test/arratech/onboarding.test.ts
+++ b/test/arratech/onboarding.test.ts
@@ -34,7 +34,7 @@ mock.module('@recommand/db', () => ({
 mock.module('@peppol/data/companies', () => ({ getCompanyById: async () => company }));
 mock.module('@peppol/data/teams', () => ({ getTeamExtension: async () => team }));
 mock.module('@peppol/data/company-identifiers', () => ({
-  getCompanyIdentifiers: async () => [{ scheme: '0225', identifier: '830905253' }],
+  getCompanyIdentifiers: async () => [{ scheme: '0225', identifier: '303265045' }],
 }));
 mock.module('@peppol/data/company-verification', () => ({
   getCompanyVerificationLog: async () => structuredClone(log),
@@ -73,8 +73,8 @@ mock.module('@peppol/data/send-arratech-kyc-review-email', () => ({
 }));
 mock.module('@peppol/data/at/kyc', () => ({
   buildArratechKycFiling: async () => ({
-    identity: { metaData: { siren: '830905253', siret: '83090525300015' }, notes: mandateNotes },
-    electronicAddresses: ['0225:830905253'],
+    identity: { metaData: { siren: '303265045', siret: '30326504500011' }, notes: mandateNotes },
+    electronicAddresses: ['0225:303265045'],
     mandate: Buffer.from('%PDF signed'),
     mandateFileName: 'mandate.pdf',
   }),
@@ -83,7 +83,7 @@ mock.module('@peppol/data/at/smp', () => ({
   getParticipantByIdentifier: async () => ({ id: 'participant', status: participantStatus }),
   upsertCompanyRegistrations: async (options: any) => {
     if (options.includeCapabilities === false) {
-      expect(options.siret).toBe('83090525300015');
+      expect(options.siret).toBe('30326504500011');
       events.push('register');
     } else {
       events.push('sync');
@@ -104,7 +104,7 @@ mock.module('@peppol/data/at/client', () => ({
     return Response.json({
       status: kycStatus,
       jurisdiction: 'FR',
-      metaData: { siren: '830905253', siret: '83090525300015' },
+      metaData: { siren: '303265045', siret: '30326504500011' },
       documents: [],
     });
   },
@@ -122,7 +122,8 @@ beforeEach(() => {
     firstName: 'Jean',
     lastName: 'Dupont',
     companyName: 'Company',
-    enterpriseNumber: '83090525300015',
+    enterpriseNumber: '303265045',
+    countrySpecific: { country: 'FR', siret: '30326504500011' },
     country: 'FR',
     address: 'Street',
     postalCode: '75001',
@@ -154,7 +155,66 @@ beforeEach(() => {
 });
 
 describe('durable Arratech onboarding', () => {
+  it('blocks a mismatched country before any provider writes', async () => {
+    log.countrySpecific = { country: 'BE', siret: '30326504500011' };
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['support']);
+    expect(log.arratechOnboarding.phase).toBe('blocked');
+  });
+
+  it('does not let a supplement override submitted country data', async () => {
+    log.arratechOnboarding.identitySupplement = {
+      countrySpecific: { country: 'FR', siret: '00000001800002' }, source: 'confirmation', reviewedBy: 'support',
+      reviewedAt: new Date().toISOString(), verificationLogId: log.id,
+    };
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['support']);
+  });
+
+  it('blocks a cached filing that differs from the submitted establishment', async () => {
+    await processArratechOnboarding(log.id);
+    events.length = 0;
+    log.arratechOnboarding.filing.siret = '00000001800002';
+    participantStatus = 'ACTIVE';
+    await processArratechOnboarding(log.id);
+    expect(events).toEqual(['support']);
+    expect(log.status).toBe('inReview');
+  });
+  it('uses the verification SIRET without a SIRET field on the company', async () => {
+    await processArratechOnboarding(log.id);
+    expect(events).toContain('approve');
+    expect(company).not.toHaveProperty('siret');
+  });
+
+  it('blocks missing establishment data before any provider writes', async () => {
+    delete log.countrySpecific;
+    await processArratechOnboarding(log.id);
+    expect(events).not.toContain('approve');
+    expect(log.arratechOnboarding.phase).toBe('blocked');
+  });
+
+  it('accepts a reviewed legacy supplement without changing the signed snapshot', async () => {
+    delete log.countrySpecific;
+    log.arratechOnboarding.identitySupplement = {
+      countrySpecific: { country: 'FR', siret: '30326504500011' }, source: 'customer-confirmation', reviewedBy: 'support',
+      reviewedAt: new Date().toISOString(), verificationLogId: log.id,
+    };
+    await processArratechOnboarding(log.id);
+    expect(events).toContain('approve');
+    expect(log.countrySpecific).toBeUndefined();
+  });
+
+  it('rejects a supplement belonging to another session', async () => {
+    delete log.countrySpecific;
+    log.arratechOnboarding.identitySupplement = {
+      countrySpecific: { country: 'FR', siret: '30326504500011' }, source: 'customer-confirmation', reviewedBy: 'support',
+      reviewedAt: new Date().toISOString(), verificationLogId: 'other',
+    };
+    await processArratechOnboarding(log.id);
+    expect(events).not.toContain('approve');
+  });
   it('routes send-only to support once without registration or approval', async () => {
+    delete log.countrySpecific;
     company.isSmpRecipient = false;
     await processArratechOnboarding(log.id);
     expect(events).toEqual(['support']);

--- a/test/mandate.test.ts
+++ b/test/mandate.test.ts
@@ -112,15 +112,14 @@ function resolveFrench(
 }
 
 describe("French company identity", () => {
-  it("assumes the head office SIRET when only a SIREN is known", () => {
+  it("does not invent an establishment SIRET when only a SIREN is known", () => {
     const identity = resolveFrench("303265045");
 
     expect(identity.metaData).toEqual({
       siren: "303265045",
-      siret: "30326504500001",
     });
     expect(identity.notes).toEqual([
-      "SIRET 30326504500001 assumed to be the head office, the company only gave us its SIREN",
+      "An explicit establishment SIRET is required before submitting KYC",
     ]);
   });
 
@@ -132,6 +131,21 @@ describe("French company identity", () => {
       { label: "SIREN", value: "303265045" },
       { label: "SIRET", value: "30326504500011" },
     ]);
+  });
+
+  it('uses a separate establishment SIRET with only a 0225 receiving identifier', () => {
+    const identity = resolveCompanyKycIdentity({
+      country: 'FR', enterpriseNumber: '303265045', enterpriseNumberScheme: '0002',
+      vatNumber: null,
+    }, [{ scheme: '0225', identifier: '303265045' }] as CompanyIdentifier[], { country: 'FR', siret: '30326504500011' });
+    expect(identity.metaData).toEqual({ siren: '303265045', siret: '30326504500011' });
+    expect(identity.notes).toEqual([]);
+  });
+
+  it('rejects a conflicting or malformed explicit establishment', () => {
+    const company = { country: 'FR', enterpriseNumber: '303265045', enterpriseNumberScheme: '0002', vatNumber: null } as const;
+    expect(() => resolveCompanyKycIdentity(company, [], { country: 'FR', siret: '303265045' })).toThrow('14 digit');
+    expect(() => resolveCompanyKycIdentity(company, [], { country: 'FR', siret: '00000001800002' })).toThrow('must match');
   });
 
   it("keeps a SIRET that is stored as the enterprise number", () => {

--- a/test/verification-country-specific.test.ts
+++ b/test/verification-country-specific.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import { getVerificationCountryRequirements, validateVerificationCountrySpecific, verificationCountrySpecificSchema } from '../types/verification-country-specific';
+
+const company = { country: 'FR', enterpriseNumber: '303265045' };
+describe('country-specific verification input', () => {
+  it('normalizes and validates an explicit establishment', () => {
+    expect(validateVerificationCountrySpecific(company, { country: 'FR', siret: '303 265 045 00011' }, true))
+      .toEqual({ country: 'FR', siret: '30326504500011' });
+  });
+  it('leaves other countries and optional send-only data unchanged', () => {
+    expect(getVerificationCountryRequirements('BE', false, true)).toBeNull();
+    expect(getVerificationCountryRequirements('FR', false, true)).toBeNull();
+    expect(getVerificationCountryRequirements('FR', true, false)).toEqual({ country: 'FR', required: false });
+    expect(validateVerificationCountrySpecific({ country: 'BE', enterpriseNumber: null }, undefined)).toBeNull();
+    expect(validateVerificationCountrySpecific(company, undefined, false)).toBeNull();
+  });
+  it('requires an establishment for French receiving mandates', () => {
+    expect(getVerificationCountryRequirements('FR', true, true)).toEqual({ country: 'FR', required: true });
+    expect(() => validateVerificationCountrySpecific(company, undefined, true)).toThrow('required');
+  });
+  it('rejects country mismatches, wrong SIREN, malformed values and unknown metadata', () => {
+    expect(() => validateVerificationCountrySpecific({ country: 'BE', enterpriseNumber: '303265045' }, { country: 'FR', siret: '30326504500011' })).toThrow('country');
+    for (const value of [
+      { country: 'FR', siret: '00000001800002' }, { country: 'FR', siret: '303265045' },
+      { country: 'FR', siret: '30326504500012' }, { country: 'BE', siret: '30326504500011' },
+      { country: 'FR', siret: '30326504500011', arbitrary: true },
+    ]) expect(() => validateVerificationCountrySpecific(company, value)).toThrow();
+  });
+  it('does not mutate the company or submitted object', () => {
+    const input = { country: 'FR', siret: '303 265 045 00011' };
+    validateVerificationCountrySpecific(company, input);
+    expect(input.siret).toBe('303 265 045 00011');
+    expect(company).not.toHaveProperty('siret');
+    expect(verificationCountrySpecificSchema.safeParse({ country: 'FR', siret: '' }).success).toBe(false);
+  });
+});

--- a/test/verification-submission.test.ts
+++ b/test/verification-submission.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+import { submitVerificationIdentity, type VerificationSubmission } from '../data/verification-submission';
+
+const input = {
+  company: { country: 'FR', enterpriseNumber: '303265045', isSmpRecipient: true },
+  firstName: 'Jean', lastName: 'Dupont', mandateRequired: true, mandateAccepted: true,
+  countrySpecific: { country: 'FR' as const, siret: '303 265 045 00011' },
+};
+
+function storage() {
+  let saved: VerificationSubmission | undefined;
+  let starts = 0;
+  let failStart = false;
+  return {
+    get saved() { return saved; },
+    get starts() { return starts; },
+    set failStart(value: boolean) { failStart = value; },
+    dependencies: {
+      claimOpenedSubmission: async (snapshot: VerificationSubmission) => {
+        if (saved) return false;
+        saved = structuredClone(snapshot);
+        return true;
+      },
+      startIdentityVerification: async () => {
+        expect(saved).toBeDefined();
+        starts++;
+        if (failStart) throw new Error('Identity provider unavailable');
+        return 'https://identity.example/session';
+      },
+    },
+  };
+}
+
+describe('verification submission', () => {
+  it('stores normalized country data before starting identity verification', async () => {
+    const store = storage();
+    expect(await submitVerificationIdentity(input, store.dependencies)).toBe('https://identity.example/session');
+    expect(store.saved?.countrySpecific).toEqual({ country: 'FR', siret: '30326504500011' });
+    expect(store.saved?.mandateAcceptedAt).toBeInstanceOf(Date);
+    expect(input.company).not.toHaveProperty('siret');
+  });
+  it('rejects invalid or missing details before claiming or starting', async () => {
+    for (const payload of [{ ...input, countrySpecific: null }, { ...input, mandateAccepted: false },
+      { ...input, countrySpecific: { country: 'FR' as const, siret: '00000001800002' } }]) {
+      const store = storage();
+      await expect(submitVerificationIdentity(payload, store.dependencies)).rejects.toThrow();
+      expect(store.saved).toBeUndefined();
+      expect(store.starts).toBe(0);
+    }
+  });
+  it('does not overwrite a submitted snapshot or start identity twice', async () => {
+    const store = storage();
+    await submitVerificationIdentity(input, store.dependencies);
+    const saved = structuredClone(store.saved);
+    await expect(submitVerificationIdentity({ ...input, firstName: 'Other' }, store.dependencies)).rejects.toThrow('already been submitted');
+    expect(store.saved).toEqual(saved);
+    expect(store.starts).toBe(1);
+  });
+  it('only starts one identity check for concurrent submissions', async () => {
+    const store = storage();
+    const results = await Promise.allSettled([
+      submitVerificationIdentity(input, store.dependencies), submitVerificationIdentity(input, store.dependencies),
+    ]);
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(store.starts).toBe(1);
+  });
+  it('preserves signed details when the provider fails, for the restart flow', async () => {
+    const store = storage(); store.failStart = true;
+    await expect(submitVerificationIdentity(input, store.dependencies)).rejects.toThrow('unavailable');
+    expect(store.saved?.countrySpecific?.siret).toBe('30326504500011');
+    await expect(submitVerificationIdentity(input, store.dependencies)).rejects.toThrow('already been submitted');
+  });
+  it('does not require French data for other countries or send-only requests', async () => {
+    const store = storage();
+    await submitVerificationIdentity({ ...input, company: { country: 'NL', enterpriseNumber: null, isSmpRecipient: true },
+      mandateRequired: false, mandateAccepted: false, countrySpecific: null }, store.dependencies);
+    expect(store.saved?.countrySpecific).toBeNull();
+    expect(store.saved?.mandateAcceptedAt).toBeNull();
+    const sendOnly = storage();
+    await submitVerificationIdentity({ ...input, company: { ...input.company, isSmpRecipient: false }, countrySpecific: null }, sendOnly.dependencies);
+    expect(sendOnly.saved?.countrySpecific).toBeNull();
+  });
+});

--- a/translations/de.csv
+++ b/translations/de.csv
@@ -338,7 +338,11 @@ Flat UBLs (all XMLs in root),Flache UBL-Struktur (alle XML-Dateien im Stammverze
 for assistance.,um Unterstützung zu erhalten.
 For Belgian businesses\, the VAT number will be used to infer the enterprise number.,Bei belgischen Unternehmen wird die Unternehmensnummer aus der Umsatzsteuer-Identifikationsnummer abgeleitet.
 For Dutch businesses\, the VAT number format is NL + 9 digits + B + 2 digits (e.g. NL123456789B01).,Bei niederländischen Unternehmen hat die Umsatzsteuer-Identifikationsnummer das Format NL + 9 Ziffern + B + 2 Ziffern (z. B. NL123456789B01).
-For French businesses\, the enterprise number is the 9 digit SIREN. A SIRET can be added as an extra Peppol identifier.,Bei französischen Unternehmen ist die Unternehmensnummer die neunstellige SIREN-Nummer. Eine SIRET-Nummer kann als zusätzliche Peppol-Kennung hinzugefügt werden.
+For French businesses\, enter the 9 digit SIREN. The establishment SIRET is requested during verification.,Geben Sie für französische Unternehmen die neunstellige SIREN ein. Die SIRET der Betriebsstätte wird bei der Verifizierung abgefragt.
+Establishment SIRET,SIRET der Betriebsstätte
+Establishment SIRET (Optional),SIRET der Betriebsstätte (optional)
+Invalid verification details,Ungültige Verifizierungsdaten
+The 14 digit SIRET identifies the establishment for verification. It does not add a receiving address.,Die 14-stellige SIRET identifiziert die Betriebsstätte für die Verifizierung. Sie fügt keine Empfangsadresse hinzu.
 For Dutch sellers\, the scheme identifier is required to be able to send invoices and credit notes.,Bei niederländischen Verkäufern ist die Schemakennung erforderlich\, um Rechnungen und Gutschriften senden zu können.
 For growing businesses with higher volumes,Für wachsende Unternehmen mit höherem Volumen
 For small businesses sending every month,Für kleine Unternehmen\, die jeden Monat senden

--- a/translations/fr.csv
+++ b/translations/fr.csv
@@ -581,7 +581,11 @@ Fill in the required fields to see a preview.,Renseignez les champs obligatoires
 Flat UBLs (all XMLs in root),UBL non imbriqués (tous les fichiers XML à la racine)
 For Belgian businesses\, the VAT number will be used to infer the enterprise number.,Pour les entreprises belges\, le numéro de TVA servira à déduire le numéro d'entreprise.
 For Dutch businesses\, the VAT number format is NL + 9 digits + B + 2 digits (e.g. NL123456789B01).,Pour les entreprises néerlandaises\, le format du numéro de TVA est NL + 9 chiffres + B + 2 chiffres (p. ex. NL123456789B01).
-For French businesses\, the enterprise number is the 9 digit SIREN. A SIRET can be added as an extra Peppol identifier.,Pour les entreprises françaises\, le numéro d'entreprise est le numéro SIREN à 9 chiffres. Un numéro SIRET peut être ajouté comme identifiant Peppol supplémentaire.
+For French businesses\, enter the 9 digit SIREN. The establishment SIRET is requested during verification.,Pour les entreprises françaises\, saisissez le SIREN à 9 chiffres. Le SIRET de l'établissement sera demandé lors de la vérification.
+Establishment SIRET,SIRET de l'établissement
+Establishment SIRET (Optional),SIRET de l'établissement (facultatif)
+Invalid verification details,Informations de vérification invalides
+The 14 digit SIRET identifies the establishment for verification. It does not add a receiving address.,Le SIRET à 14 chiffres identifie l'établissement pour la vérification. Il n'ajoute pas d'adresse de réception.
 For Dutch sellers\, the scheme identifier is required to be able to send invoices and credit notes.,Pour les vendeurs néerlandais\, l'identifiant de schéma est requis afin de pouvoir envoyer des factures et des avoirs.
 For growing businesses with higher volumes,Pour les entreprises en croissance avec des volumes plus élevés
 For small businesses sending every month,Pour les petites entreprises qui envoient des documents chaque mois

--- a/translations/nl.csv
+++ b/translations/nl.csv
@@ -643,7 +643,11 @@ Fill in the required fields to see a preview.,Vul de verplichte velden in om een
 Flat UBLs (all XMLs in root),Platte UBL's (alle XML-bestanden in de hoofdmap)
 For Belgian businesses\, the VAT number will be used to infer the enterprise number.,Voor Belgische bedrijven wordt het ondernemingsnummer afgeleid uit het btw-nummer.
 For Dutch businesses\, the VAT number format is NL + 9 digits + B + 2 digits (e.g. NL123456789B01).,Voor Nederlandse bedrijven heeft het btw-nummer de notatie NL + 9 cijfers + B + 2 cijfers (bijv. NL123456789B01).
-For French businesses\, the enterprise number is the 9 digit SIREN. A SIRET can be added as an extra Peppol identifier.,Voor Franse bedrijven is het ondernemingsnummer het SIREN-nummer van 9 cijfers. Een SIRET-nummer kan als extra Peppol-identificatie worden toegevoegd.
+For French businesses\, enter the 9 digit SIREN. The establishment SIRET is requested during verification.,Vul voor Franse bedrijven het SIREN-nummer van 9 cijfers in. Het SIRET-nummer van de vestiging wordt tijdens de verificatie gevraagd.
+Establishment SIRET,SIRET van de vestiging
+Establishment SIRET (Optional),SIRET van de vestiging (optioneel)
+Invalid verification details,Ongeldige verificatiegegevens
+The 14 digit SIRET identifies the establishment for verification. It does not add a receiving address.,Het SIRET-nummer van 14 cijfers identificeert de vestiging voor verificatie. Het voegt geen ontvangstadres toe.
 For Dutch sellers\, the scheme identifier is required to be able to send invoices and credit notes.,Voor Nederlandse verkopers is de schema-identificatie verplicht om facturen en creditnota's te kunnen verzenden.
 Full Peppol participation: send documents and receive them from your network.,Volledige deelname aan Peppol: verzend documenten en ontvang ze vanuit je netwerk.
 Generates a PDF of the document and embeds it as an attachment.,Genereert een pdf van het document en voegt deze als bijlage toe.

--- a/types/verification-country-specific.ts
+++ b/types/verification-country-specific.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { isSiren, isSiret } from '@peppol/utils/identifier-validation';
+import { UserFacingError } from '@directory/utils/util';
+
+export const verificationCountrySpecificSchema = z.object({
+  country: z.literal('FR'),
+  siret: z.string().transform(value => value.replace(/[\s.-]/g, ''))
+    .refine(isSiret, 'SIRET must be a valid 14 digit establishment number'),
+}).strict();
+
+export type VerificationCountrySpecific = z.infer<typeof verificationCountrySpecificSchema>;
+export type VerificationCountryRequirements = { country: 'FR'; required: boolean } | null;
+
+export function getVerificationCountryRequirements(
+  country: string,
+  mandateRequired: boolean,
+  isSmpRecipient: boolean,
+): VerificationCountryRequirements {
+  return country === 'FR' && mandateRequired ? { country: 'FR', required: isSmpRecipient } : null;
+}
+
+export function validateVerificationCountrySpecific(
+  company: { country: string; enterpriseNumber: string | null },
+  input: unknown,
+  required = false,
+): VerificationCountrySpecific | null {
+  if (input == null) {
+    if (required) throw new UserFacingError('An establishment SIRET is required for this verification.');
+    return null;
+  }
+  const parsed = verificationCountrySpecificSchema.safeParse(input);
+  if (!parsed.success) throw new UserFacingError(parsed.error.issues[0]?.message ?? 'Invalid country-specific verification data');
+  const data = parsed.data;
+  if (data.country !== company.country) throw new UserFacingError('Verification country must match the company country');
+  const enterprise = company.enterpriseNumber?.replace(/[\s.-]/g, '') ?? '';
+  if ((!isSiren(enterprise) && !isSiret(enterprise)) || data.siret.slice(0, 9) !== enterprise.slice(0, 9) ||
+    (enterprise.length === 14 && data.siret !== enterprise)) {
+    throw new UserFacingError('The establishment SIRET must match the company enterprise number');
+  }
+  return data;
+}


### PR DESCRIPTION
## Summary

- Capture typed country-specific establishment data in the verification flow without changing the company model or company API.
- Require an explicit SIRET for French receiving mandates; remove the assumed establishment fallback.
- Preserve submitted details before starting identity verification and guard retries against conflicting data.
- Support reviewed establishment supplements for existing verification sessions and use synthetic onboarding test identifiers.

## Validation

- 83 targeted package tests passed.
- TypeScript check passed.
- Diff whitespace checks passed.

## Deployment

Adds a nullable country_specific JSONB column to company_verification_log. No existing records are backfilled. Existing sessions without the required establishment data require manual review; send-only requests retain their support follow-up path.