### PR TITLE
Keep document deletion idempotent

### DIFF
--- a/api/documents/delete-document.ts
+++ b/api/documents/delete-document.ts
@@ -19,12 +19,11 @@ const server = new Server();
 
 const deleteTransmittedDocumentRouteDescription = describeRoute({
     operationId: "deleteDocument",
-    description: "Permanently delete a document and everything stored with it: its XML, its attachments and its original payload. This cannot be undone, and the document disappears from the list, inbox and export endpoints. Deleting a document does not withdraw anything from the Peppol network; a document that was transmitted has already reached its recipient. An ID that does not exist, or that belongs to another team, returns 404.",
+    description: "Permanently delete a document and everything stored with it: its XML, its attachments and its original payload. This cannot be undone, and the document disappears from the list, inbox and export endpoints. Deleting a document does not withdraw anything from the Peppol network; a document that was transmitted has already reached its recipient. Deleting an ID that does not exist, or that was deleted before, also succeeds, so a retried delete is safe.",
     summary: "Delete Document",
     tags: ["Documents"],
     responses: {
         ...describeSuccessResponse("Successfully deleted the document"),
-        ...describeErrorResponse(404, "Document not found"),
         ...describeErrorResponse(500, "Failed to delete document"),
     },
 });

--- a/data/transmitted-documents.ts
+++ b/data/transmitted-documents.ts
@@ -330,9 +330,8 @@ export async function deleteTransmittedDocument(
     .select(offloadedDocumentSelect)
     .from(transmittedDocuments)
     .where(and(eq(transmittedDocuments.id, documentId), eq(transmittedDocuments.teamId, teamId)));
-  if (docs.length === 0) {
-    throw new Error("Document not found");
-  }
+  // A delete of an id that no longer exists is answered like the first one:
+  // the outcome the caller asked for holds, and a retried delete stays safe.
 
   // Offloaded S3 objects are removed by the background deletion worker;
   // enqueueing in the same transaction as the delete means they can never be


### PR DESCRIPTION
A delete of an id that does not exist went back to answering 404, which turned a retried delete into a failure for clients that treat every non-2xx response as an error. Deleting is idempotent again: the second delete succeeds like the first, and the reference says so.