### PR TITLE
Protect finalized verification sessions from late callbacks

### DIFF
--- a/api/internal/didit-webhook.ts
+++ b/api/internal/didit-webhook.ts
@@ -7,7 +7,8 @@ import { eq } from "drizzle-orm";
 import { db } from "@recommand/db";
 import { companyVerificationLog } from "@peppol/db/schema";
 import { UserFacingError } from "@directory/utils/util";
-import { finalizeCompanyVerification, getCompanyVerificationLog } from "@peppol/data/company-verification";
+import { finalizeCompanyVerification, getCompanyVerificationLog, isFinalVerificationStatus } from "@peppol/data/company-verification";
+import { withVerificationLock, VerificationBusyError } from "@peppol/data/verification-lock";
 import { requiresArratechKycReview } from "@peppol/data/at/kyc";
 import { startArratechKycReview } from "@peppol/data/at/kyc-review";
 import { getCompanyById } from "@peppol/data/companies";
@@ -82,9 +83,13 @@ server.post(
         return c.json(actionSuccess({ message: "Webhook type not processed" }), 200);
       }
 
+      return await withVerificationLock(vendor_data, async () => {
       const companyVerificationLogRecord = await getCompanyVerificationLog(vendor_data);
       if (!companyVerificationLogRecord) {
         return c.json(actionFailure("Company verification log not found"), 404);
+      }
+      if (isFinalVerificationStatus(companyVerificationLogRecord.status)) {
+        return c.json(actionSuccess({ message: "Verification status not changed (already finalized)" }), 200);
       }
 
       const verificationProofReference = session_id;
@@ -161,7 +166,11 @@ server.post(
       }
 
       return c.json(actionSuccess({ message: result.status === "error" ? "Verification completed with activation error" : "Verification status updated" }), 200);
+      });
     } catch (error) {
+      if (error instanceof VerificationBusyError) {
+        return c.json(actionFailure(error.message), 503);
+      }
       console.error("Error processing Didit webhook:", error);
       if (error instanceof UserFacingError) {
         return c.json(actionFailure(error), 400);

--- a/data/at/kyc-onboarding.ts
+++ b/data/at/kyc-onboarding.ts
@@ -32,26 +32,8 @@ import type { ArratechOnboarding } from '@peppol/data/at/kyc-onboarding-state';
 import { validateVerificationCountrySpecific } from '@peppol/types/verification-country-specific';
 import { getParticipantByIdentifier, upsertCompanyRegistrations } from '@peppol/data/at/smp';
 
-export class VerificationBusyError extends KycOnboardingError {
-  constructor() {
-    super('Verification is already being processed; retry shortly.', true);
-  }
-}
-
-export async function withArratechVerificationLock<T>(
-  id: string,
-  action: () => Promise<T>,
-): Promise<T> {
-  return db.transaction(async (tx) => {
-    const result = await tx.execute(
-      sql`select pg_try_advisory_xact_lock(hashtextextended(${`arratech-kyc:${id}`}, 0)) as acquired`,
-    );
-    if (!result.rows[0]?.acquired) {
-      throw new VerificationBusyError();
-    }
-    return action();
-  });
-}
+import { withVerificationLock } from '@peppol/data/verification-lock';
+export { VerificationBusyError, withVerificationLock as withArratechVerificationLock } from '@peppol/data/verification-lock';
 
 function request(path: string, options: RequestInit) {
   return fetchArratech(path, {
@@ -157,7 +139,7 @@ async function notifySendOnlySupport(id: string, company: Company, state: Arrate
 }
 
 export async function processArratechOnboarding(id: string): Promise<void> {
-  await withArratechVerificationLock(id, async () => {
+  await withVerificationLock(id, async () => {
     const log = await getCompanyVerificationLog(id);
     if (!log?.arratechOnboarding) return;
     const state = log.arratechOnboarding;

--- a/data/company-verification.ts
+++ b/data/company-verification.ts
@@ -12,7 +12,7 @@ import { shouldRegisterWithSmp } from "@peppol/utils/playground";
 import { unregisterCompanyRegistrations, upsertCompanyRegistrations } from "./smp-providers";
 import { publishCompanyVerificationEvent } from "./company-verification-webhooks";
 import type { VerificationCountrySpecific } from '@peppol/types/verification-country-specific';
-import { submitVerificationIdentity } from '@peppol/data/verification-submission';
+import { submitVerificationIdentity, restartVerificationIdentity } from '@peppol/data/verification-submission';
 
 export type CompanyVerificationLog = typeof companyVerificationLog.$inferSelect;
 export type CompanyVerificationStatus = CompanyVerificationLog["status"];
@@ -384,19 +384,19 @@ export async function requestIdVerification(
     throw new UserFacingError("Verification is not in a state that allows identity verification.");
   }
 
-  const verificationUrl = await createIdVerificationUrl(companyVerificationLogId, company, {
-    firstName: log.firstName,
-    lastName: log.lastName,
+  return restartVerificationIdentity({
+    startIdentityVerification: () => createIdVerificationUrl(companyVerificationLogId, company, {
+      firstName: log.firstName,
+      lastName: log.lastName,
+    }),
+    confirmStillPending: async () => {
+      const rows = await db.update(companyVerificationLog)
+        .set({ status: 'idVerificationRequested' })
+        .where(and(eq(companyVerificationLog.id, companyVerificationLogId), eq(companyVerificationLog.status, 'idVerificationRequested')))
+        .returning({ id: companyVerificationLog.id });
+      return rows.length === 1;
+    },
   });
-
-  await db
-    .update(companyVerificationLog)
-    .set({ status: "idVerificationRequested" })
-    .where(eq(companyVerificationLog.id, companyVerificationLogId))
-    .returning()
-    .then((rows) => rows[0]);
-  
-  return verificationUrl;
 }
 
 async function createIdVerificationUrl(

--- a/data/verification-lock.ts
+++ b/data/verification-lock.ts
@@ -1,0 +1,20 @@
+import { db } from '@recommand/db';
+import { sql } from 'drizzle-orm';
+
+export class VerificationBusyError extends Error {
+  constructor() {
+    super('Verification is already being processed; retry shortly.');
+    this.name = 'VerificationBusyError';
+  }
+}
+
+export async function withVerificationLock<T>(id: string, action: () => Promise<T>): Promise<T> {
+  return db.transaction(async tx => {
+    // Preserve the lock key used by existing workers and rolling deployments.
+    const result = await tx.execute(
+      sql`select pg_try_advisory_xact_lock(hashtextextended(${`arratech-kyc:${id}`}, 0)) as acquired`,
+    );
+    if (!result.rows[0]?.acquired) throw new VerificationBusyError();
+    return action();
+  });
+}

--- a/data/verification-submission.ts
+++ b/data/verification-submission.ts
@@ -8,6 +8,17 @@ export type VerificationSubmission = {
   countrySpecific: VerificationCountrySpecific | null;
 };
 
+export async function restartVerificationIdentity(dependencies: {
+  startIdentityVerification: () => Promise<string>;
+  confirmStillPending: () => Promise<boolean>;
+}): Promise<string> {
+  const url = await dependencies.startIdentityVerification();
+  if (!await dependencies.confirmStillPending()) {
+    throw new UserFacingError('This verification changed while restarting. Please use the latest verification request.');
+  }
+  return url;
+}
+
 export async function submitVerificationIdentity(input: {
   company: { country: string; enterpriseNumber: string | null; isSmpRecipient: boolean };
   firstName: string;

--- a/test/verification-restart.test.ts
+++ b/test/verification-restart.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+import { restartVerificationIdentity } from '../data/verification-submission';
+
+describe('identity verification restart', () => {
+  it('returns a provider link only after confirming the session is still pending', async () => {
+    const events: string[] = [];
+    expect(await restartVerificationIdentity({
+      startIdentityVerification: async () => {events.push('start'); return 'https://example.com/verify';},
+      confirmStillPending: async () => {events.push('confirm'); return true;},
+    })).toBe('https://example.com/verify');
+    expect(events).toEqual(['start','confirm']);
+  });
+  it('rejects a stale link when the session was closed while the provider was responding', async () => {
+    await expect(restartVerificationIdentity({
+      startIdentityVerification: async () => 'https://example.com/stale',
+      confirmStillPending: async () => false,
+    })).rejects.toThrow('Please use the latest verification request');
+  });
+  it('does not confirm or change state when the provider fails', async () => {
+    let confirmed = false;
+    await expect(restartVerificationIdentity({
+      startIdentityVerification: async () => {throw new Error('Provider unavailable');},
+      confirmStillPending: async () => {confirmed = true; return true;},
+    })).rejects.toThrow('Provider unavailable');
+    expect(confirmed).toBe(false);
+  });
+});

--- a/test/webhooks/didit-final-session.test.ts
+++ b/test/webhooks/didit-final-session.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import { Hono } from 'hono';
+
+let status = 'rejected';
+let locked = false;
+let lockFails = false;
+let requiresKyc = true;
+class BusyError extends Error {}
+const events: string[] = [];
+const secret = crypto.randomUUID();
+mock.module('@recommand/lib/api', () => ({ Server: Hono }));
+mock.module('@recommand/lib/utils', () => ({ actionSuccess: (value: unknown) => value, actionFailure: (value: unknown) => ({error: String(value)}) }));
+mock.module('@directory/utils/util', () => ({ UserFacingError: class extends Error {} }));
+mock.module('@peppol/db/schema', () => ({companyVerificationLog: {id:'id'}}));
+mock.module('@recommand/db', () => ({db: {update: () => { events.push('update'); return {set: () => ({where: async () => {}})}; }}}));
+mock.module('@peppol/data/company-verification', () => ({
+  getCompanyVerificationLog: async () => { expect(locked).toBe(true); return {id:'session', status, companyId:'company', firstName:'Example', lastName:'Signer'}; },
+  isFinalVerificationStatus: (value: string) => ['verified','rejected','error'].includes(value),
+  finalizeCompanyVerification: async (input: {status: string}) => {events.push(`finalize:${input.status}`); return {status:input.status};},
+}));
+mock.module('@peppol/data/verification-lock', () => ({ VerificationBusyError: BusyError, withVerificationLock: async (_id: string, action: () => Promise<unknown>) => {
+  if (lockFails) throw new BusyError('busy');
+  locked = true; try {return await action();} finally {locked = false;}
+}}));
+mock.module('@peppol/data/at/kyc', () => ({requiresArratechKycReview: async () => requiresKyc}));
+mock.module('@peppol/data/at/kyc-review', () => ({startArratechKycReview: async () => { events.push('kyc'); return {status:'inReview'}; }}));
+mock.module('@peppol/data/companies', () => ({getCompanyById: async () => { events.push('company'); return {id:'company',teamId:'team',name:'Example'}; }}));
+mock.module('@peppol/data/send-manual-verification-email', () => ({
+  sendManualVerificationEmail: async () => {events.push('email');},
+  sendManualVerificationDeclinedEmail: async () => {events.push('email');},
+}));
+const {default: server} = await import('../../api/internal/didit-webhook');
+beforeEach(() => {status = 'rejected'; locked = false; lockFails = false; requiresKyc = true; events.length = 0;});
+async function send(providerStatus: string, manual = false) {
+  const body = JSON.stringify({session_id:'identity-session',vendor_data:'session',webhook_type:'status.updated',status:providerStatus,
+    decision: {id_verification:{first_name:'Example',last_name:'Signer'}, ...(manual ? {reviews:[{new_status:providerStatus}]} : {})}});
+  const previous = process.env.DIDIT_WEBHOOK_SECRET_KEY;
+  process.env.DIDIT_WEBHOOK_SECRET_KEY = secret;
+  try {
+    return await server.request('/didit', {method:'POST',body,headers:{
+      'X-Timestamp': String(Math.floor(Date.now()/1000)), 'X-Signature':createHmac('sha256',secret).update(body).digest('hex'),
+    }});
+  } finally {
+    if (previous === undefined) delete process.env.DIDIT_WEBHOOK_SECRET_KEY;
+    else process.env.DIDIT_WEBHOOK_SECRET_KEY = previous;
+  }
+}
+describe('late identity callbacks', () => {
+  it('does not reopen finalized sessions or send notifications, including manual decisions', async () => {
+    for (const final of ['rejected','verified','error']) {
+      status = final;
+      for (const provider of ['In Review','Approved','Declined']) {
+        for (const manual of [false,true]) expect((await send(provider,manual)).status).toBe(200);
+      }
+    }
+    expect(events).toEqual([]);
+  });
+  it('retains ordinary review and approved onboarding for non-final sessions', async () => {
+    status = 'idVerificationRequested';
+    expect((await send('In Review')).status).toBe(200);
+    expect(events).toEqual(['update']); events.length = 0;
+    expect((await send('Approved')).status).toBe(200);
+    expect(events).toEqual(['company','kyc']);
+  });
+  it('does no work while a restart owns the session lock', async () => {
+    lockFails = true;
+    expect((await send('Approved')).status).toBe(503);
+    expect(events).toEqual([]);
+  });
+  it('preserves ordinary approvals and rejections outside the Arratech flow', async () => {
+    requiresKyc = false;
+    status = 'idVerificationRequested';
+    expect((await send('Approved')).status).toBe(200);
+    expect(events).toEqual(['company','finalize:verified']);
+    events.length = 0;
+    expect((await send('Declined')).status).toBe(200);
+    expect(events).toEqual(['company','finalize:rejected']);
+  });
+  it('preserves manual decision notifications for open non-Arratech sessions', async () => {
+    requiresKyc = false;
+    status = 'inReview';
+    for (const [decision, result] of [['Approved','verified'],['Declined','rejected']]) {
+      events.length = 0;
+      expect((await send(decision!,true)).status).toBe(200);
+      expect(events).toEqual(['company',`finalize:${result}`,'email']);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Coordinate identity callbacks through a shared verification lock, retaining the existing lock key for rolling-deployment compatibility.
- Ignore late callbacks for finalized sessions before state changes or notifications.
- Return a retryable HTTP response when a session is busy.
- Reject stale identity-restart links when the verification state changes during the provider request.
- Keep existing provider-module exports compatible for downstream consumers.

## Validation

- 33 targeted tests passed, including ordinary approvals/rejections, manual decisions, finalized callbacks, restart races and provider onboarding.
- TypeScript and diff whitespace checks passed.

## Deployment

No migration or configuration changes. Country-specific identity requirements and API payloads are unchanged. Finalized sessions are not reopened by identity-provider callbacks.