### PR TITLE
Record provider-reported send failures and send under 0225:SIREN through the French access point

### DIFF
--- a/api/documents/get-document.ts
+++ b/api/documents/get-document.ts
@@ -17,6 +17,7 @@ import {
 import { requireIntegrationSupportedTeamAccess, type CompanyAccessContext } from "@peppol/utils/auth-middleware";
 import { transmittedDocumentResponse } from "./shared";
 import { withFrenchReportingStatus } from "@peppol/data/fr-reporting-submissions";
+import { withDeliveryFailure } from "@peppol/data/delivery-failures";
 
 const server = new Server();
 
@@ -78,7 +79,7 @@ async function _getTransmittedDocumentImplementation(c: GetTransmittedDocumentCo
           }
         }
 
-        const [apiDocument] = await withFrenchReportingStatus([await toApiTransmittedDocument(document)]);
+        const [apiDocument] = await withDeliveryFailure(await withFrenchReportingStatus([await toApiTransmittedDocument(document)]));
         return c.json(actionSuccess({ document: apiDocument! }));
       } catch (error) {
         return c.json(actionFailure("Failed to fetch document"), 500);

--- a/api/documents/list-documents.ts
+++ b/api/documents/list-documents.ts
@@ -16,6 +16,7 @@ import { supportedDocumentTypeEnum } from "@peppol/db/schema";
 import { requireIntegrationSupportedTeamAccess, type CompanyAccessContext } from "@peppol/utils/auth-middleware";
 import { transmittedDocumentResponse } from "./shared";
 import { withFrenchReportingStatus } from "@peppol/data/fr-reporting-submissions";
+import { withDeliveryFailure } from "@peppol/data/delivery-failures";
 
 const server = new Server();
 
@@ -153,7 +154,7 @@ async function _getTransmittedDocumentsImplementation(c: GetTransmittedDocuments
 
     return c.json(
       actionSuccess({
-        documents: await withFrenchReportingStatus(documents),
+        documents: await withDeliveryFailure(await withFrenchReportingStatus(documents)),
         pagination: {
           total,
           page,

--- a/api/documents/shared.ts
+++ b/api/documents/shared.ts
@@ -29,6 +29,27 @@ export const frenchReportingStatusResponse = z.object({
     simulated: z.boolean().openapi({ description: "True for playground and test-network reports, which are recorded but never filed." }),
 }).openapi({ ref: "FrenchReportingStatus" });
 
+export const deliveryFailureResponse = z.object({
+    code: z.string().nullable().openapi({
+        description: "The access point's error code for the failure, when it reported one.",
+        example: "TXE-1005",
+    }),
+    message: z.string().nullable().openapi({
+        description: "The access point's description of what went wrong, written for the sender.",
+    }),
+    category: z.string().nullable().openapi({
+        description: "The kind of failure, as classified by the access point, such as a validation error, an unknown recipient or a transport error.",
+        example: "VALIDATION_ERROR",
+    }),
+    transactionStatus: z.string().nullable().openapi({
+        description: "The access point's status of the transaction when it reported the failure.",
+        example: "FAILED",
+    }),
+    reportedAt: z.string().openapi({
+        description: "When the failure was reported.",
+    }),
+});
+
 export const transmittedDocumentResponse = z.object({
     id: z.string().openapi({
         description: "The Recommand document ID. Use it with the other document endpoints.",
@@ -127,5 +148,8 @@ export const transmittedDocumentResponse = z.object({
     }),
     reporting: frenchReportingStatusResponse.nullable().openapi({
         description: "Where a French e-reporting report stands with the tax administration. Null for documents that are not reports.",
+    }),
+    deliveryFailure: deliveryFailureResponse.nullable().openapi({
+        description: "Set when the access point reported that an outgoing document failed validation or delivery after accepting it. The document was then not delivered to the recipient, even though it was sent over Peppol. Null while no failure has been reported, and for incoming documents.",
     }),
 });

--- a/api/generate-document.ts
+++ b/api/generate-document.ts
@@ -126,7 +126,7 @@ async function generateImplementation(c: GenerateContext) {
     const team = c.var.team;
     const isPlayground = team.isPlayground ?? false;
     const useTestNetwork = team.useTestNetwork ?? false;
-    const senderIdentifier = await getSendingCompanyIdentifier(company.id);
+    const senderIdentifier = await getSendingCompanyIdentifier(company);
     const recipientAddress = normalizePeppolAddress(input.recipient);
 
     // The same lookup the send endpoint does, under the same condition, so the

--- a/api/internal/arratech-webhook.ts
+++ b/api/internal/arratech-webhook.ts
@@ -10,12 +10,42 @@ import { UserFacingError } from "@directory/utils/util";
 import { downloadBusinessDocument } from "@peppol/data/at/ap";
 import { getArratechConfig } from "@peppol/data/at/client";
 import { recordProviderSentTransaction } from "@peppol/data/provider-sent";
+import { recordProviderDeliveryFailure } from "@peppol/data/delivery-failures";
 import { receivingPipeline } from "@peppol/utils/pipelines/receiving";
 
 const server = new Server();
 
 const RECEIVED_EVENT_TYPE = "transaction.received";
 const SENT_EVENT_TYPE = "transaction.sent";
+// Reported for an outbound transaction the API accepted that then failed validation
+// or delivery. Neither of the events above is emitted for it, so this one is what
+// tells us a send did not arrive.
+const SEND_FAILED_EVENT_TYPE = "transaction.send_failed";
+
+const PROCESSED_EVENT_TYPES: ReadonlySet<string> = new Set([
+  RECEIVED_EVENT_TYPE,
+  SENT_EVENT_TYPE,
+  SEND_FAILED_EVENT_TYPE,
+]);
+
+// The provider's customer-facing error for a failed transaction. Present on a failure
+// event only when the provider has details, and omitted rather than null otherwise.
+const serviceErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  category: z.string(),
+});
+
+// Every field but the transaction id and its status is omitted from a transaction
+// event when it does not apply, which for a failure can be most of them: a document
+// refused before it was routed has no access point or addressing to report.
+const failedTransactionPayloadSchema = z.object({
+  id: z.string(),
+  transactionStatus: z.string().optional(),
+  apId: z.string().optional(),
+  docInstanceId: z.string().optional(),
+  serviceError: serviceErrorSchema.optional(),
+});
 
 // The access point every company on this provider sends through, and therefore the
 // provider that reported the transactions this webhook queues.
@@ -122,9 +152,56 @@ server.post(
       }
 
       const eventType = parseResult.data.eventType;
-      if (eventType !== RECEIVED_EVENT_TYPE && eventType !== SENT_EVENT_TYPE) {
+      if (!PROCESSED_EVENT_TYPES.has(eventType)) {
         console.log("Ignoring Arratech webhook event type:", eventType);
         return c.json(actionSuccess({ message: "Event type not processed" }), 200);
+      }
+
+      if (eventType === SEND_FAILED_EVENT_TYPE) {
+        const failedResult = failedTransactionPayloadSchema.safeParse(parseResult.data.payload);
+        if (!failedResult.success) {
+          console.error("Invalid failed transaction payload:", failedResult.error);
+          return c.json(actionFailure("Invalid transaction payload: " + failedResult.error.message), 400);
+        }
+        const failed = failedResult.data;
+
+        // A failure event may omit the access point. The signature then decides the
+        // network on its own, which it can only do when exactly one secret matched;
+        // when the access point is reported it has to agree with the signature, as
+        // for every other event.
+        let useTestNetwork: boolean;
+        if (failed.apId !== undefined) {
+          const resolved = resolveUseTestNetwork(failed.apId);
+          if (resolved === null) {
+            console.warn("Ignoring Arratech webhook for unknown access point:", failed.apId);
+            return c.json(actionSuccess({ message: "Unknown access point" }), 200);
+          }
+          if (resolved ? !matchesTestSecret : !matchesProductionSecret) {
+            return c.json(actionFailure("Signature does not match the access point's network"), 401);
+          }
+          useTestNetwork = resolved;
+        } else if (matchesProductionSecret !== matchesTestSecret) {
+          useTestNetwork = matchesTestSecret;
+        } else {
+          console.error(
+            "Cannot tell which network an Arratech failure event without an access point belongs to",
+            "- ARRATECH_WEBHOOK_SECRET and ARRATECH_TEST_WEBHOOK_SECRET must be different values"
+          );
+          return c.json(actionFailure("Ambiguous webhook network"), 400);
+        }
+
+        const outcome = await recordProviderDeliveryFailure({
+          accessPointProvider: ARRATECH_ACCESS_POINT_PROVIDER,
+          apTransactionId: failed.id,
+          useTestNetwork,
+          eventId: parseResult.data.id,
+          eventType,
+          transactionStatus: failed.transactionStatus ?? null,
+          docInstanceId: failed.docInstanceId ?? null,
+          error: failed.serviceError ?? null,
+          payload: (parseResult.data.payload ?? {}) as Record<string, unknown>,
+        });
+        return c.json(actionSuccess({ outcome }), 200);
       }
 
       const transactionPayloadSchema = z.object({

--- a/api/preview-document.ts
+++ b/api/preview-document.ts
@@ -68,9 +68,7 @@ async function _previewDocumentImplementation(c: PreviewDocumentContext) {
       );
     }
 
-    const senderIdentifier = await getSendingCompanyIdentifier(
-      c.var.company.id,
-    );
+    const senderIdentifier = await getSendingCompanyIdentifier(c.var.company);
     const senderAddress = `${senderIdentifier.scheme}:${senderIdentifier.identifier}`;
     let recipientAddress = input.recipient ?? "0000:0000";
     if (!recipientAddress.includes(":")) {

--- a/api/reporting/submit.ts
+++ b/api/reporting/submit.ts
@@ -17,7 +17,7 @@ import {
   submitArratechB2CReport,
   type FrenchReportingSubmissionResult,
 } from "@peppol/data/at/fr-reporting";
-import { getSendingCompanyIdentifier } from "@peppol/data/company-identifiers";
+import { getDefaultCompanyIdentifier } from "@peppol/data/company-identifiers";
 import {
   getReadyFrenchReportingDeclarant,
   isFrenchReportingSimulated,
@@ -287,9 +287,10 @@ async function fileFrenchReport({
     return c.json(actionSuccess({ id: existing.id, duplicate: true }));
   }
 
-  // The report is filed rather than transmitted, so it has no XML and no
-  // recipient. The sending identifier still records which company filed it.
-  const senderIdentifier = await getSendingCompanyIdentifier(company.id);
+  // The report is filed rather than transmitted, so it has no XML, no recipient and
+  // no transport sender. The company's default identifier records which company
+  // filed it.
+  const senderIdentifier = await getDefaultCompanyIdentifier(company.id);
   const transmittedDocument = await recordOutgoingDocument({
     c,
     id: "doc_" + ulid(),

--- a/api/webhooks/create-webhook.ts
+++ b/api/webhooks/create-webhook.ts
@@ -15,7 +15,7 @@ const server = new Server();
 
 const createWebhookRouteDescription = describeRoute({
     operationId: "createWebhook",
-    description: "Register an HTTPS endpoint that Recommand posts events to as they happen, so you do not have to poll the documents endpoints. It receives every peppol event for the team: `document.received`, `document.sent`, `document.label.assigned`, `document.label.unassigned`, `document.reporting_status_changed` and `company.verification`. There is no per-event subscription. Set a `secret` to have every delivery signed, and check that signature before acting on a request. Deliveries are retried for a while on a timeout or a 5xx; any other response is treated as final.",
+    description: "Register an HTTPS endpoint that Recommand posts events to as they happen, so you do not have to poll the documents endpoints. It receives every peppol event for the team: `document.received`, `document.sent`, `document.delivery_failed`, `document.label.assigned`, `document.label.unassigned`, `document.reporting_status_changed` and `company.verification`. There is no per-event subscription. Set a `secret` to have every delivery signed, and check that signature before acting on a request. Deliveries are retried for a while on a timeout or a 5xx; any other response is treated as final.",
     summary: "Create Webhook",
     tags: ["Webhooks"],
     responses: {

--- a/app/(dashboard)/transmitted-documents/[id]/page.tsx
+++ b/app/(dashboard)/transmitted-documents/[id]/page.tsx
@@ -56,7 +56,9 @@ import type { MessageLevelResponse } from "@peppol/utils/parsing/message-level-r
 import { DocumentLabelPicker } from "@peppol/components/document-label-picker";
 import { isReportingDocumentTypeKey } from "@peppol/utils/type-repository/document-types/keys";
 import { FrenchReportingStatusBadge } from "../../../../components/french-reporting-status-badge";
+import { DeliveryFailureBadge } from "../../../../components/delivery-failure-badge";
 import type { FrenchReportingStatusSummary } from "@peppol/data/fr-reporting-submissions";
+import type { DeliveryFailureSummary } from "@peppol/data/delivery-failures";
 import { useTranslation } from "@core/hooks/use-translation";
 import { getDocumentTypeLabel } from "@peppol/lib/client/document-type-labels";
 
@@ -66,6 +68,7 @@ const labelsClient = rc<Labels>("v1");
 type TransmittedDocumentWithLabels = TransmittedDocument & {
   labels?: Label[];
   reporting?: FrenchReportingStatusSummary | null;
+  deliveryFailure?: DeliveryFailureSummary | null;
 };
 
 export default function TransmittedDocumentDetailPage() {
@@ -540,6 +543,7 @@ export default function TransmittedDocumentDetailPage() {
                 isReporting={isReportingDocumentTypeKey(doc.type)}
               />
               <FrenchReportingStatusBadge reporting={doc.reporting} />
+              <DeliveryFailureBadge failure={doc.deliveryFailure} />
               {doc.labels &&
                 doc.labels.map((label) => (
                   <LabelBadge
@@ -551,6 +555,19 @@ export default function TransmittedDocumentDetailPage() {
             </div>
           </CardContent>
         </Card>
+
+        {doc.deliveryFailure && (
+          <Alert variant="destructive">
+            <AlertTitle>{t`Delivery failed`}</AlertTitle>
+            <AlertDescription>
+              <p>{t`The access point accepted this document but reported afterwards that it could not be validated or delivered. It did not reach the recipient.`}</p>
+              {doc.deliveryFailure.message && <p className="mt-1">{doc.deliveryFailure.message}</p>}
+              {doc.deliveryFailure.code && (
+                <p className="mt-1 text-xs">{t`Error code ${doc.deliveryFailure.code}.`}</p>
+              )}
+            </AlertDescription>
+          </Alert>
+        )}
 
         {!hasStructuredData && (
           <Alert className="border-dashed">

--- a/app/(dashboard)/transmitted-documents/page.tsx
+++ b/app/(dashboard)/transmitted-documents/page.tsx
@@ -31,6 +31,7 @@ import { TransmissionStatusIcons } from "@peppol/components/transmission-status-
 import { DocumentTypeCell } from "@peppol/components/document-type-cell";
 import { LabelBadge } from "@directory/components/label-badge";
 import { FrenchReportingStatusBadge } from "../../../components/french-reporting-status-badge";
+import { DeliveryFailureBadge } from "../../../components/delivery-failure-badge";
 import { DocumentLabelPicker } from "@peppol/components/document-label-picker";
 import {
   Popover,
@@ -892,6 +893,7 @@ export default function Page() {
                     emailRecipients={emailRecipients || undefined}
                     isReporting={isReporting}
                   />
+                  <DeliveryFailureBadge failure={document.deliveryFailure} size="sm" />
                 </div>
               </div>
             );
@@ -909,6 +911,7 @@ export default function Page() {
               isReporting={isReporting}
             />
             {isReporting && <FrenchReportingStatusBadge reporting={document.reporting} size="sm" />}
+            <DeliveryFailureBadge failure={document.deliveryFailure} size="sm" />
           </div>
         );
       },

--- a/components/delivery-failure-badge.tsx
+++ b/components/delivery-failure-badge.tsx
@@ -1,0 +1,49 @@
+import { Badge } from "@core/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@core/components/ui/tooltip";
+import { useTranslation } from "@core/hooks/use-translation";
+
+type DeliveryFailureBadgeProps = {
+  failure: {
+    code: string | null;
+    message: string | null;
+    category: string | null;
+  } | null | undefined;
+  size?: "sm" | "md";
+};
+
+/**
+ * Marks an outgoing document the access point accepted and then reported as failed.
+ * The transmission icons next to it still say the document went over Peppol, which
+ * it did; this says it did not arrive.
+ */
+export function DeliveryFailureBadge({ failure, size = "md" }: DeliveryFailureBadgeProps) {
+  const { t } = useTranslation();
+  if (!failure) {
+    return null;
+  }
+
+  const details: string[] = [t`The access point could not deliver this document.`];
+  if (failure.message) {
+    details.push(failure.message);
+  }
+  if (failure.code) {
+    details.push(t`Error code ${failure.code}.`);
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant="destructive" className={size === "sm" ? "text-xs" : undefined}>
+          {t`Delivery failed`}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="max-w-sm space-y-1 text-xs">
+          {details.map((detail) => (
+            <p key={detail}>{detail}</p>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/data/company-identifiers.ts
+++ b/data/company-identifiers.ts
@@ -6,6 +6,8 @@ import { db } from "@recommand/db";
 import { eq, and, asc, ne, or, isNull } from "drizzle-orm";
 import { unregisterCompanyIdentifier, upsertCompanyRegistration } from "./smp-providers";
 import { getTeamExtensionAndCompanyByCompanyId } from "./teams";
+import type { Company } from "./companies";
+import type { AccessPointProviderId } from "./peppol-providers";
 
 export type CompanyIdentifier = typeof companyIdentifiers.$inferSelect;
 export type InsertCompanyIdentifier = typeof companyIdentifiers.$inferInsert;
@@ -68,7 +70,11 @@ export async function getCompanyIdentifierBySchemeAndValue(
     .then((rows) => rows[0]);
 }
 
-export async function getSendingCompanyIdentifier(companyId: string): Promise<CompanyIdentifier> {
+/**
+ * The company's first identifier by scheme: the address a document of the company is
+ * attributed to when nothing about how it travels decides otherwise.
+ */
+export async function getDefaultCompanyIdentifier(companyId: string): Promise<CompanyIdentifier> {
   const identifiers = await db
     .select()
     .from(companyIdentifiers)
@@ -81,6 +87,59 @@ export async function getSendingCompanyIdentifier(companyId: string): Promise<Co
   }
 
   return identifiers[0];
+}
+
+/** The access point that sends for French companies, and requires a particular sender address. */
+const FRENCH_ACCESS_POINT_PROVIDER: AccessPointProviderId = "at-shared-ap-fr";
+
+/**
+ * The address a company sends under: the sender of the transport envelope and the
+ * seller's endpoint in the documents we write for it.
+ *
+ * Through the French access point the sender has to be the company's SIREN under the
+ * French electronic address scheme (0225), whatever other identifiers the company
+ * registered: that is the address the access point recognises the sender by. A
+ * SIRET or a suffixed electronic address under that scheme names an establishment
+ * rather than the company and is not accepted in its place. Every other access point
+ * takes the company's default identifier, as before.
+ */
+export async function getSendingCompanyIdentifier(
+  company: Pick<Company, "id" | "accessPointProvider">
+): Promise<CompanyIdentifier> {
+  if (company.accessPointProvider !== FRENCH_ACCESS_POINT_PROVIDER) {
+    return await getDefaultCompanyIdentifier(company.id);
+  }
+
+  return chooseSendingCompanyIdentifier(company, await getCompanyIdentifiers(company.id));
+}
+
+/**
+ * The choice getSendingCompanyIdentifier makes, given the company's identifiers in
+ * the order getCompanyIdentifiers lists them. Separate so the choice can be asserted
+ * without a database.
+ */
+export function chooseSendingCompanyIdentifier<T extends Pick<CompanyIdentifier, "scheme" | "identifier">>(
+  company: Pick<Company, "accessPointProvider">,
+  identifiers: T[]
+): T {
+  if (identifiers.length === 0) {
+    throw new UserFacingError("No sending company identifier found. Ensure you have added a company identifier to your company.");
+  }
+
+  if (company.accessPointProvider !== FRENCH_ACCESS_POINT_PROVIDER) {
+    return identifiers[0]!;
+  }
+
+  const sirenAddress = identifiers.find(
+    (identifier) => identifier.scheme === "0225" && isSiren(identifier.identifier)
+  );
+  if (!sirenAddress) {
+    throw new UserFacingError(
+      "Sending through the French access point requires a company identifier with scheme 0225 and the company's 9 digit SIREN as identifier (for example 0225:123456789). Add it to your company to send documents."
+    );
+  }
+
+  return sirenAddress;
 }
 
 /**

--- a/data/delivery-failures.ts
+++ b/data/delivery-failures.ts
@@ -1,0 +1,256 @@
+import { writeAuditEvent } from "@core/lib/audit";
+import { publishEvent } from "@core/data/rules/events";
+import type { AccessPointProviderId } from "@peppol/data/peppol-providers";
+import { providerDeliveryFailures, transmittedDocuments } from "@peppol/db/schema";
+import { sendSystemAlert } from "@peppol/utils/system-notifications/telegram";
+import { db } from "@recommand/db";
+import { and, eq, inArray, isNull } from "drizzle-orm";
+
+export type ProviderDeliveryFailure = typeof providerDeliveryFailures.$inferSelect;
+
+/** What the provider said went wrong, as its customer-facing error. */
+export type DeliveryFailureError = {
+  code: string;
+  message: string;
+  category: string;
+};
+
+/** A delivery failure as an access point reported it, before it is stored. */
+export type ReportedDeliveryFailure = {
+  accessPointProvider: AccessPointProviderId;
+  apTransactionId: string;
+  useTestNetwork: boolean;
+  /** The provider's id and name for the webhook event, so a report can be traced back. */
+  eventId: string;
+  eventType: string;
+  transactionStatus: string | null;
+  docInstanceId: string | null;
+  error: DeliveryFailureError | null;
+  /** The event payload as reported. */
+  payload: Record<string, unknown>;
+};
+
+/** The failure as a document's consumers see it. */
+export type DeliveryFailureSummary = {
+  code: string | null;
+  message: string | null;
+  category: string | null;
+  transactionStatus: string | null;
+  reportedAt: string;
+};
+
+export type DeliveryFailureOutcome =
+  /** Attached to its document, which is now marked as failed. */
+  | "attached"
+  /** Stored; no document has been recorded for the transaction yet. */
+  | "pending"
+  /** Already attached: a retry of a report that was handled. */
+  | "known";
+
+/** The document a failure attaches to, as much of it as the failure event needs. */
+export type OutgoingDocumentReference = {
+  id: string;
+  teamId: string;
+  companyId: string;
+  type: string;
+  senderId: string;
+  receiverId: string | null;
+  envelopeId: string | null;
+  apTransactionId: string;
+};
+
+export function toDeliveryFailureSummary(
+  failure: ProviderDeliveryFailure
+): DeliveryFailureSummary {
+  return {
+    code: failure.errorCode,
+    message: failure.errorMessage,
+    category: failure.errorCategory,
+    transactionStatus: failure.transactionStatus,
+    reportedAt: failure.reportedAt.toISOString(),
+  };
+}
+
+async function findOutgoingDocument(
+  apTransactionId: string
+): Promise<OutgoingDocumentReference | undefined> {
+  const [document] = await db
+    .select({
+      id: transmittedDocuments.id,
+      teamId: transmittedDocuments.teamId,
+      companyId: transmittedDocuments.companyId,
+      type: transmittedDocuments.type,
+      senderId: transmittedDocuments.senderId,
+      receiverId: transmittedDocuments.receiverId,
+      envelopeId: transmittedDocuments.envelopeId,
+    })
+    .from(transmittedDocuments)
+    .where(
+      and(
+        eq(transmittedDocuments.apTransactionId, apTransactionId),
+        eq(transmittedDocuments.direction, "outgoing")
+      )
+    )
+    .limit(1);
+  return document ? { ...document, apTransactionId } : undefined;
+}
+
+/**
+ * Attaches the stored failure for the document's transaction to the document, and
+ * tells the document's owner about it. The attach is a conditional update, so of two
+ * callers seeing the same failure and document only one gets to attach it, and only
+ * that one publishes the event: the customer hears about a failure exactly once.
+ * Returns false when there is no failure for the transaction or it was attached
+ * already.
+ */
+async function attachDeliveryFailure(
+  document: OutgoingDocumentReference
+): Promise<boolean> {
+  const attached = await db.transaction(async (tx) => {
+    const [failure] = await tx
+      .update(providerDeliveryFailures)
+      .set({ transmittedDocumentId: document.id, attachedAt: new Date() })
+      .where(
+        and(
+          eq(providerDeliveryFailures.apTransactionId, document.apTransactionId),
+          isNull(providerDeliveryFailures.transmittedDocumentId)
+        )
+      )
+      .returning();
+    if (!failure) {
+      return null;
+    }
+
+    await publishEvent("peppol.document.delivery_failed.v1", {
+      teamId: document.teamId,
+      aggregateType: "peppol.document",
+      aggregateId: document.id,
+      idempotencyKey: `peppol.document.delivery_failed:${document.id}`,
+      payload: {
+        companyId: document.companyId,
+        docType: document.type,
+        senderId: document.senderId,
+        receiverId: document.receiverId,
+        envelopeId: document.envelopeId,
+        errorCode: failure.errorCode,
+        errorMessage: failure.errorMessage,
+        errorCategory: failure.errorCategory,
+        transactionStatus: failure.transactionStatus,
+      },
+      tx,
+    });
+    return failure;
+  });
+  if (!attached) {
+    return false;
+  }
+
+  await writeAuditEvent({
+    action: "update",
+    subsystem: "peppol.documents",
+    objectType: "peppol.document",
+    objectId: document.id,
+    teamId: document.teamId,
+    reasonCode: "delivery_failed",
+    metadata: {
+      apTransactionId: document.apTransactionId,
+      accessPointProvider: attached.accessPointProvider,
+      transactionStatus: attached.transactionStatus,
+      errorCode: attached.errorCode,
+      errorCategory: attached.errorCategory,
+    },
+  });
+  sendSystemAlert(
+    "Document Delivery Failed",
+    `The access point reported that document ${document.id} (transaction ${document.apTransactionId}) failed after it was accepted.\n` +
+      `${attached.errorCode ?? "no code"} ${attached.errorCategory ?? ""}: ${attached.errorMessage ?? "no error details"}`,
+    "warning"
+  );
+  return true;
+}
+
+/**
+ * Stores a failure an access point reported for a transaction it had accepted, and
+ * attaches it to the transaction's document when that document has been recorded.
+ *
+ * The provider retries a report it could not deliver, so the same failure may arrive
+ * more than once: the row is keyed by the transaction and a repeat changes nothing.
+ * The report can also arrive before our own send has recorded its document, in which
+ * case the failure waits here and is attached by recordOutgoingDocument. Nothing is
+ * resent: the document's owner is told and decides what to do.
+ */
+export async function recordProviderDeliveryFailure(
+  failure: ReportedDeliveryFailure
+): Promise<DeliveryFailureOutcome> {
+  await db
+    .insert(providerDeliveryFailures)
+    .values({
+      apTransactionId: failure.apTransactionId,
+      accessPointProvider: failure.accessPointProvider,
+      useTestNetwork: failure.useTestNetwork,
+      eventId: failure.eventId,
+      eventType: failure.eventType,
+      transactionStatus: failure.transactionStatus,
+      errorCode: failure.error?.code ?? null,
+      errorMessage: failure.error?.message ?? null,
+      errorCategory: failure.error?.category ?? null,
+      docInstanceId: failure.docInstanceId,
+      payload: failure.payload,
+    })
+    .onConflictDoNothing();
+
+  // Looked up after the insert, whether or not the insert wrote anything: a document
+  // recorded in between is found here, and a retry of a report whose first delivery
+  // stored the row but failed before attaching it completes the attach now.
+  const document = await findOutgoingDocument(failure.apTransactionId);
+  if (!document) {
+    sendSystemAlert(
+      "Delivery Failure For Unrecorded Transaction",
+      `The access point reported a failed transaction ${failure.apTransactionId} that no outgoing document has been recorded for yet. ` +
+        `It is attached once the document is recorded.\n` +
+        `${failure.error?.code ?? "no code"} ${failure.error?.category ?? ""}: ${failure.error?.message ?? "no error details"}`,
+      "warning"
+    );
+    return "pending";
+  }
+
+  return (await attachDeliveryFailure(document)) ? "attached" : "known";
+}
+
+/**
+ * Attaches to a freshly recorded document the failure its access point reported
+ * before the document existed. Returns whether there was one.
+ */
+export async function attachPendingDeliveryFailure(
+  document: OutgoingDocumentReference
+): Promise<boolean> {
+  return await attachDeliveryFailure(document);
+}
+
+/**
+ * Adds to each document the delivery failure its access point reported, or null when
+ * none was. Incoming documents never have one and are not looked up.
+ */
+export async function withDeliveryFailure<
+  T extends { id: string; direction: "incoming" | "outgoing" },
+>(documents: T[]): Promise<(T & { deliveryFailure: DeliveryFailureSummary | null })[]> {
+  const outgoingIds = documents
+    .filter((document) => document.direction === "outgoing")
+    .map((document) => document.id);
+  const failures = outgoingIds.length
+    ? await db
+        .select()
+        .from(providerDeliveryFailures)
+        .where(inArray(providerDeliveryFailures.transmittedDocumentId, outgoingIds))
+    : [];
+  const byDocument = new Map(
+    failures.map((failure) => [failure.transmittedDocumentId, failure])
+  );
+  return documents.map((document) => {
+    const failure = byDocument.get(document.id);
+    return {
+      ...document,
+      deliveryFailure: failure ? toDeliveryFailureSummary(failure) : null,
+    };
+  });
+}

--- a/data/record-outgoing-document.ts
+++ b/data/record-outgoing-document.ts
@@ -13,6 +13,7 @@ import {
   uploadDocumentOriginalPayload,
   type OriginalPayloadContainerFormat,
 } from "@peppol/data/offload/storage";
+import { attachPendingDeliveryFailure } from "@peppol/data/delivery-failures";
 import { sendOutgoingDocumentNotifications } from "@peppol/data/send-document-notifications";
 import { transferEvents, transmittedDocuments } from "@peppol/db/schema";
 import { isUniqueViolation } from "@peppol/utils/db-errors";
@@ -169,6 +170,32 @@ export async function recordOutgoingDocument(options: {
     });
     if (te.length > 0) {
       await db.insert(transferEvents).values(te);
+    }
+  }
+
+  // The access point may already have reported this transaction as failed, if its
+  // report overtook the send that produced the document. That failure is attached
+  // here so the document is never shown as delivered; nothing above is undone, the
+  // document did leave the platform and its transmission was made.
+  if (facts.apTransactionId) {
+    try {
+      await attachPendingDeliveryFailure({
+        id: transmittedDocument.id,
+        teamId,
+        companyId: company.id,
+        type: document.type,
+        senderId: document.senderId,
+        receiverId: document.receiverId,
+        envelopeId: facts.envelopeId,
+        apTransactionId: facts.apTransactionId,
+      });
+    } catch (error) {
+      console.error("Failed to attach a pending delivery failure:", error);
+      sendSystemAlert(
+        "Delivery Failure Not Attached",
+        `Could not check for a delivery failure reported for transaction ${facts.apTransactionId} of document ${transmittedDocument.id}.`,
+        "error"
+      );
     }
   }
 

--- a/data/transmitted-documents.ts
+++ b/data/transmitted-documents.ts
@@ -4,6 +4,7 @@ import { db } from "@recommand/db";
 import { eq, and, or, sql, desc, isNull, isNotNull, inArray, ilike, gte, lt } from "drizzle-orm";
 import type { Label } from "@directory/data/labels";
 import type { FrenchReportingStatusSummary } from "./fr-reporting-submissions";
+import type { DeliveryFailureSummary } from "./delivery-failures";
 import { removeAttachmentsFromParsedDocument } from "@peppol/utils/parsing/remove-attachments";
 import {
   offloadedDocumentS3Prefixes,
@@ -31,6 +32,8 @@ export type PublicTransmittedDocumentWithLabels = PublicTransmittedDocument & {
   labels?: TransmittedDocumentLabel[];
   /** Present on filed reports once the API has attached where they stand. */
   reporting?: FrenchReportingStatusSummary | null;
+  /** Present once the API has attached the failure the access point reported, if any. */
+  deliveryFailure?: DeliveryFailureSummary | null;
 };
 
 // Internal storage-location fields that must never be exposed to API consumers.
@@ -40,6 +43,7 @@ type InternalStorageField = "xmlLocation" | "attachmentsLocation" | "originalPay
 export type TransmittedDocumentWithoutBody = Omit<PublicTransmittedDocument, "xml" | InternalStorageField> & {
   labels?: TransmittedDocumentLabel[];
   reporting?: FrenchReportingStatusSummary | null;
+  deliveryFailure?: DeliveryFailureSummary | null;
 };
 type InboxTransmittedDocument = Omit<PublicTransmittedDocument, "xml" | InternalStorageField | "parsed"> & {
   labels?: TransmittedDocumentLabel[];

--- a/db/drizzle/20260909101656_provider_delivery_failures.sql
+++ b/db/drizzle/20260909101656_provider_delivery_failures.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "peppol_provider_delivery_failures" (
+	"ap_transaction_id" text PRIMARY KEY NOT NULL,
+	"access_point_provider" "peppol_access_point_provider" NOT NULL,
+	"use_test_network" boolean DEFAULT false NOT NULL,
+	"event_id" text NOT NULL,
+	"event_type" text NOT NULL,
+	"transaction_status" text,
+	"error_code" text,
+	"error_message" text,
+	"error_category" text,
+	"doc_instance_id" text,
+	"payload" jsonb NOT NULL,
+	"transmitted_document_id" text,
+	"reported_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"attached_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "peppol_provider_delivery_failures" ADD CONSTRAINT "peppol_provider_delivery_failures_transmitted_document_id_peppol_transmitted_documents_id_fk" FOREIGN KEY ("transmitted_document_id") REFERENCES "public"."peppol_transmitted_documents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "peppol_provider_delivery_failures_document_idx" ON "peppol_provider_delivery_failures" USING btree ("transmitted_document_id") WHERE "peppol_provider_delivery_failures"."transmitted_document_id" is not null;

--- a/db/drizzle/meta/20260909101656_snapshot.json
+++ b/db/drizzle/meta/20260909101656_snapshot.json
@@ -1,0 +1,3303 @@
+{
+  "id": "9ea7123d-7024-44e6-a1ba-a46bb39d4e82",
+  "prevId": "14ef12c4-1428-452e-bd99-c77240aca379",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activated_integrations": {
+      "name": "activated_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activated_integrations_team_id_idx": {
+          "name": "activated_integrations_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activated_integrations_team_id_teams_id_fk": {
+          "name": "activated_integrations_team_id_teams_id_fk",
+          "tableFrom": "activated_integrations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activated_integrations_company_id_peppol_companies_id_fk": {
+          "name": "activated_integrations_company_id_peppol_companies_id_fk",
+          "tableFrom": "activated_integrations",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_billing_profiles": {
+      "name": "peppol_billing_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mollie_customer_id": {
+          "name": "mollie_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_payment_id": {
+          "name": "first_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_payment_status": {
+          "name": "first_payment_status",
+          "type": "peppol_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "is_mandate_validated": {
+          "name": "is_mandate_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile_standing": {
+          "name": "profile_standing",
+          "type": "peppol_profile_standing",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "grace_started_at": {
+          "name": "grace_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_reason": {
+          "name": "grace_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_peppol_address": {
+          "name": "billing_peppol_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_manually_billed": {
+          "name": "is_manually_billed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "peppol_billing_profiles_team_id_unique": {
+          "name": "peppol_billing_profiles_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_companies": {
+      "name": "peppol_companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enterprise_number_scheme": {
+          "name": "enterprise_number_scheme",
+          "type": "peppol_valid_iso_icd_scheme_identifiers",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_smp_recipient": {
+          "name": "is_smp_recipient",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_point_provider": {
+          "name": "access_point_provider",
+          "type": "peppol_access_point_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-ap1'"
+        },
+        "smp_provider": {
+          "name": "smp_provider",
+          "type": "peppol_smp_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-smp1'"
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_proof_reference": {
+          "name": "verification_proof_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_companies_team_id_teams_id_fk": {
+          "name": "peppol_companies_team_id_teams_id_fk",
+          "tableFrom": "peppol_companies",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_document_types": {
+      "name": "peppol_company_document_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type_id": {
+          "name": "doc_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_document_types_unique": {
+          "name": "peppol_company_document_types_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doc_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "process_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_document_types_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_document_types_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_document_types",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_identifiers": {
+      "name": "peppol_company_identifiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_identifiers_unique": {
+          "name": "peppol_company_identifiers_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"scheme\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"identifier\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_identifiers_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_identifiers_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_identifiers",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_notification_email_addresses": {
+      "name": "peppol_company_notification_email_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notify_incoming": {
+          "name": "notify_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_outgoing": {
+          "name": "notify_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_auto_generated_pdf_incoming": {
+          "name": "include_auto_generated_pdf_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_auto_generated_pdf_outgoing": {
+          "name": "include_auto_generated_pdf_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_document_json_incoming": {
+          "name": "include_document_json_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_document_json_outgoing": {
+          "name": "include_document_json_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_notification_email_addresses_unique": {
+          "name": "peppol_company_notification_email_addresses_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_notification_email_addresses_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_notification_email_addresses_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_notification_email_addresses",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_verification_log": {
+      "name": "company_verification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opened'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_specific": {
+          "name": "country_specific",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_proof_reference": {
+          "name": "verification_proof_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mandate_accepted_at": {
+          "name": "mandate_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arratech_onboarding": {
+          "name": "arratech_onboarding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_verification_log_company_id_peppol_companies_id_fk": {
+          "name": "company_verification_log_company_id_peppol_companies_id_fk",
+          "tableFrom": "company_verification_log",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enterprise_data_cache": {
+      "name": "enterprise_data_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "begin_date": {
+          "name": "begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_code": {
+          "name": "juridical_form_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_description": {
+          "name": "juridical_form_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_begin_date": {
+          "name": "juridical_form_begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_code": {
+          "name": "denomination_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_description": {
+          "name": "denomination_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_begin_date": {
+          "name": "denomination_begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "enterprise_data_cache_unique": {
+          "name": "enterprise_data_cache_unique",
+          "columns": [
+            {
+              "expression": "enterprise_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_fr_reporting_declarants": {
+      "name": "peppol_fr_reporting_declarants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "peppol_fr_reporting_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_name": {
+          "name": "issuer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_regime": {
+          "name": "vat_regime",
+          "type": "peppol_fr_vat_regime",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_exigibility": {
+          "name": "vat_exigibility",
+          "type": "peppol_fr_vat_exigibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "simulated": {
+          "name": "simulated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "peppol_fr_reporting_declarant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partner_snapshot": {
+          "name": "partner_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_fr_reporting_declarants_company_environment_idx": {
+          "name": "peppol_fr_reporting_declarants_company_environment_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_fr_reporting_declarants_due_idx": {
+          "name": "peppol_fr_reporting_declarants_due_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_fr_reporting_declarants_company_id_peppol_companies_id_fk": {
+          "name": "peppol_fr_reporting_declarants_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_fr_reporting_declarants",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_fr_reporting_submissions": {
+      "name": "peppol_fr_reporting_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declarant_id": {
+          "name": "declarant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "peppol_fr_reporting_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_flux": {
+          "name": "sub_flux",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmission_type": {
+          "name": "transmission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulated": {
+          "name": "simulated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ledger_status": {
+          "name": "ledger_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporting_status": {
+          "name": "reporting_status",
+          "type": "peppol_fr_reporting_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_date": {
+          "name": "operation_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_code": {
+          "name": "outcome_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_at": {
+          "name": "outcome_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_attempts": {
+          "name": "check_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_fr_reporting_submissions_flow_id_idx": {
+          "name": "peppol_fr_reporting_submissions_flow_id_idx",
+          "columns": [
+            {
+              "expression": "flow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_fr_reporting_submissions_document_idx": {
+          "name": "peppol_fr_reporting_submissions_document_idx",
+          "columns": [
+            {
+              "expression": "transmitted_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_fr_reporting_submissions_due_idx": {
+          "name": "peppol_fr_reporting_submissions_due_idx",
+          "columns": [
+            {
+              "expression": "next_check_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_fr_reporting_submissions_transmitted_document_id_peppol_transmitted_documents_id_fk": {
+          "name": "peppol_fr_reporting_submissions_transmitted_document_id_peppol_transmitted_documents_id_fk",
+          "tableFrom": "peppol_fr_reporting_submissions",
+          "tableTo": "peppol_transmitted_documents",
+          "columnsFrom": [
+            "transmitted_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_fr_reporting_submissions_declarant_id_peppol_fr_reporting_declarants_id_fk": {
+          "name": "peppol_fr_reporting_submissions_declarant_id_peppol_fr_reporting_declarants_id_fk",
+          "tableFrom": "peppol_fr_reporting_submissions",
+          "tableTo": "peppol_fr_reporting_declarants",
+          "columnsFrom": [
+            "declarant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_task_logs": {
+      "name": "integration_task_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integration_task_logs_integration_id_activated_integrations_id_fk": {
+          "name": "integration_task_logs_integration_id_activated_integrations_id_fk",
+          "tableFrom": "integration_task_logs",
+          "tableTo": "activated_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_outgoing_envelope_claims": {
+      "name": "peppol_outgoing_envelope_claims",
+      "schema": "",
+      "columns": {
+        "instance_identifier": {
+          "name": "instance_identifier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_outgoing_envelope_claims_created_at_idx": {
+          "name": "peppol_outgoing_envelope_claims_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_payment_failure_reminders": {
+      "name": "peppol_payment_failure_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_event_id": {
+          "name": "billing_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_addresses": {
+          "name": "email_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_payment_failure_reminders_billing_event_id_peppol_subscription_billing_events_id_fk": {
+          "name": "peppol_payment_failure_reminders_billing_event_id_peppol_subscription_billing_events_id_fk",
+          "tableFrom": "peppol_payment_failure_reminders",
+          "tableTo": "peppol_subscription_billing_events",
+          "columnsFrom": [
+            "billing_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_s3_deletions": {
+      "name": "pending_s3_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_s3_deletions_claim_idx": {
+          "name": "pending_s3_deletions_claim_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_provider_delivery_failures": {
+      "name": "peppol_provider_delivery_failures",
+      "schema": "",
+      "columns": {
+        "ap_transaction_id": {
+          "name": "ap_transaction_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_point_provider": {
+          "name": "access_point_provider",
+          "type": "peppol_access_point_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_test_network": {
+          "name": "use_test_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_status": {
+          "name": "transaction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_category": {
+          "name": "error_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_instance_id": {
+          "name": "doc_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "peppol_provider_delivery_failures_document_idx": {
+          "name": "peppol_provider_delivery_failures_document_idx",
+          "columns": [
+            {
+              "expression": "transmitted_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"peppol_provider_delivery_failures\".\"transmitted_document_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_provider_delivery_failures_transmitted_document_id_peppol_transmitted_documents_id_fk": {
+          "name": "peppol_provider_delivery_failures_transmitted_document_id_peppol_transmitted_documents_id_fk",
+          "tableFrom": "peppol_provider_delivery_failures",
+          "tableTo": "peppol_transmitted_documents",
+          "columnsFrom": [
+            "transmitted_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscription_billing_event_lines": {
+      "name": "peppol_subscription_billing_event_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_billing_event_id": {
+          "name": "subscription_billing_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_start_date": {
+          "name": "subscription_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_end_date": {
+          "name": "subscription_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_last_billed_at": {
+          "name": "subscription_last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_config": {
+          "name": "billing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included_monthly_documents": {
+          "name": "included_monthly_documents",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_document_overage_price": {
+          "name": "incoming_document_overage_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outgoing_document_overage_price": {
+          "name": "outgoing_document_overage_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty": {
+          "name": "used_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_incoming": {
+          "name": "used_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_outgoing": {
+          "name": "used_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_incoming": {
+          "name": "overage_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_outgoing": {
+          "name": "overage_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_excl": {
+          "name": "total_amount_excl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_subscription_billing_event_lines_subscription_billing_event_id_peppol_subscription_billing_events_id_fk": {
+          "name": "peppol_subscription_billing_event_lines_subscription_billing_event_id_peppol_subscription_billing_events_id_fk",
+          "tableFrom": "peppol_subscription_billing_event_lines",
+          "tableTo": "peppol_subscription_billing_events",
+          "columnsFrom": [
+            "subscription_billing_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscription_billing_events": {
+      "name": "peppol_subscription_billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_profile_id": {
+          "name": "billing_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_date": {
+          "name": "billing_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_start": {
+          "name": "billing_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_end": {
+          "name": "billing_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_excl": {
+          "name": "total_amount_excl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_amount": {
+          "name": "vat_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_category": {
+          "name": "vat_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_percentage": {
+          "name": "vat_percentage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_incl": {
+          "name": "total_amount_incl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty": {
+          "name": "used_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_incoming": {
+          "name": "used_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_outgoing": {
+          "name": "used_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_incoming": {
+          "name": "overage_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_outgoing": {
+          "name": "overage_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_due": {
+          "name": "amount_due",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "peppol_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_reference": {
+          "name": "invoice_reference",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_subscription_billing_events_billing_profile_id_peppol_billing_profiles_id_fk": {
+          "name": "peppol_subscription_billing_events_billing_profile_id_peppol_billing_profiles_id_fk",
+          "tableFrom": "peppol_subscription_billing_events",
+          "tableTo": "peppol_billing_profiles",
+          "columnsFrom": [
+            "billing_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "peppol_subscription_billing_events_invoice_id_unique": {
+          "name": "peppol_subscription_billing_events_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_id"
+          ]
+        },
+        "peppol_subscription_billing_events_invoice_reference_unique": {
+          "name": "peppol_subscription_billing_events_invoice_reference_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_reference"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscriptions": {
+      "name": "peppol_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_config": {
+          "name": "billing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_billed_at": {
+          "name": "last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_team_extensions": {
+      "name": "peppol_team_extensions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_playground": {
+          "name": "is_playground",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_test_network": {
+          "name": "use_test_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_requirements": {
+          "name": "verification_requirements",
+          "type": "verification_requirements",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lax'"
+        },
+        "company_verification_extension_until": {
+          "name": "company_verification_extension_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_email_address": {
+          "name": "support_email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_team_extensions_id_teams_id_fk": {
+          "name": "peppol_team_extensions_id_teams_id_fk",
+          "tableFrom": "peppol_team_extensions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transfer_events": {
+      "name": "peppol_transfer_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "peppol_transfer_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'peppol'"
+        },
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "peppol_transfer_event_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transmitted_document_labels": {
+      "name": "peppol_transmitted_document_labels",
+      "schema": "",
+      "columns": {
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_transmitted_document_labels_transmitted_document_id_peppol_transmitted_documents_id_fk": {
+          "name": "peppol_transmitted_document_labels_transmitted_document_id_peppol_transmitted_documents_id_fk",
+          "tableFrom": "peppol_transmitted_document_labels",
+          "tableTo": "peppol_transmitted_documents",
+          "columnsFrom": [
+            "transmitted_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_transmitted_document_labels_label_id_peppol_labels_id_fk": {
+          "name": "peppol_transmitted_document_labels_label_id_peppol_labels_id_fk",
+          "tableFrom": "peppol_transmitted_document_labels",
+          "tableTo": "peppol_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "peppol_transmitted_document_labels_pkey": {
+          "name": "peppol_transmitted_document_labels_pkey",
+          "columns": [
+            "transmitted_document_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transmitted_documents": {
+      "name": "peppol_transmitted_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "peppol_transfer_event_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_type_id": {
+          "name": "doc_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_c1": {
+          "name": "country_c1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_point_provider": {
+          "name": "access_point_provider",
+          "type": "peppol_access_point_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-ap1'"
+        },
+        "smp_provider": {
+          "name": "smp_provider",
+          "type": "peppol_smp_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-smp1'"
+        },
+        "xml": {
+          "name": "xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_location": {
+          "name": "xml_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'db'"
+        },
+        "attachments_location": {
+          "name": "attachments_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'db'"
+        },
+        "original_payload_location": {
+          "name": "original_payload_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "original_payload_container_format": {
+          "name": "original_payload_container_format",
+          "type": "peppol_original_payload_container_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "s3_key_prefix": {
+          "name": "s3_key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offload_claimed_at": {
+          "name": "offload_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_over_peppol": {
+          "name": "sent_over_peppol",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sent_over_email": {
+          "name": "sent_over_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_recipients": {
+          "name": "email_recipients",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "type": {
+          "name": "type",
+          "type": "peppol_supported_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "parsed": {
+          "name": "parsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation": {
+          "name": "validation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_name": {
+          "name": "receiver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peppol_message_id": {
+          "name": "peppol_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peppol_conversation_id": {
+          "name": "peppol_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_peppol_signal_message": {
+          "name": "received_peppol_signal_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envelope_id": {
+          "name": "envelope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ap_transaction_id": {
+          "name": "ap_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_reference_id": {
+          "name": "external_reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_transmitted_documents_offload_idx": {
+          "name": "peppol_transmitted_documents_offload_idx",
+          "columns": [
+            {
+              "expression": "xml_location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "offload_claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_transmitted_documents_ap_transaction_id_idx": {
+          "name": "peppol_transmitted_documents_ap_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "ap_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"peppol_transmitted_documents\".\"ap_transaction_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_transmitted_documents_external_reference_id_idx": {
+          "name": "peppol_transmitted_documents_external_reference_id_idx",
+          "columns": [
+            {
+              "expression": "external_reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"peppol_transmitted_documents\".\"external_reference_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_transmitted_documents_team_id_teams_id_fk": {
+          "name": "peppol_transmitted_documents_team_id_teams_id_fk",
+          "tableFrom": "peppol_transmitted_documents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_transmitted_documents_company_id_peppol_companies_id_fk": {
+          "name": "peppol_transmitted_documents_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_transmitted_documents",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_webhooks": {
+      "name": "peppol_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_webhooks_team_id_teams_id_fk": {
+          "name": "peppol_webhooks_team_id_teams_id_fk",
+          "tableFrom": "peppol_webhooks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_webhooks_company_id_peppol_companies_id_fk": {
+          "name": "peppol_webhooks_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_webhooks",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.peppol_access_point_provider": {
+      "name": "peppol_access_point_provider",
+      "schema": "public",
+      "values": [
+        "recommand-ap1",
+        "at-shared-ap-fr"
+      ]
+    },
+    "public.peppol_fr_reporting_declarant_state": {
+      "name": "peppol_fr_reporting_declarant_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "registered",
+        "blocked"
+      ]
+    },
+    "public.peppol_fr_reporting_environment": {
+      "name": "peppol_fr_reporting_environment",
+      "schema": "public",
+      "values": [
+        "PROD",
+        "TEST"
+      ]
+    },
+    "public.peppol_fr_reporting_status": {
+      "name": "peppol_fr_reporting_status",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "pending_rectificative",
+        "filed",
+        "filed_rectificative",
+        "superseded",
+        "rejected"
+      ]
+    },
+    "public.peppol_fr_vat_exigibility": {
+      "name": "peppol_fr_vat_exigibility",
+      "schema": "public",
+      "values": [
+        "ENCAISSEMENTS",
+        "DEBITS"
+      ]
+    },
+    "public.peppol_fr_vat_regime": {
+      "name": "peppol_fr_vat_regime",
+      "schema": "public",
+      "values": [
+        "REEL_NORMAL_MENSUEL",
+        "REEL_SIMPLIFIE",
+        "FRANCHISE_EN_BASE"
+      ]
+    },
+    "public.peppol_original_payload_container_format": {
+      "name": "peppol_original_payload_container_format",
+      "schema": "public",
+      "values": [
+        "none",
+        "pdf"
+      ]
+    },
+    "public.peppol_payload_location": {
+      "name": "peppol_payload_location",
+      "schema": "public",
+      "values": [
+        "none",
+        "db",
+        "s3"
+      ]
+    },
+    "public.peppol_payment_status": {
+      "name": "peppol_payment_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "open",
+        "pending",
+        "authorized",
+        "paid",
+        "canceled",
+        "expired",
+        "failed"
+      ]
+    },
+    "public.peppol_profile_standing": {
+      "name": "peppol_profile_standing",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "grace",
+        "suspended"
+      ]
+    },
+    "public.peppol_smp_provider": {
+      "name": "peppol_smp_provider",
+      "schema": "public",
+      "values": [
+        "recommand-smp1",
+        "at-shared-smp-fr"
+      ]
+    },
+    "public.peppol_supported_document_type": {
+      "name": "peppol_supported_document_type",
+      "schema": "public",
+      "values": [
+        "invoice",
+        "creditNote",
+        "selfBillingInvoice",
+        "selfBillingCreditNote",
+        "messageLevelResponse",
+        "frenchInvoicingCdar",
+        "frenchB2CSalesReport",
+        "frenchB2CPaymentReport",
+        "frenchB2BiInvoiceReport",
+        "frenchB2BiPaymentReport",
+        "unknown"
+      ]
+    },
+    "public.peppol_transfer_event_direction": {
+      "name": "peppol_transfer_event_direction",
+      "schema": "public",
+      "values": [
+        "incoming",
+        "outgoing"
+      ]
+    },
+    "public.peppol_transfer_event_type": {
+      "name": "peppol_transfer_event_type",
+      "schema": "public",
+      "values": [
+        "peppol",
+        "email",
+        "reporting"
+      ]
+    },
+    "public.peppol_valid_country_codes": {
+      "name": "peppol_valid_country_codes",
+      "schema": "public",
+      "values": [
+        "AU",
+        "AT",
+        "BE",
+        "BG",
+        "CA",
+        "HR",
+        "DK",
+        "EE",
+        "FI",
+        "FR",
+        "DE",
+        "GR",
+        "HK",
+        "HU",
+        "IS",
+        "IE",
+        "IT",
+        "JP",
+        "LV",
+        "LU",
+        "MY",
+        "NL",
+        "NZ",
+        "NO",
+        "PL",
+        "PT",
+        "RO",
+        "SG",
+        "SK",
+        "SI",
+        "ES",
+        "SE",
+        "AE",
+        "GB",
+        "US"
+      ]
+    },
+    "public.peppol_valid_iso_icd_scheme_identifiers": {
+      "name": "peppol_valid_iso_icd_scheme_identifiers",
+      "schema": "public",
+      "values": [
+        "0002",
+        "0003",
+        "0004",
+        "0005",
+        "0006",
+        "0007",
+        "0008",
+        "0009",
+        "0010",
+        "0011",
+        "0012",
+        "0013",
+        "0014",
+        "0015",
+        "0016",
+        "0017",
+        "0018",
+        "0019",
+        "0020",
+        "0021",
+        "0022",
+        "0023",
+        "0024",
+        "0025",
+        "0026",
+        "0027",
+        "0028",
+        "0029",
+        "0030",
+        "0031",
+        "0032",
+        "0033",
+        "0034",
+        "0035",
+        "0036",
+        "0037",
+        "0038",
+        "0039",
+        "0040",
+        "0041",
+        "0042",
+        "0043",
+        "0044",
+        "0045",
+        "0046",
+        "0047",
+        "0048",
+        "0049",
+        "0050",
+        "0051",
+        "0052",
+        "0053",
+        "0054",
+        "0055",
+        "0056",
+        "0057",
+        "0058",
+        "0059",
+        "0060",
+        "0061",
+        "0062",
+        "0063",
+        "0064",
+        "0065",
+        "0066",
+        "0067",
+        "0068",
+        "0069",
+        "0070",
+        "0071",
+        "0072",
+        "0073",
+        "0074",
+        "0075",
+        "0076",
+        "0077",
+        "0078",
+        "0079",
+        "0080",
+        "0081",
+        "0082",
+        "0083",
+        "0084",
+        "0085",
+        "0086",
+        "0087",
+        "0088",
+        "0089",
+        "0090",
+        "0091",
+        "0093",
+        "0094",
+        "0095",
+        "0096",
+        "0097",
+        "0098",
+        "0099",
+        "0100",
+        "0101",
+        "0102",
+        "0104",
+        "0105",
+        "0106",
+        "0107",
+        "0108",
+        "0109",
+        "0110",
+        "0111",
+        "0112",
+        "0113",
+        "0114",
+        "0115",
+        "0116",
+        "0117",
+        "0118",
+        "0119",
+        "0120",
+        "0121",
+        "0122",
+        "0123",
+        "0124",
+        "0125",
+        "0126",
+        "0127",
+        "0128",
+        "0129",
+        "0130",
+        "0131",
+        "0132",
+        "0133",
+        "0134",
+        "0135",
+        "0136",
+        "0137",
+        "0138",
+        "0139",
+        "0140",
+        "0141",
+        "0142",
+        "0143",
+        "0144",
+        "0145",
+        "0146",
+        "0147",
+        "0148",
+        "0149",
+        "0150",
+        "0151",
+        "0152",
+        "0153",
+        "0154",
+        "0155",
+        "0156",
+        "0157",
+        "0158",
+        "0159",
+        "0160",
+        "0161",
+        "0162",
+        "0163",
+        "0164",
+        "0165",
+        "0166",
+        "0167",
+        "0168",
+        "0169",
+        "0170",
+        "0171",
+        "0172",
+        "0173",
+        "0174",
+        "0175",
+        "0176",
+        "0177",
+        "0178",
+        "0179",
+        "0180",
+        "0183",
+        "0184",
+        "0185",
+        "0186",
+        "0187",
+        "0188",
+        "0189",
+        "0190",
+        "0191",
+        "0192",
+        "0193",
+        "0194",
+        "0195",
+        "0196",
+        "0197",
+        "0198",
+        "0199",
+        "0200",
+        "0201",
+        "0202",
+        "0203",
+        "0204",
+        "0205",
+        "0206",
+        "0207",
+        "0208",
+        "0209",
+        "0210",
+        "0211",
+        "0212",
+        "0213",
+        "0214",
+        "0215",
+        "0216",
+        "0217",
+        "0218",
+        "0219",
+        "0220",
+        "0221",
+        "0222",
+        "0223",
+        "0224",
+        "0225",
+        "0226",
+        "0227",
+        "0228",
+        "0229",
+        "0230",
+        "0231",
+        "0232",
+        "0233",
+        "0234",
+        "0235",
+        "0236",
+        "0237",
+        "0238",
+        "0239",
+        "0240"
+      ]
+    },
+    "public.peppol_validation_result": {
+      "name": "peppol_validation_result",
+      "schema": "public",
+      "values": [
+        "valid",
+        "invalid",
+        "not_supported",
+        "error"
+      ]
+    },
+    "public.verification_requirements": {
+      "name": "verification_requirements",
+      "schema": "public",
+      "values": [
+        "strict",
+        "trusted",
+        "lax"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "opened",
+        "idVerificationRequested",
+        "inReview",
+        "verified",
+        "rejected",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/drizzle/meta/_journal.json
+++ b/db/drizzle/meta/_journal.json
@@ -743,6 +743,13 @@
       "when": 1788859469135,
       "tag": "20260908092429_fr_reporting_submissions",
       "breakpoints": true
+    },
+    {
+      "idx": 106,
+      "version": "7",
+      "when": 1788949016412,
+      "tag": "20260909101656_provider_delivery_failures",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -797,6 +797,47 @@ export const outgoingEnvelopeClaims = pgTable("peppol_outgoing_envelope_claims",
   index("peppol_outgoing_envelope_claims_created_at_idx").on(table.createdAt),
 ]);
 
+// A delivery failure an access point reported for a transaction it had already
+// accepted. Acceptance is all a send gets to see; validation and delivery happen
+// afterwards and their failure is reported through the provider's webhook. Keyed by
+// the transaction because the report can arrive before the send has recorded its
+// document, in which case the row waits here and is attached when the document is
+// written (see data/delivery-failures). One row per transaction, however many times
+// the provider retries the report.
+export const providerDeliveryFailures = pgTable(
+  "peppol_provider_delivery_failures",
+  {
+    apTransactionId: text("ap_transaction_id").primaryKey(),
+    accessPointProvider: accessPointProviderEnum("access_point_provider").notNull(),
+    useTestNetwork: boolean("use_test_network").notNull().default(false),
+    // The provider's own id for the webhook event that reported the failure, and the
+    // provider's name for the event. The payload of a failure carries no direction:
+    // the event type is what says whether a send or a receipt failed.
+    eventId: text("event_id").notNull(),
+    eventType: text("event_type").notNull(),
+    transactionStatus: text("transaction_status"),
+    errorCode: text("error_code"),
+    errorMessage: text("error_message"),
+    errorCategory: text("error_category"),
+    docInstanceId: text("doc_instance_id"),
+    // The event payload as reported, for support.
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    transmittedDocumentId: text("transmitted_document_id").references(
+      () => transmittedDocuments.id,
+      { onDelete: "cascade" }
+    ),
+    reportedAt: timestamp("reported_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    attachedAt: timestamp("attached_at", { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex("peppol_provider_delivery_failures_document_idx")
+      .on(table.transmittedDocumentId)
+      .where(isNotNull(table.transmittedDocumentId)),
+  ]
+);
+
 export const transmittedDocumentLabels = pgTable(
   "peppol_transmitted_document_labels",
   {

--- a/lib/event-types.ts
+++ b/lib/event-types.ts
@@ -106,6 +106,18 @@ const documentReportingStatusPayloadSchema = z.object({
   outcomeCode: z.string().nullable().optional(),
 });
 
+const documentDeliveryFailedPayloadSchema = z.object({
+  companyId: z.string(),
+  docType: z.string(),
+  senderId: z.string(),
+  receiverId: z.string().nullable(),
+  envelopeId: z.string().nullable().optional(),
+  errorCode: z.string().nullable().optional(),
+  errorMessage: z.string().nullable().optional(),
+  errorCategory: z.string().nullable().optional(),
+  transactionStatus: z.string().nullable().optional(),
+});
+
 const companyVerificationPayloadSchema = z.object({
   companyId: z.string(),
   status: z.enum(verificationStatuses),
@@ -262,6 +274,39 @@ export function registerPeppolEventTypes() {
     },
     ui: {
       label: "Document label unassigned",
+      group: "Documents",
+    },
+  });
+
+  registerEventType({
+    type: "peppol.document.delivery_failed.v1",
+    aggregateType: "peppol.document",
+    payload: documentDeliveryFailedPayloadSchema,
+    conditionFields: [
+      { path: "payload.companyId", label: "Company", valueType: "string", operators: ["eq", "neq", "in"], picker: "company" },
+      documentTypeField,
+      { path: "payload.senderId", label: "Sender address", valueType: "string", operators: ["eq", "neq", "in", "notIn"] },
+      { path: "payload.receiverId", label: "Receiver address", valueType: "string", operators: ["eq", "neq", "in", "notIn"] },
+      { path: "payload.errorCategory", label: "Failure category", valueType: "string", operators: ["eq", "neq", "in", "notIn", "exists"] },
+    ],
+    webhook: {
+      eventType: "document.delivery_failed",
+      project: (event) => {
+        const payload = event.payload as z.infer<typeof documentDeliveryFailedPayloadSchema>;
+        return {
+          eventType: "document.delivery_failed",
+          documentId: event.aggregateId,
+          teamId: event.teamId,
+          companyId: payload.companyId,
+          errorCode: payload.errorCode ?? null,
+          errorMessage: payload.errorMessage ?? null,
+          errorCategory: payload.errorCategory ?? null,
+        };
+      },
+    },
+    ui: {
+      label: "Document delivery failed",
+      description: "The access point reported that a sent document failed validation or delivery after it was accepted",
       group: "Documents",
     },
   });

--- a/test/sending-company-identifier.test.ts
+++ b/test/sending-company-identifier.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, mock } from "bun:test";
+
+// The choice under test never touches the database, but the module it lives in
+// connects at import time.
+mock.module("@recommand/db", () => ({ db: {} }));
+
+const { chooseSendingCompanyIdentifier } = await import("../data/company-identifiers");
+
+const siren = { scheme: "0225", identifier: "443061841" };
+const siret = { scheme: "0225", identifier: "44306184100047" };
+const suffixed = { scheme: "0225", identifier: "443061841_0001" };
+const sirenScheme = { scheme: "0002", identifier: "443061841" };
+const siretScheme = { scheme: "0009", identifier: "44306184100047" };
+const belgian = { scheme: "0208", identifier: "1012081766" };
+
+const frenchCompany = { accessPointProvider: "at-shared-ap-fr" } as const;
+const otherCompany = { accessPointProvider: "recommand-ap1" } as const;
+
+// In the order getCompanyIdentifiers lists them: by scheme, then by identifier.
+function sorted<T extends { scheme: string; identifier: string }>(...identifiers: T[]): T[] {
+  return [...identifiers].sort(
+    (a, b) => a.scheme.localeCompare(b.scheme) || a.identifier.localeCompare(b.identifier)
+  );
+}
+
+describe("the address a company sends under", () => {
+  it("is the SIREN under the French electronic address scheme through the French access point, even when lower schemes exist", () => {
+    expect(
+      chooseSendingCompanyIdentifier(frenchCompany, sorted(sirenScheme, siretScheme, siret, siren))
+    ).toBe(siren);
+  });
+
+  it("is refused through the French access point when the company has no such identifier", () => {
+    for (const identifiers of [
+      sorted(sirenScheme, siretScheme),
+      sorted(siret),
+      sorted(suffixed),
+      sorted(sirenScheme, siret, suffixed),
+    ]) {
+      expect(() => chooseSendingCompanyIdentifier(frenchCompany, identifiers)).toThrow(
+        /scheme 0225 and the company's 9 digit SIREN/
+      );
+    }
+  });
+
+  it("stays the lowest scheme for every other access point", () => {
+    expect(chooseSendingCompanyIdentifier(otherCompany, sorted(belgian, siren, sirenScheme))).toBe(
+      sirenScheme
+    );
+    expect(chooseSendingCompanyIdentifier(otherCompany, sorted(belgian))).toBe(belgian);
+  });
+
+  it("refuses a company without identifiers the same way for every access point", () => {
+    for (const company of [frenchCompany, otherCompany]) {
+      expect(() => chooseSendingCompanyIdentifier(company, [])).toThrow(
+        /No sending company identifier found/
+      );
+    }
+  });
+});

--- a/test/webhooks/arratech-send-failed.test.ts
+++ b/test/webhooks/arratech-send-failed.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { createHmac } from "node:crypto";
+import { Hono } from "hono";
+
+const productionSecret = "production-" + crypto.randomUUID();
+const testSecret = "test-" + crypto.randomUUID();
+const productionAp = "ap-production";
+const testAp = "ap-test";
+
+const failures: unknown[] = [];
+const sent: unknown[] = [];
+
+mock.module("@recommand/lib/api", () => ({ Server: Hono }));
+mock.module("@recommand/lib/utils", () => ({
+  actionSuccess: (value: unknown) => ({ success: true, ...(value as object) }),
+  actionFailure: (value: unknown) => ({ success: false, error: String(value) }),
+}));
+mock.module("@directory/utils/util", () => ({ UserFacingError: class extends Error {} }));
+mock.module("@peppol/db/schema", () => ({ transmittedDocuments: { id: "id", apTransactionId: "ap", direction: "direction" } }));
+mock.module("@recommand/db", () => ({ db: {} }));
+mock.module("@peppol/data/at/ap", () => ({ downloadBusinessDocument: async () => null }));
+mock.module("@peppol/data/at/client", () => ({
+  getArratechConfig: (useTestNetwork: boolean) => ({ apRef: useTestNetwork ? testAp : productionAp }),
+}));
+mock.module("@peppol/data/provider-sent", () => ({
+  recordProviderSentTransaction: async (transaction: unknown) => {
+    sent.push(transaction);
+    return "sent-by-us";
+  },
+}));
+mock.module("@peppol/data/delivery-failures", () => ({
+  recordProviderDeliveryFailure: async (failure: unknown) => {
+    failures.push(failure);
+    return "attached";
+  },
+}));
+mock.module("@peppol/utils/pipelines/receiving", () => ({ receivingPipeline: async () => {} }));
+
+const { default: server } = await import("../../api/internal/arratech-webhook");
+
+const failedPayload = {
+  id: "tx-1",
+  transactionStatus: "FAILED",
+  createdAt: "2026-09-09T10:00:00Z",
+  apId: productionAp,
+  docInstanceId: "env-1",
+  serviceError: {
+    code: "TXE-1005",
+    message: "The document could not be delivered to the recipient.",
+    category: "TRANSPORT_ERROR",
+  },
+};
+
+async function post(body: object, secret: string | null) {
+  const raw = JSON.stringify(body);
+  const headers: Record<string, string> = {};
+  if (secret !== null) {
+    headers["x-arratech-webhook-sign"] = createHmac("sha256", secret).update(raw).digest("hex");
+  }
+  const response = await server.request("/arratech", { method: "POST", body: raw, headers });
+  return { status: response.status, body: (await response.json()) as Record<string, unknown> };
+}
+
+function event(payload: object, eventType = "transaction.send_failed") {
+  return { id: "evt-1", eventType, payload };
+}
+
+beforeEach(() => {
+  failures.length = 0;
+  sent.length = 0;
+  process.env.ARRATECH_WEBHOOK_SECRET = productionSecret;
+  process.env.ARRATECH_TEST_WEBHOOK_SECRET = testSecret;
+});
+
+describe("transaction.send_failed", () => {
+  it("stores the failure for the transaction with the provider's error details", async () => {
+    const result = await post(event(failedPayload), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(result.body.outcome).toBe("attached");
+    expect(failures).toEqual([
+      {
+        accessPointProvider: "at-shared-ap-fr",
+        apTransactionId: "tx-1",
+        useTestNetwork: false,
+        eventId: "evt-1",
+        eventType: "transaction.send_failed",
+        transactionStatus: "FAILED",
+        docInstanceId: "env-1",
+        error: failedPayload.serviceError,
+        payload: failedPayload,
+      },
+    ]);
+    expect(sent).toEqual([]);
+  });
+
+  it("accepts a failure without error details or addressing, which the provider omits rather than nulls", async () => {
+    const result = await post(event({ id: "tx-2", transactionStatus: "REJECTED", createdAt: "2026-09-09T10:00:00Z", apId: productionAp }), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({ apTransactionId: "tx-2", transactionStatus: "REJECTED", error: null, docInstanceId: null });
+  });
+
+  it("takes the network from the signature when the access point is omitted", async () => {
+    const { apId: _omitted, ...withoutAp } = failedPayload;
+
+    const production = await post(event(withoutAp), productionSecret);
+    const test = await post(event(withoutAp), testSecret);
+
+    expect(production.status).toBe(200);
+    expect(test.status).toBe(200);
+    expect(failures.map((failure) => (failure as { useTestNetwork: boolean }).useTestNetwork)).toEqual([false, true]);
+  });
+
+  it("refuses to guess the network when both secrets match and no access point is reported", async () => {
+    process.env.ARRATECH_TEST_WEBHOOK_SECRET = productionSecret;
+    const { apId: _omitted, ...withoutAp } = failedPayload;
+
+    const result = await post(event(withoutAp), productionSecret);
+
+    expect(result.status).toBe(400);
+    expect(failures).toEqual([]);
+  });
+
+  it("requires the signature to belong to the reported access point's network", async () => {
+    const result = await post(event({ ...failedPayload, apId: testAp }), productionSecret);
+
+    expect(result.status).toBe(401);
+    expect(failures).toEqual([]);
+  });
+
+  it("ignores a failure for an access point that is not ours", async () => {
+    const result = await post(event({ ...failedPayload, apId: "someone-elses-ap" }), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(failures).toEqual([]);
+  });
+
+  it("rejects a failure without a transaction id", async () => {
+    const { id: _omitted, ...withoutId } = failedPayload;
+
+    const result = await post(event(withoutId), productionSecret);
+
+    expect(result.status).toBe(400);
+    expect(failures).toEqual([]);
+  });
+
+  it("rejects an unsigned or wrongly signed report", async () => {
+    expect((await post(event(failedPayload), null)).status).toBe(401);
+    expect((await post(event(failedPayload), "not-a-secret")).status).toBe(401);
+    expect(failures).toEqual([]);
+  });
+});
+
+describe("other transaction events", () => {
+  it("still ignores event types it does not handle, including inbound failures", async () => {
+    for (const eventType of ["transaction.receive_failed", "mls.received", "webhooks.test"]) {
+      const result = await post(event(failedPayload, eventType), productionSecret);
+      expect(result.status).toBe(200);
+      expect(result.body.message).toBe("Event type not processed");
+    }
+    expect(failures).toEqual([]);
+    expect(sent).toEqual([]);
+  });
+
+  it("still records a completed transaction.sent through the provider-sent path", async () => {
+    const payload = {
+      id: "tx-3",
+      apId: productionAp,
+      senderId: "0225:123456789",
+      receiverId: "0208:0123456789",
+      docTypeId: "doc-type",
+      processId: "process",
+      transactionStatus: "COMPLETED",
+      docInstanceId: "env-3",
+    };
+
+    const result = await post(event(payload, "transaction.sent"), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ apTransactionId: "tx-3", useTestNetwork: false, docInstanceId: "env-3" });
+    expect(failures).toEqual([]);
+  });
+
+  it("does not turn a transaction.sent that is not completed into a failure", async () => {
+    const payload = {
+      id: "tx-4",
+      apId: productionAp,
+      senderId: "0225:123456789",
+      receiverId: "0208:0123456789",
+      docTypeId: "doc-type",
+      processId: "process",
+      transactionStatus: "FAILED",
+    };
+
+    const result = await post(event(payload, "transaction.sent"), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(result.body.message).toBe("Transaction not completed");
+    expect(sent).toEqual([]);
+    expect(failures).toEqual([]);
+  });
+});

--- a/translations/de.csv
+++ b/translations/de.csv
@@ -967,6 +967,8 @@ Change VAT settings,MwSt.-Einstellungen ändern
 Changing the regime during a reporting period can leave that period unfiled. Coordinate such a change with support.,Eine Änderung des Regimes während eines Meldezeitraums kann dazu führen\, dass dieser Zeitraum nicht eingereicht wird. Stimmen Sie eine solche Änderung mit dem Support ab.
 Choose the VAT regime and when VAT becomes due first,Wählen Sie zuerst das MwSt.-Regime und den Zeitpunkt der Steuerentstehung
 Daily B2C totals and cross-border invoices are reported to the French tax administration on the company's behalf. Register the company once\, then submit reports through the API.,Tägliche B2C-Summen und grenzüberschreitende Rechnungen werden im Namen des Unternehmens an die französische Steuerverwaltung gemeldet. Registrieren Sie das Unternehmen einmalig und reichen Sie die Meldungen anschließend über die API ein.
+Delivery failed,Zustellung fehlgeschlagen
+Error code {0}.,Fehlercode {0}.
 Failed to load the e-reporting registration,Die E-Reporting-Registrierung konnte nicht geladen werden
 Failed to register the company for e-reporting,Das Unternehmen konnte nicht für E-Reporting registriert werden
 Filed by corrective filing,Eingereicht per Korrekturmeldung
@@ -994,6 +996,8 @@ Simulated,Simuliert
 Simulated: this report is recorded but not filed.,Simuliert: Diese Meldung wurde gespeichert\, aber nicht eingereicht.
 Superseded,Ersetzt
 Suspended,Ausgesetzt
+The access point accepted this document but reported afterwards that it could not be validated or delivered. It did not reach the recipient.,Der Peppol Access Point hat dieses Dokument angenommen, meldete danach aber, dass es nicht validiert oder zugestellt werden konnte. Es hat den Empfänger nicht erreicht.
+The access point could not deliver this document.,Der Peppol Access Point konnte dieses Dokument nicht zustellen.
 The company is registered for French e-reporting,Das Unternehmen ist für französisches E-Reporting registriert
 The regime determines how often the reports are filed with the tax administration.,Das Regime bestimmt\, wie oft die Meldungen bei der Steuerverwaltung eingereicht werden.
 The registration could not be completed.,Die Registrierung konnte nicht abgeschlossen werden.

--- a/translations/fr.csv
+++ b/translations/fr.csv
@@ -967,6 +967,8 @@ Change VAT settings,Modifier les paramètres de TVA
 Changing the regime during a reporting period can leave that period unfiled. Coordinate such a change with support.,Modifier le régime pendant une période de déclaration peut laisser cette période sans dépôt. Coordonnez ce changement avec le support.
 Choose the VAT regime and when VAT becomes due first,Choisissez d'abord le régime de TVA et le moment d'exigibilité de la TVA
 Daily B2C totals and cross-border invoices are reported to the French tax administration on the company's behalf. Register the company once\, then submit reports through the API.,Les totaux B2C journaliers et les factures transfrontalières sont transmis à l'administration fiscale française au nom de l'entreprise. Enregistrez l'entreprise une fois\, puis soumettez les déclarations via l'API.
+Delivery failed,Livraison échouée
+Error code {0}.,Code d'erreur {0}.
 Failed to load the e-reporting registration,Impossible de charger l'enregistrement e-reporting
 Failed to register the company for e-reporting,Impossible d'enregistrer l'entreprise pour l'e-reporting
 Filed by corrective filing,Déposée par dépôt rectificatif
@@ -994,6 +996,8 @@ Simulated,Simulée
 Simulated: this report is recorded but not filed.,Simulée : cette déclaration est enregistrée mais non déposée.
 Superseded,Remplacée
 Suspended,Suspendue
+The access point accepted this document but reported afterwards that it could not be validated or delivered. It did not reach the recipient.,Le Peppol Access Point a accepté ce document mais a signalé ensuite qu'il n'a pas pu être validé ou livré. Il n'est pas parvenu au destinataire.
+The access point could not deliver this document.,Le Peppol Access Point n'a pas pu livrer ce document.
 The company is registered for French e-reporting,L'entreprise est enregistrée pour l'e-reporting France
 The regime determines how often the reports are filed with the tax administration.,Le régime détermine la fréquence de dépôt des déclarations auprès de l'administration fiscale.
 The registration could not be completed.,L'enregistrement n'a pas pu être finalisé.

--- a/translations/nl.csv
+++ b/translations/nl.csv
@@ -967,6 +967,8 @@ Change VAT settings,Btw-instellingen wijzigen
 Changing the regime during a reporting period can leave that period unfiled. Coordinate such a change with support.,Het regime wijzigen tijdens een aangifteperiode kan ervoor zorgen dat die periode niet wordt aangegeven. Stem zo'n wijziging af met support.
 Choose the VAT regime and when VAT becomes due first,Kies eerst het btw-regime en wanneer de btw verschuldigd wordt
 Daily B2C totals and cross-border invoices are reported to the French tax administration on the company's behalf. Register the company once\, then submit reports through the API.,Dagelijkse B2C-totalen en grensoverschrijdende facturen worden namens het bedrijf aan de Franse belastingdienst gerapporteerd. Registreer het bedrijf eenmalig en dien daarna rapporten in via de API.
+Delivery failed,Aflevering mislukt
+Error code {0}.,Foutcode {0}.
 Failed to load the e-reporting registration,Laden van de e-reporting-registratie mislukt
 Failed to register the company for e-reporting,Registreren van het bedrijf voor e-reporting mislukt
 Filed by corrective filing,Aangegeven via corrigerende aangifte
@@ -994,6 +996,8 @@ Simulated,Gesimuleerd
 Simulated: this report is recorded but not filed.,Gesimuleerd: dit rapport is opgeslagen maar niet ingediend.
 Superseded,Vervangen
 Suspended,Opgeschort
+The access point accepted this document but reported afterwards that it could not be validated or delivered. It did not reach the recipient.,Het Peppol Access Point heeft dit document aanvaard maar meldde nadien dat het niet gevalideerd of afgeleverd kon worden. Het heeft de ontvanger niet bereikt.
+The access point could not deliver this document.,Het Peppol Access Point kon dit document niet afleveren.
 The company is registered for French e-reporting,Het bedrijf is geregistreerd voor Franse e-reporting
 The regime determines how often the reports are filed with the tax administration.,Het regime bepaalt hoe vaak de rapporten bij de belastingdienst worden ingediend.
 The registration could not be completed.,De registratie kon niet worden voltooid.

--- a/utils/pipelines/sending/index.ts
+++ b/utils/pipelines/sending/index.ts
@@ -57,7 +57,7 @@ export async function sendingPipeline(c: SendingContext) {
       );
     }
 
-    const senderIdentifier = await getSendingCompanyIdentifier(company.id);
+    const senderIdentifier = await getSendingCompanyIdentifier(company);
     const senderAddress = `${senderIdentifier.scheme}:${senderIdentifier.identifier}`;
 
     // Raw XML already is one specific format, and states the process it belongs to, so


### PR DESCRIPTION
## Why

An access point can accept a transaction and fail it afterwards, during validation or delivery. Arratech reports that through a separate `transaction.send_failed` webhook event; `transaction.sent` and `transaction.received` are never emitted for such a transaction, so a send that failed after acceptance was indistinguishable from one that arrived.

Separately, the French access point recognises a sender by its SIREN under scheme 0225, while the sending address was the company's lowest scheme.

## What

**Delivery failures** (commit "Record the delivery failures an access point reports after accepting a send")
- The Arratech webhook handles `transaction.send_failed` with its own lenient schema: per the provider's OpenAPI spec only the transaction id and status are guaranteed, everything else is omitted when not applicable. When the access point id is absent, the network is taken from which webhook secret signed the report; when both secrets match, the report is refused rather than guessed.
- New table `peppol_provider_delivery_failures`, keyed by the provider's transaction id. Retries are no-ops. A report that arrives before the send has recorded its document waits and is attached by `recordOutgoingDocument`. Attaching is a conditional update, so the failure is attached, and the customer told, exactly once.
- New event `peppol.document.delivery_failed.v1`, delivered to customer webhooks as `document.delivery_failed`, plus an audit event and a system alert. Existing billing transfer events, notifications and quota are untouched; nothing is resent.
- Document API: `deliveryFailure` (code, message, category, transactionStatus, reportedAt) on outgoing documents. Dashboard: badge in the list and on the detail page, with an explanatory alert (nl, fr, de translated).
- `transaction.receive_failed` and `mls.received` are still ignored on purpose; the stored event type lets the same table serve inbound failures later without a migration.

**Sender address** (commit "Send under the company's 0225 SIREN address through the French access point")
- `getSendingCompanyIdentifier` takes the company. On the French access point it returns the 0225 identifier whose value is a SIREN, whatever other schemes exist, and errors clearly when it is missing. A SIRET or suffixed 0225 address is not accepted in its place. Other access points keep the lowest scheme. Filed reports keep the default identifier, since they have no transport sender.

## Tests

- `test/webhooks/arratech-send-failed.test.ts`: signature checks, network scoping with and without `apId`, ambiguous secrets, payload leniency, unknown access point, other event types still ignored, `transaction.sent` paths unchanged.
- `test/sending-company-identifier.test.ts`: the choice for French and other companies, including the refusals.
- `SKIP_E2E=1 bun run test:unit`: 434 tests pass. `tsc --noEmit` clean.

## Deploy notes

- Migration `20260909101656_provider_delivery_failures` creates the new table on startup.
- After deploy, the provider webhook must be subscribed to the **Transaction Send Failed** event in the Arratech portal; until then no failure reports arrive.
- A companion change in the admin package exposes the failure in the support document diagnosis.
