### PR TITLE
Send under the company's 0225 SIREN address through the French access point

### DIFF
--- a/api/generate-document.ts
+++ b/api/generate-document.ts
@@ -126,7 +126,7 @@ async function generateImplementation(c: GenerateContext) {
     const team = c.var.team;
     const isPlayground = team.isPlayground ?? false;
     const useTestNetwork = team.useTestNetwork ?? false;
-    const senderIdentifier = await getSendingCompanyIdentifier(company.id);
+    const senderIdentifier = await getSendingCompanyIdentifier(company);
     const recipientAddress = normalizePeppolAddress(input.recipient);
 
     // The same lookup the send endpoint does, under the same condition, so the

--- a/api/preview-document.ts
+++ b/api/preview-document.ts
@@ -68,9 +68,7 @@ async function _previewDocumentImplementation(c: PreviewDocumentContext) {
       );
     }
 
-    const senderIdentifier = await getSendingCompanyIdentifier(
-      c.var.company.id,
-    );
+    const senderIdentifier = await getSendingCompanyIdentifier(c.var.company);
     const senderAddress = `${senderIdentifier.scheme}:${senderIdentifier.identifier}`;
     let recipientAddress = input.recipient ?? "0000:0000";
     if (!recipientAddress.includes(":")) {

--- a/api/reporting/submit.ts
+++ b/api/reporting/submit.ts
@@ -17,7 +17,7 @@ import {
   submitArratechB2CReport,
   type FrenchReportingSubmissionResult,
 } from "@peppol/data/at/fr-reporting";
-import { getSendingCompanyIdentifier } from "@peppol/data/company-identifiers";
+import { getDefaultCompanyIdentifier } from "@peppol/data/company-identifiers";
 import {
   getReadyFrenchReportingDeclarant,
   isFrenchReportingSimulated,
@@ -287,9 +287,10 @@ async function fileFrenchReport({
     return c.json(actionSuccess({ id: existing.id, duplicate: true }));
   }
 
-  // The report is filed rather than transmitted, so it has no XML and no
-  // recipient. The sending identifier still records which company filed it.
-  const senderIdentifier = await getSendingCompanyIdentifier(company.id);
+  // The report is filed rather than transmitted, so it has no XML, no recipient and
+  // no transport sender. The company's default identifier records which company
+  // filed it.
+  const senderIdentifier = await getDefaultCompanyIdentifier(company.id);
   const transmittedDocument = await recordOutgoingDocument({
     c,
     id: "doc_" + ulid(),

--- a/data/company-identifiers.ts
+++ b/data/company-identifiers.ts
@@ -6,6 +6,8 @@ import { db } from "@recommand/db";
 import { eq, and, asc, ne, or, isNull } from "drizzle-orm";
 import { unregisterCompanyIdentifier, upsertCompanyRegistration } from "./smp-providers";
 import { getTeamExtensionAndCompanyByCompanyId } from "./teams";
+import type { Company } from "./companies";
+import type { AccessPointProviderId } from "./peppol-providers";
 
 export type CompanyIdentifier = typeof companyIdentifiers.$inferSelect;
 export type InsertCompanyIdentifier = typeof companyIdentifiers.$inferInsert;
@@ -68,7 +70,11 @@ export async function getCompanyIdentifierBySchemeAndValue(
     .then((rows) => rows[0]);
 }
 
-export async function getSendingCompanyIdentifier(companyId: string): Promise<CompanyIdentifier> {
+/**
+ * The company's first identifier by scheme: the address a document of the company is
+ * attributed to when nothing about how it travels decides otherwise.
+ */
+export async function getDefaultCompanyIdentifier(companyId: string): Promise<CompanyIdentifier> {
   const identifiers = await db
     .select()
     .from(companyIdentifiers)
@@ -81,6 +87,59 @@ export async function getSendingCompanyIdentifier(companyId: string): Promise<Co
   }
 
   return identifiers[0];
+}
+
+/** The access point that sends for French companies, and requires a particular sender address. */
+const FRENCH_ACCESS_POINT_PROVIDER: AccessPointProviderId = "at-shared-ap-fr";
+
+/**
+ * The address a company sends under: the sender of the transport envelope and the
+ * seller's endpoint in the documents we write for it.
+ *
+ * Through the French access point the sender has to be the company's SIREN under the
+ * French electronic address scheme (0225), whatever other identifiers the company
+ * registered: that is the address the access point recognises the sender by. A
+ * SIRET or a suffixed electronic address under that scheme names an establishment
+ * rather than the company and is not accepted in its place. Every other access point
+ * takes the company's default identifier, as before.
+ */
+export async function getSendingCompanyIdentifier(
+  company: Pick<Company, "id" | "accessPointProvider">
+): Promise<CompanyIdentifier> {
+  if (company.accessPointProvider !== FRENCH_ACCESS_POINT_PROVIDER) {
+    return await getDefaultCompanyIdentifier(company.id);
+  }
+
+  return chooseSendingCompanyIdentifier(company, await getCompanyIdentifiers(company.id));
+}
+
+/**
+ * The choice getSendingCompanyIdentifier makes, given the company's identifiers in
+ * the order getCompanyIdentifiers lists them. Separate so the choice can be asserted
+ * without a database.
+ */
+export function chooseSendingCompanyIdentifier<T extends Pick<CompanyIdentifier, "scheme" | "identifier">>(
+  company: Pick<Company, "accessPointProvider">,
+  identifiers: T[]
+): T {
+  if (identifiers.length === 0) {
+    throw new UserFacingError("No sending company identifier found. Ensure you have added a company identifier to your company.");
+  }
+
+  if (company.accessPointProvider !== FRENCH_ACCESS_POINT_PROVIDER) {
+    return identifiers[0]!;
+  }
+
+  const sirenAddress = identifiers.find(
+    (identifier) => identifier.scheme === "0225" && isSiren(identifier.identifier)
+  );
+  if (!sirenAddress) {
+    throw new UserFacingError(
+      "Sending through the French access point requires a company identifier with scheme 0225 and the company's 9 digit SIREN as identifier (for example 0225:123456789). Add it to your company to send documents."
+    );
+  }
+
+  return sirenAddress;
 }
 
 /**

--- a/test/sending-company-identifier.test.ts
+++ b/test/sending-company-identifier.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, mock } from "bun:test";
+
+// The choice under test never touches the database, but the module it lives in
+// connects at import time.
+mock.module("@recommand/db", () => ({ db: {} }));
+
+const { chooseSendingCompanyIdentifier } = await import("../data/company-identifiers");
+
+const siren = { scheme: "0225", identifier: "443061841" };
+const siret = { scheme: "0225", identifier: "44306184100047" };
+const suffixed = { scheme: "0225", identifier: "443061841_0001" };
+const sirenScheme = { scheme: "0002", identifier: "443061841" };
+const siretScheme = { scheme: "0009", identifier: "44306184100047" };
+const belgian = { scheme: "0208", identifier: "1012081766" };
+
+const frenchCompany = { accessPointProvider: "at-shared-ap-fr" } as const;
+const otherCompany = { accessPointProvider: "recommand-ap1" } as const;
+
+// In the order getCompanyIdentifiers lists them: by scheme, then by identifier.
+function sorted<T extends { scheme: string; identifier: string }>(...identifiers: T[]): T[] {
+  return [...identifiers].sort(
+    (a, b) => a.scheme.localeCompare(b.scheme) || a.identifier.localeCompare(b.identifier)
+  );
+}
+
+describe("the address a company sends under", () => {
+  it("is the SIREN under the French electronic address scheme through the French access point, even when lower schemes exist", () => {
+    expect(
+      chooseSendingCompanyIdentifier(frenchCompany, sorted(sirenScheme, siretScheme, siret, siren))
+    ).toBe(siren);
+  });
+
+  it("is refused through the French access point when the company has no such identifier", () => {
+    for (const identifiers of [
+      sorted(sirenScheme, siretScheme),
+      sorted(siret),
+      sorted(suffixed),
+      sorted(sirenScheme, siret, suffixed),
+    ]) {
+      expect(() => chooseSendingCompanyIdentifier(frenchCompany, identifiers)).toThrow(
+        /scheme 0225 and the company's 9 digit SIREN/
+      );
+    }
+  });
+
+  it("stays the lowest scheme for every other access point", () => {
+    expect(chooseSendingCompanyIdentifier(otherCompany, sorted(belgian, siren, sirenScheme))).toBe(
+      sirenScheme
+    );
+    expect(chooseSendingCompanyIdentifier(otherCompany, sorted(belgian))).toBe(belgian);
+  });
+
+  it("refuses a company without identifiers the same way for every access point", () => {
+    for (const company of [frenchCompany, otherCompany]) {
+      expect(() => chooseSendingCompanyIdentifier(company, [])).toThrow(
+        /No sending company identifier found/
+      );
+    }
+  });
+});

--- a/utils/pipelines/sending/index.ts
+++ b/utils/pipelines/sending/index.ts
@@ -57,7 +57,7 @@ export async function sendingPipeline(c: SendingContext) {
       );
     }
 
-    const senderIdentifier = await getSendingCompanyIdentifier(company.id);
+    const senderIdentifier = await getSendingCompanyIdentifier(company);
     const senderAddress = `${senderIdentifier.scheme}:${senderIdentifier.identifier}`;
 
     // Raw XML already is one specific format, and states the process it belongs to, so


### PR DESCRIPTION
## Why

The French access point recognises a sender by its SIREN under the French electronic address scheme (0225). The sending address was the company's lowest scheme, so a company that had also registered 0002 or 0009 sent under one of those, and both the transport envelope and the seller endpoint in the documents we write named an address the access point does not accept.

## What

- `getSendingCompanyIdentifier` takes the company. On the French access point it returns the 0225 identifier whose value is a valid SIREN, whatever other schemes exist. A SIRET or a suffixed 0225 address names an establishment and is not accepted in its place; a company without the address gets an error naming the identifier to add.
- Every other access point keeps the lowest scheme, as before.
- Callsites: the sending pipeline, document generation and preview. Filed reports have no transport sender and keep recording the company's default identifier through `getDefaultCompanyIdentifier`.
- No identifiers are created, removed or re-registered; the company identifier inside the invoice body is untouched.

## Tests

- `test/sending-company-identifier.test.ts`: the choice for French and other companies, including both refusals.
- `SKIP_E2E=1 bun run test:unit` passes; `tsc --noEmit` clean.
