### PR TITLE
Drop the deprecated baseUrl compiler option

### DIFF
--- a/app/(dashboard)/billing/subscription/page.tsx
+++ b/app/(dashboard)/billing/subscription/page.tsx
@@ -1,6 +1,6 @@
 import { PageTemplate } from "@core/components/page-template";
 import { rc } from "@recommand/lib/client";
-import type { Subscription } from "api/subscription";
+import type { Subscription } from "@peppol/api/subscription";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@core/components/ui/button";
 import {

--- a/components/plans-grid.tsx
+++ b/components/plans-grid.tsx
@@ -15,7 +15,7 @@ import { availablePlans, type Plan } from "@peppol/data/plans";
 import type { Subscription as SubscriptionType } from "@peppol/data/subscriptions";
 import { toast } from "@core/components/ui/sonner";
 import { rc } from "@recommand/lib/client";
-import type { Subscription } from "api/subscription";
+import type { Subscription } from "@peppol/api/subscription";
 import { stringifyActionFailure } from "@recommand/lib/utils";
 import { Check } from "lucide-react";
 import { cn } from "@core/lib/utils";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,12 +24,11 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false,
 
-    "baseUrl": ".",
     "paths": {
       "@recommand": ["../framework/index.ts"],
       "@recommand/*": ["../framework/*"],
       "@core/*": ["../core/*"],
-      "@peppol/*": ["*"],
+      "@peppol/*": ["./*"],
       "@directory/*": ["../directory/*"],
     }
   }


### PR DESCRIPTION
TypeScript 6.0 deprecates the baseUrl compiler option and 7.0 removes it,
so editors running a current TypeScript flag this tsconfig on every open.

Drop baseUrl. Since TypeScript 4.1, paths resolves relative to the tsconfig
file when baseUrl is absent, so the alias mappings keep working unchanged.

A handful of imports used bare specifiers such as api/... that only resolved
because baseUrl pointed at the package root. Rewrite them to the package
alias every neighbouring import already uses.