### PR TITLE
Clarify the identifier scheme for French SIREN numbers

### DIFF
--- a/components/company-form-fields.tsx
+++ b/components/company-form-fields.tsx
@@ -149,7 +149,7 @@ export function CompanyIdentityFields({
                             className="flex-1"
                         />
                     </div>
-                    {country === "FR" && <p className="text-xs text-pretty text-muted-foreground">{t`For French businesses, enter the 9 digit SIREN. The establishment SIRET is requested during verification.`}</p>}
+                    {country === "FR" && <p className="text-xs text-pretty text-muted-foreground">{t`For French businesses, select scheme 0002 and enter the 9 digit SIREN. The establishment SIRET is requested during verification.`}</p>}
                     {showDutchEnterpriseNumberSchemeAlert && country === "NL" && enterpriseNumberScheme !== "0106" && enterpriseNumberScheme !== "0190" && enterpriseNumber.trim() && (
                         <StatusMessage
                             tone="warning"

--- a/translations/de.csv
+++ b/translations/de.csv
@@ -338,7 +338,7 @@ Flat UBLs (all XMLs in root),Flache UBL-Struktur (alle XML-Dateien im Stammverze
 for assistance.,um Unterstützung zu erhalten.
 For Belgian businesses\, the VAT number will be used to infer the enterprise number.,Bei belgischen Unternehmen wird die Unternehmensnummer aus der Umsatzsteuer-Identifikationsnummer abgeleitet.
 For Dutch businesses\, the VAT number format is NL + 9 digits + B + 2 digits (e.g. NL123456789B01).,Bei niederländischen Unternehmen hat die Umsatzsteuer-Identifikationsnummer das Format NL + 9 Ziffern + B + 2 Ziffern (z. B. NL123456789B01).
-For French businesses\, enter the 9 digit SIREN. The establishment SIRET is requested during verification.,Geben Sie für französische Unternehmen die neunstellige SIREN ein. Die SIRET der Betriebsstätte wird bei der Verifizierung abgefragt.
+For French businesses\, select scheme 0002 and enter the 9 digit SIREN. The establishment SIRET is requested during verification.,Wählen Sie für französische Unternehmen das Schema 0002 und geben Sie die neunstellige SIREN ein. Die SIRET der Betriebsstätte wird bei der Verifizierung abgefragt.
 Establishment SIRET,SIRET der Betriebsstätte
 Establishment SIRET (Optional),SIRET der Betriebsstätte (optional)
 Invalid verification details,Ungültige Verifizierungsdaten

--- a/translations/fr.csv
+++ b/translations/fr.csv
@@ -581,7 +581,7 @@ Fill in the required fields to see a preview.,Renseignez les champs obligatoires
 Flat UBLs (all XMLs in root),UBL non imbriqués (tous les fichiers XML à la racine)
 For Belgian businesses\, the VAT number will be used to infer the enterprise number.,Pour les entreprises belges\, le numéro de TVA servira à déduire le numéro d'entreprise.
 For Dutch businesses\, the VAT number format is NL + 9 digits + B + 2 digits (e.g. NL123456789B01).,Pour les entreprises néerlandaises\, le format du numéro de TVA est NL + 9 chiffres + B + 2 chiffres (p. ex. NL123456789B01).
-For French businesses\, enter the 9 digit SIREN. The establishment SIRET is requested during verification.,Pour les entreprises françaises\, saisissez le SIREN à 9 chiffres. Le SIRET de l'établissement sera demandé lors de la vérification.
+For French businesses\, select scheme 0002 and enter the 9 digit SIREN. The establishment SIRET is requested during verification.,Pour les entreprises françaises\, sélectionnez le schéma 0002 et saisissez le SIREN à 9 chiffres. Le SIRET de l'établissement sera demandé lors de la vérification.
 Establishment SIRET,SIRET de l'établissement
 Establishment SIRET (Optional),SIRET de l'établissement (facultatif)
 Invalid verification details,Informations de vérification invalides

--- a/translations/nl.csv
+++ b/translations/nl.csv
@@ -643,7 +643,7 @@ Fill in the required fields to see a preview.,Vul de verplichte velden in om een
 Flat UBLs (all XMLs in root),Platte UBL's (alle XML-bestanden in de hoofdmap)
 For Belgian businesses\, the VAT number will be used to infer the enterprise number.,Voor Belgische bedrijven wordt het ondernemingsnummer afgeleid uit het btw-nummer.
 For Dutch businesses\, the VAT number format is NL + 9 digits + B + 2 digits (e.g. NL123456789B01).,Voor Nederlandse bedrijven heeft het btw-nummer de notatie NL + 9 cijfers + B + 2 cijfers (bijv. NL123456789B01).
-For French businesses\, enter the 9 digit SIREN. The establishment SIRET is requested during verification.,Vul voor Franse bedrijven het SIREN-nummer van 9 cijfers in. Het SIRET-nummer van de vestiging wordt tijdens de verificatie gevraagd.
+For French businesses\, select scheme 0002 and enter the 9 digit SIREN. The establishment SIRET is requested during verification.,Kies voor Franse bedrijven schema 0002 en vul het SIREN-nummer van 9 cijfers in. Het SIRET-nummer van de vestiging wordt tijdens de verificatie gevraagd.
 Establishment SIRET,SIRET van de vestiging
 Establishment SIRET (Optional),SIRET van de vestiging (optioneel)
 Invalid verification details,Ongeldige verificatiegegevens


### PR DESCRIPTION
The company form now tells French businesses to select identifier scheme 0002 when entering their nine-digit SIREN. The Dutch, French and German translations include the same instruction; the SIRET remains requested during verification.

Validation: `bun run test:unit` passed with access to the XML validation service. No runtime logic or schema changes.
