### PR TITLE
Track where each delivery of an outgoing document stands

### DIFF
--- a/api/documents/get-document.ts
+++ b/api/documents/get-document.ts
@@ -17,6 +17,7 @@ import {
 import { requireIntegrationSupportedTeamAccess, type CompanyAccessContext } from "@peppol/utils/auth-middleware";
 import { transmittedDocumentResponse } from "./shared";
 import { withFrenchReportingStatus } from "@peppol/data/fr-reporting-submissions";
+import { withDocumentDeliveries } from "@peppol/data/deliveries";
 
 const server = new Server();
 
@@ -78,7 +79,7 @@ async function _getTransmittedDocumentImplementation(c: GetTransmittedDocumentCo
           }
         }
 
-        const [apiDocument] = await withFrenchReportingStatus([await toApiTransmittedDocument(document)]);
+        const [apiDocument] = await withDocumentDeliveries(await withFrenchReportingStatus([await toApiTransmittedDocument(document)]));
         return c.json(actionSuccess({ document: apiDocument! }));
       } catch (error) {
         return c.json(actionFailure("Failed to fetch document"), 500);

--- a/api/documents/list-documents.ts
+++ b/api/documents/list-documents.ts
@@ -12,10 +12,11 @@ import {
   describeErrorResponse,
   describeSuccessResponseWithZod,
 } from "@core/lib/api-docs";
-import { supportedDocumentTypeEnum } from "@peppol/db/schema";
+import { deliveryStatuses, supportedDocumentTypeEnum } from "@peppol/db/schema";
 import { requireIntegrationSupportedTeamAccess, type CompanyAccessContext } from "@peppol/utils/auth-middleware";
 import { transmittedDocumentResponse } from "./shared";
 import { withFrenchReportingStatus } from "@peppol/data/fr-reporting-submissions";
+import { withDocumentDeliveries } from "@peppol/data/deliveries";
 
 const server = new Server();
 
@@ -86,6 +87,14 @@ const getTransmittedDocumentsQuerySchema = z.object({
   envelopeId: z.string().optional().openapi({
     description: "Filter documents by envelope ID (Standard Business Document Header Instance Identifier)",
   }),
+  deliveryStatus: z.enum(deliveryStatuses).optional().openapi({
+    description: "Filter outgoing documents by their summarised delivery status: `delivered` (confirmed on at least one channel), `failed` (every delivery failed) or `pending` (still awaiting confirmation). Documents without deliveries never match.",
+    example: "failed",
+  }),
+  deliveryFailed: z.enum(["true", "false"]).optional().openapi({
+    description: "When true, only documents with at least one failed delivery, whatever their other deliveries did. Use it to find the sends that need attention.",
+    example: "true",
+  }),
   excludeAttachments: z
     .preprocess(
       (value) => {
@@ -124,7 +133,7 @@ const _transmittedDocuments = server.get(
 
 async function _getTransmittedDocumentsImplementation(c: GetTransmittedDocumentsContext) {
   try {
-    const { page, limit, companyId, labelId, direction, search, type, from, to, isUnread, envelopeId, excludeAttachments } = c.req.valid("query");
+    const { page, limit, companyId, labelId, direction, search, type, from, to, isUnread, envelopeId, deliveryStatus, deliveryFailed, excludeAttachments } = c.req.valid("query");
     const { documents, total } = await getTransmittedDocuments(
       c.var.team.id,
       {
@@ -147,13 +156,15 @@ async function _getTransmittedDocumentsImplementation(c: GetTransmittedDocuments
         to,
         isUnread: isUnread === "true" ? true : isUnread === "false" ? false : undefined,
         envelopeId,
+        deliveryStatus,
+        deliveryFailed: deliveryFailed === "true" ? true : deliveryFailed === "false" ? false : undefined,
         excludeAttachments,
       }
     );
 
     return c.json(
       actionSuccess({
-        documents: await withFrenchReportingStatus(documents),
+        documents: await withDocumentDeliveries(await withFrenchReportingStatus(documents)),
         pagination: {
           total,
           page,

--- a/api/documents/shared.ts
+++ b/api/documents/shared.ts
@@ -11,7 +11,12 @@ import { storedFrenchB2BiReportSchema } from "@peppol/utils/parsing/b2bi-reporti
 import { labelResponse } from "@directory/api/labels/shared";
 import { validationResponse } from "@peppol/types/validation";
 import { STORED_DOCUMENT_TYPE_KEYS } from "@peppol/utils/type-repository/document-types/keys";
-import { zodFrReportingStatuses } from "@peppol/db/schema";
+import {
+    deliveryChannels,
+    deliveryFailureCategories,
+    deliveryStatuses,
+    zodFrReportingStatuses,
+} from "@peppol/db/schema";
 
 const transmittedDocumentTypeSchema = z.enum(STORED_DOCUMENT_TYPE_KEYS);
 
@@ -28,6 +33,57 @@ export const frenchReportingStatusResponse = z.object({
     checkedAt: z.string().nullable().openapi({ description: "When the status was last refreshed from the reporting service." }),
     simulated: z.boolean().openapi({ description: "True for playground and test-network reports, which are recorded but never filed." }),
 }).openapi({ ref: "FrenchReportingStatus" });
+
+export const deliveryStatusResponse = z.enum(deliveryStatuses).nullable().openapi({
+    description: "Whether the document reached its recipient, summarised over its deliveries: `delivered` when at least one delivery was confirmed, `failed` when every delivery failed, `pending` while any is still awaiting the channel's confirmation. Null for documents without deliveries, such as incoming documents and filed reports.",
+    example: "delivered",
+});
+
+export const deliveryFailureResponse = z.object({
+    category: z.enum(deliveryFailureCategories).openapi({
+        description: "Why the delivery failed, in the same terms for every channel and access point: `recipient_not_found` (the address is not registered on the network), `document_not_supported` (the recipient does not receive this document type), `validation` (the document was refused by a rule), `transport` (it could not be transmitted), `recipient_rejected`, `duplicate` or `other`.",
+        example: "validation",
+    }),
+    message: z.string().nullable().openapi({
+        description: "What went wrong, as the channel or access point described it.",
+    }),
+    providerCode: z.string().nullable().openapi({
+        description: "The access point's own code for the failure, when it reported one.",
+        example: "TXE-1005",
+    }),
+}).openapi({ ref: "DeliveryFailure" });
+
+export const deliveryResponse = z.object({
+    id: z.string().openapi({
+        description: "The delivery ID. It identifies this delivery in `document.delivery_status_changed` webhook events.",
+        example: "dlv_01JQZ8X0M4T7RB6K9V2NDHW3PA",
+    }),
+    channel: z.enum(deliveryChannels).openapi({
+        description: "How the document was sent to this address.",
+        example: "peppol",
+    }),
+    address: z.string().openapi({
+        description: "The Peppol address or email address the document was sent to.",
+        example: "0208:0428643097",
+    }),
+    status: z.enum(deliveryStatuses).openapi({
+        description: "`pending`: the channel accepted the document and has not confirmed arrival. `delivered`: the channel confirmed arrival; for Peppol the recipient's access point acknowledged the document, for email the recipient's mail server accepted it. `failed`: the document did not arrive; see `failure`.",
+        example: "delivered",
+    }),
+    statusChangedAt: z.string().openapi({
+        description: "When the delivery reached its current status.",
+    }),
+    failure: deliveryFailureResponse.nullable().openapi({
+        description: "Why the delivery failed. Null unless the status is `failed`.",
+    }),
+    references: z.object({
+        peppolMessageId: z.string().nullable().optional().openapi({ description: "The AS4 message ID of the transmission." }),
+        peppolConversationId: z.string().nullable().optional().openapi({ description: "The AS4 conversation ID of the transmission." }),
+        envelopeId: z.string().nullable().optional().openapi({ description: "The envelope ID (SBDH instance identifier) of the transmission." }),
+    }).openapi({
+        description: "The identifiers the transmission is known by on its channel. Present for `peppol` deliveries; empty for other channels.",
+    }),
+}).openapi({ ref: "Delivery" });
 
 export const transmittedDocumentResponse = z.object({
     id: z.string().openapi({
@@ -101,7 +157,7 @@ export const transmittedDocumentResponse = z.object({
         description: "The outcome of validating the document against the rules of its document type. Null when the document was not validated.",
     }),
     sentOverPeppol: z.boolean().openapi({
-        description: "Whether the document travelled over the Peppol network. False for a document that was only delivered by email.",
+        description: "Whether the document was handed over to the Peppol network. False for a document that was only delivered by email. Whether it reached the recipient is what `deliveryStatus` and `deliveries` say.",
         example: true,
     }),
     sentOverEmail: z.boolean().openapi({
@@ -129,5 +185,9 @@ export const transmittedDocumentResponse = z.object({
     }),
     reporting: frenchReportingStatusResponse.nullable().openapi({
         description: "Where a French e-reporting report stands with the tax administration. Null for documents that are not reports.",
+    }),
+    deliveryStatus: deliveryStatusResponse,
+    deliveries: z.array(deliveryResponse).openapi({
+        description: "Where an outgoing document stands with each recipient: one entry per channel and address it was sent to. Empty for incoming documents and filed reports. `sentOverPeppol` says the document was handed to the network; a delivery says whether it arrived.",
     }),
 });

--- a/api/internal/arratech-webhook.ts
+++ b/api/internal/arratech-webhook.ts
@@ -10,12 +10,46 @@ import { UserFacingError } from "@directory/utils/util";
 import { downloadBusinessDocument } from "@peppol/data/at/ap";
 import { getArratechConfig } from "@peppol/data/at/client";
 import { recordProviderSentTransaction } from "@peppol/data/provider-sent";
+import {
+  applyProviderDeliveryReport,
+  arratechFailure,
+} from "@peppol/data/deliveries";
 import { receivingPipeline } from "@peppol/utils/pipelines/receiving";
 
 const server = new Server();
 
 const RECEIVED_EVENT_TYPE = "transaction.received";
 const SENT_EVENT_TYPE = "transaction.sent";
+// Reported for an outbound transaction the API accepted that then failed validation
+// or delivery. Neither of the events above is emitted for it, so this one is what
+// tells us a send did not arrive.
+const SEND_FAILED_EVENT_TYPE = "transaction.send_failed";
+
+const PROCESSED_EVENT_TYPES: ReadonlySet<string> = new Set([
+  RECEIVED_EVENT_TYPE,
+  SENT_EVENT_TYPE,
+  SEND_FAILED_EVENT_TYPE,
+]);
+
+// The provider's customer-facing error for a failed transaction. Present on a failure
+// event only when the provider has details, and omitted rather than null otherwise.
+// Mapped to a delivery failure by its category (see data/deliveries/model).
+const serviceErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  category: z.string(),
+});
+
+// Every field but the transaction id and its status is omitted from a transaction
+// event when it does not apply, which for a failure can be most of them: a document
+// refused before it was routed has no access point or addressing to report.
+const failedTransactionPayloadSchema = z.object({
+  id: z.string(),
+  transactionStatus: z.string().optional(),
+  apId: z.string().optional(),
+  docInstanceId: z.string().optional(),
+  serviceError: serviceErrorSchema.optional(),
+});
 
 // The access point every company on this provider sends through, and therefore the
 // provider that reported the transactions this webhook queues.
@@ -122,9 +156,58 @@ server.post(
       }
 
       const eventType = parseResult.data.eventType;
-      if (eventType !== RECEIVED_EVENT_TYPE && eventType !== SENT_EVENT_TYPE) {
+      if (!PROCESSED_EVENT_TYPES.has(eventType)) {
         console.log("Ignoring Arratech webhook event type:", eventType);
         return c.json(actionSuccess({ message: "Event type not processed" }), 200);
+      }
+
+      if (eventType === SEND_FAILED_EVENT_TYPE) {
+        const failedResult = failedTransactionPayloadSchema.safeParse(parseResult.data.payload);
+        if (!failedResult.success) {
+          console.error("Invalid failed transaction payload:", failedResult.error);
+          return c.json(actionFailure("Invalid transaction payload: " + failedResult.error.message), 400);
+        }
+        const failed = failedResult.data;
+
+        // A failure event may omit the access point. The signature then decides the
+        // network on its own, which it can only do when exactly one secret matched;
+        // when the access point is reported it has to agree with the signature, as
+        // for every other event.
+        let useTestNetwork: boolean;
+        if (failed.apId !== undefined) {
+          const resolved = resolveUseTestNetwork(failed.apId);
+          if (resolved === null) {
+            console.warn("Ignoring Arratech webhook for unknown access point:", failed.apId);
+            return c.json(actionSuccess({ message: "Unknown access point" }), 200);
+          }
+          if (resolved ? !matchesTestSecret : !matchesProductionSecret) {
+            return c.json(actionFailure("Signature does not match the access point's network"), 401);
+          }
+          useTestNetwork = resolved;
+        } else if (matchesProductionSecret !== matchesTestSecret) {
+          useTestNetwork = matchesTestSecret;
+        } else {
+          console.error(
+            "Cannot tell which network an Arratech failure event without an access point belongs to",
+            "- ARRATECH_WEBHOOK_SECRET and ARRATECH_TEST_WEBHOOK_SECRET must be different values"
+          );
+          return c.json(actionFailure("Ambiguous webhook network"), 400);
+        }
+
+        // The transaction had been accepted, so its delivery is pending; this report
+        // is what fails it.
+        const outcome = await applyProviderDeliveryReport({
+          channel: "peppol",
+          provider: ARRATECH_ACCESS_POINT_PROVIDER,
+          providerTransactionId: failed.id,
+          useTestNetwork,
+          status: "failed",
+          failure: arratechFailure(failed.serviceError),
+          eventId: parseResult.data.id,
+          eventType,
+          payload: (parseResult.data.payload ?? {}) as Record<string, unknown>,
+        });
+        return c.json(actionSuccess({ outcome }), 200);
       }
 
       const transactionPayloadSchema = z.object({
@@ -186,7 +269,22 @@ server.post(
           docInstanceId: payload.docInstanceId ?? null,
         });
 
-        return c.json(actionSuccess({ outcome }), 200);
+        // A completed transaction is a delivered document, whoever sent it: the
+        // delivery our own send left pending is confirmed here, and the delivery a
+        // document recorded from this report just got is confirmed the same way.
+        const delivery = await applyProviderDeliveryReport({
+          channel: "peppol",
+          provider: ARRATECH_ACCESS_POINT_PROVIDER,
+          providerTransactionId: payload.id,
+          useTestNetwork,
+          status: "delivered",
+          failure: null,
+          eventId: parseResult.data.id,
+          eventType,
+          payload: (parseResult.data.payload ?? {}) as Record<string, unknown>,
+        });
+
+        return c.json(actionSuccess({ outcome, delivery }), 200);
       }
 
       if (await findTransmittedDocument(payload.id, "incoming")) {

--- a/api/send-document.ts
+++ b/api/send-document.ts
@@ -16,23 +16,24 @@ import { describeRoute } from "hono-openapi";
 import { z } from "zod";
 import { captureSendDocumentRecording } from "@peppol/data/send-document-recording";
 import { trackSendDocument } from "@peppol/utils/metrics";
+import { deliveryResponse, deliveryStatusResponse } from "./documents/shared";
 
 const server = new Server();
 
 const sendDocumentResponse = z.object({
   sentOverPeppol: z.boolean().openapi({
     description:
-      "Whether the recipient's access point accepted the document over Peppol. False when the document could not be routed or the access point refused it, in which case it was delivered by email instead.",
+      "Whether the document was handed over to the Peppol network. False when the document could not be routed or the sending access point refused it, in which case it was delivered by email instead. Handing over is not arrival: see `deliveryStatus` and `deliveries` for whether the recipient's access point acknowledged it.",
     example: true,
   }),
   sentOverEmail: z.boolean().openapi({
     description:
-      "Whether the document was also delivered by email. Email delivery happens when you configure it, either always or only as a fallback when Peppol delivery fails.",
+      "Whether the document was also sent by email in this request. Email delivery happens when you configure it, either always or only as a fallback when Peppol delivery fails. This field describes the send itself: an email fallback that goes out afterwards, when the access point reports the transmission failed, appears in `deliveries` and in `document.delivery_status_changed` events, not here.",
     example: false,
   }),
   emailRecipients: z.array(z.string()).openapi({
     description:
-      "The email addresses the document was delivered to. Empty when it was not sent by email; an address the email failed for is left out.",
+      "The email addresses the document was sent to in this request. Empty when it was not sent by email in this request; an address the mail service refused is left out. Like `sentOverEmail` this describes the send itself; `deliveries` is where every delivery of the document stands, including an email fallback sent later.",
     example: [],
   }),
   teamId: z.string().openapi({
@@ -58,6 +59,11 @@ const sendDocumentResponse = z.object({
       "The envelope ID of the transmission, also known as the SBDH instance identifier (Standard Business Document Header Instance Identifier). Null when the document was not transmitted over Peppol, and for playground teams, whose transmissions are simulated.",
     example: "9f1b3c7e-52a4-4d68-8b0f-6c9d2e4a17b5",
   }),
+  deliveryStatus: deliveryStatusResponse,
+  deliveries: z.array(deliveryResponse).openapi({
+    description:
+      "Where the document stands with each recipient: one entry per channel and address it was sent to. A Peppol delivery is `delivered` once the recipient's access point acknowledged the document and `pending` while the sending access point has not yet reported the outcome; email deliveries are `pending` once the mail was accepted for delivery. Later changes arrive as `document.delivery_status_changed` webhook events.",
+  }),
 });
 
 const sendDocumentParamSchema = z.object({
@@ -82,7 +88,7 @@ const routeDescription = describeRoute({
     ...describeValidationErrorResponse("Invalid document data provided"),
     ...describeErrorResponse(
       422,
-      "Recipient could not be reached and no email fallback was configured or possible",
+      "Recipient could not be reached and no email fallback was configured or possible. The body carries `deliveryFailure` with the channel and the failure category, the same category a later `document.delivery_status_changed` event would carry.",
     ),
   },
 });

--- a/api/webhooks/create-webhook.ts
+++ b/api/webhooks/create-webhook.ts
@@ -15,7 +15,7 @@ const server = new Server();
 
 const createWebhookRouteDescription = describeRoute({
     operationId: "createWebhook",
-    description: "Register an HTTPS endpoint that Recommand posts events to as they happen, so you do not have to poll the documents endpoints. It receives every peppol event for the team: `document.received`, `document.sent`, `document.label.assigned`, `document.label.unassigned`, `document.reporting_status_changed` and `company.verification`. There is no per-event subscription. Set a `secret` to have every delivery signed, and check that signature before acting on a request. Deliveries are retried for a while on a timeout or a 5xx; any other response is treated as final.",
+    description: "Register an HTTPS endpoint that Recommand posts events to as they happen, so you do not have to poll the documents endpoints. It receives every peppol event for the team: `document.received`, `document.sent`, `document.delivery_status_changed`, `document.label.assigned`, `document.label.unassigned`, `document.reporting_status_changed` and `company.verification`. There is no per-event subscription. Set a `secret` to have every delivery signed, and check that signature before acting on a request. Deliveries are retried for a while on a timeout or a 5xx; any other response is treated as final.",
     summary: "Create Webhook",
     tags: ["Webhooks"],
     responses: {

--- a/app/(dashboard)/transmitted-documents/[id]/page.tsx
+++ b/app/(dashboard)/transmitted-documents/[id]/page.tsx
@@ -56,7 +56,10 @@ import type { MessageLevelResponse } from "@peppol/utils/parsing/message-level-r
 import { DocumentLabelPicker } from "@peppol/components/document-label-picker";
 import { isReportingDocumentTypeKey } from "@peppol/utils/type-repository/document-types/keys";
 import { FrenchReportingStatusBadge } from "../../../../components/french-reporting-status-badge";
+import { DeliveryFailedBadge } from "../../../../components/delivery-failed-badge";
+import { DocumentDeliveries } from "../../../../components/document-deliveries";
 import type { FrenchReportingStatusSummary } from "@peppol/data/fr-reporting-submissions";
+import type { DeliveryStatus, DeliverySummary } from "@peppol/data/deliveries/model";
 import { useTranslation } from "@core/hooks/use-translation";
 import { getDocumentTypeLabel } from "@peppol/lib/client/document-type-labels";
 
@@ -66,6 +69,8 @@ const labelsClient = rc<Labels>("v1");
 type TransmittedDocumentWithLabels = TransmittedDocument & {
   labels?: Label[];
   reporting?: FrenchReportingStatusSummary | null;
+  deliveries?: DeliverySummary[];
+  deliveryStatus?: DeliveryStatus | null;
 };
 
 export default function TransmittedDocumentDetailPage() {
@@ -540,6 +545,7 @@ export default function TransmittedDocumentDetailPage() {
                 isReporting={isReportingDocumentTypeKey(doc.type)}
               />
               <FrenchReportingStatusBadge reporting={doc.reporting} />
+              <DeliveryFailedBadge deliveries={doc.deliveries} />
               {doc.labels &&
                 doc.labels.map((label) => (
                   <LabelBadge
@@ -551,6 +557,20 @@ export default function TransmittedDocumentDetailPage() {
             </div>
           </CardContent>
         </Card>
+
+        {doc.direction === "outgoing" && doc.deliveries && doc.deliveries.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{t`Deliveries`}</CardTitle>
+              <CardDescription>
+                {t`Where this document stands with each recipient it was sent to.`}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DocumentDeliveries deliveries={doc.deliveries} />
+            </CardContent>
+          </Card>
+        )}
 
         {!hasStructuredData && (
           <Alert className="border-dashed">

--- a/app/(dashboard)/transmitted-documents/page.tsx
+++ b/app/(dashboard)/transmitted-documents/page.tsx
@@ -31,6 +31,7 @@ import { TransmissionStatusIcons } from "@peppol/components/transmission-status-
 import { DocumentTypeCell } from "@peppol/components/document-type-cell";
 import { LabelBadge } from "@directory/components/label-badge";
 import { FrenchReportingStatusBadge } from "../../../components/french-reporting-status-badge";
+import { DeliveryFailedBadge } from "../../../components/delivery-failed-badge";
 import { DocumentLabelPicker } from "@peppol/components/document-label-picker";
 import {
   Popover,
@@ -892,6 +893,7 @@ export default function Page() {
                     emailRecipients={emailRecipients || undefined}
                     isReporting={isReporting}
                   />
+                  <DeliveryFailedBadge deliveries={document.deliveries} size="sm" />
                 </div>
               </div>
             );
@@ -909,6 +911,7 @@ export default function Page() {
               isReporting={isReporting}
             />
             {isReporting && <FrenchReportingStatusBadge reporting={document.reporting} size="sm" />}
+            <DeliveryFailedBadge deliveries={document.deliveries} size="sm" />
           </div>
         );
       },

--- a/components/delivery-failed-badge.tsx
+++ b/components/delivery-failed-badge.tsx
@@ -1,0 +1,55 @@
+import { Badge } from "@core/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@core/components/ui/tooltip";
+import { useTranslation } from "@core/hooks/use-translation";
+import type { DeliverySummary } from "@peppol/data/deliveries/model";
+
+type DeliveryFailedBadgeProps = {
+  deliveries: DeliverySummary[] | null | undefined;
+  size?: "sm" | "md";
+};
+
+/**
+ * Marks a document one of whose deliveries failed. The transmission icons next to it
+ * still say the document was handed to Peppol or mailed, which it was; this says it
+ * did not arrive somewhere. A pending delivery shows nothing: most are confirmed
+ * within minutes and a badge for them would only be noise.
+ */
+export function DeliveryFailedBadge({ deliveries, size = "md" }: DeliveryFailedBadgeProps) {
+  const { t } = useTranslation();
+  const failed = (deliveries ?? []).filter((delivery) => delivery.status === "failed");
+  if (failed.length === 0) {
+    return null;
+  }
+
+  const details = failed.map((delivery) => {
+    const parts = [
+      delivery.channel === "peppol"
+        ? t`Peppol delivery to ${delivery.address} failed.`
+        : t`Email delivery to ${delivery.address} failed.`,
+    ];
+    if (delivery.failure?.message) {
+      parts.push(delivery.failure.message);
+    }
+    if (delivery.failure?.providerCode) {
+      parts.push(t`Error code ${delivery.failure.providerCode}.`);
+    }
+    return { id: delivery.id, text: parts.join(" ") };
+  });
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant="destructive" className={size === "sm" ? "text-xs" : undefined}>
+          {t`Delivery failed`}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="max-w-sm space-y-1 text-xs">
+          {details.map((detail) => (
+            <p key={detail.id}>{detail.text}</p>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/components/document-deliveries.tsx
+++ b/components/document-deliveries.tsx
@@ -1,0 +1,56 @@
+import { Badge } from "@core/components/ui/badge";
+import { useTranslation } from "@core/hooks/use-translation";
+import type { DeliveryStatus, DeliverySummary } from "@peppol/data/deliveries/model";
+
+/**
+ * Where a document stands with each recipient: one line per channel and address,
+ * with what went wrong when a delivery failed.
+ */
+export function DocumentDeliveries({ deliveries }: { deliveries: DeliverySummary[] }) {
+  const { t, language } = useTranslation();
+
+  const statusLabels: Record<DeliveryStatus, string> = {
+    pending: t`Pending`,
+    delivered: t`Delivered`,
+    failed: t`Failed`,
+  };
+  const statusVariants: Record<DeliveryStatus, "default" | "secondary" | "destructive"> = {
+    pending: "secondary",
+    delivered: "default",
+    failed: "destructive",
+  };
+  const channelLabels: Record<DeliverySummary["channel"], string> = {
+    peppol: t`Peppol`,
+    email: t`Email`,
+  };
+
+  if (deliveries.length === 0) {
+    return <p className="text-sm text-muted-foreground">{t`No deliveries recorded for this document.`}</p>;
+  }
+
+  return (
+    <ul className="space-y-3">
+      {deliveries.map((delivery) => (
+        <li key={delivery.id} className="space-y-1 text-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium">{channelLabels[delivery.channel]}</span>
+            <span className="break-all text-muted-foreground">{delivery.address}</span>
+            <Badge variant={statusVariants[delivery.status]}>{statusLabels[delivery.status]}</Badge>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t`Status since ${new Date(delivery.statusChangedAt).toLocaleString(language, {
+              dateStyle: "medium",
+              timeStyle: "short",
+            })}`}
+          </p>
+          {delivery.failure && (
+            <div className="text-xs text-destructive">
+              {delivery.failure.message && <p>{delivery.failure.message}</p>}
+              {delivery.failure.providerCode && <p>{t`Error code ${delivery.failure.providerCode}.`}</p>}
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/data/at/ap.ts
+++ b/data/at/ap.ts
@@ -14,6 +14,11 @@ import { UserFacingError } from "@directory/utils/util";
 import { claimOutgoingEnvelope } from "@peppol/data/provider-sent/claims";
 import { fetchArratech, fetchArratechJson, getArratechConfig } from "./client";
 
+// Raised when the recipient's SMP entry for the document cannot be resolved: the
+// address is not registered, or not for this document type. Told apart from the
+// other ways a send fails so the delivery can say the recipient was not found.
+class RecipientLookupError extends UserFacingError {}
+
 // Arratech does not synchronously check receiver support before accepting a transaction, so
 // we perform the SMP-level document type and process check ourselves.
 async function checkReceiverSupportsDocumentType(options: {
@@ -35,7 +40,7 @@ async function checkReceiverSupportsDocumentType(options: {
     const encodedProcessId = processId.includes("::")
       ? processId
       : `${PROCESS_SCHEME}::${processId}`;
-    throw new UserFacingError(
+    throw new RecipientLookupError(
       `Failed to resolve SMP endpoint (${PARTICIPANT_SCHEME}::${receiverId}, ${DOCUMENT_SCHEME}::${docTypeId}, ${encodedProcessId})`
     );
   }
@@ -144,6 +149,8 @@ export async function sendAs4(options: {
           error instanceof Error
             ? error.message
             : "Failed to send document via AT access point",
+        category:
+          error instanceof RecipientLookupError ? "recipient_not_found" : "transport",
       },
     };
   }

--- a/data/at/client.ts
+++ b/data/at/client.ts
@@ -63,6 +63,29 @@ export async function fetchArratech(
   });
 }
 
+/**
+ * Resolves with `promise`, or rejects as soon as `signal` aborts. A response whose
+ * body never ends keeps the fetch's own promise pending, so a caller's deadline has
+ * to cover reading the body as well as receiving the headers.
+ */
+function untilAborted<T>(promise: Promise<T>, signal: AbortSignal | null | undefined): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    return Promise.reject(signal.reason ?? new Error("Request aborted"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(signal.reason ?? new Error("Request aborted"));
+    signal.addEventListener("abort", abort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+  });
+}
+
+/**
+ * Fetches JSON from the provider. A `signal` in the options bounds the whole
+ * exchange: the request, the wait for the response and the reading of its body.
+ */
 export async function fetchArratechJson<T>(
   path: string,
   options: { useTestNetwork: boolean } & RequestInit
@@ -76,9 +99,9 @@ export async function fetchArratechJson<T>(
   });
 
   if (!response.ok) {
-    const message = await getErrorMessage(response);
+    const message = await untilAborted(getErrorMessage(response), options.signal);
     throw new UserFacingError(`AT request failed: ${message}`);
   }
 
-  return await response.json();
+  return await untilAborted(response.json() as Promise<T>, options.signal);
 }

--- a/data/deliveries/backfill.ts
+++ b/data/deliveries/backfill.ts
@@ -1,0 +1,267 @@
+import { Cron } from "croner";
+import { and, asc, eq, gt, isNull, sql } from "drizzle-orm";
+import type { Logger } from "@recommand/lib/logger";
+import { db } from "@recommand/db";
+import { documentDeliveries, teamExtensions, transmittedDocuments } from "@peppol/db/schema";
+import type { AccessPointProviderId } from "@peppol/data/peppol-providers";
+import { buildOutgoingDocumentDeliveries } from "@peppol/data/outgoing-document-row";
+import { sendSystemAlert } from "@peppol/utils/system-notifications/telegram";
+
+// Deliveries for the outgoing documents that predate delivery tracking. They are
+// derived from what each document recorded about its transmission, in bounded
+// batches that each commit on their own, so the documents table is never locked
+// for longer than one batch and a deploy does not wait for history. The job keeps
+// going until no outgoing document is left without deliveries, then does nothing.
+// Documents recorded since the deploy get their deliveries with the document, so
+// only documents that have none are ever touched.
+
+/** What a document recorded about its transmission, as much of it as its deliveries need. */
+export type HistoricalOutgoingDocument = {
+  id: string;
+  teamId: string;
+  companyId: string;
+  receiverId: string | null;
+  sentOverPeppol: boolean;
+  emailRecipients: string[];
+  accessPointProvider: AccessPointProviderId;
+  apTransactionId: string | null;
+  useTestNetwork: boolean;
+  createdAt: Date;
+};
+
+/**
+ * The delivery rows of a document recorded before delivery tracking, built by the
+ * same rules as a document recorded today: a transmission through our own access
+ * point or a simulated one was acknowledged in the send and is delivered; one
+ * through an access point that reports later, recognisable by its transaction id,
+ * is pending until the reconciliation poll settles it; a document with a receiver
+ * that never went over Peppol was refused in the send and is failed; each mailed
+ * address is a pending email delivery. Everything is dated when the document was.
+ */
+export function buildHistoricalDeliveries(
+  document: HistoricalOutgoingDocument
+): (typeof documentDeliveries.$inferInsert)[] {
+  return buildOutgoingDocumentDeliveries({
+    transmittedDocumentId: document.id,
+    teamId: document.teamId,
+    company: { id: document.companyId, accessPointProvider: document.accessPointProvider },
+    document: { receiverId: document.receiverId },
+    delivery: {
+      kind: "peppol",
+      sentPeppol: document.sentOverPeppol,
+      emailRecipients: document.emailRecipients,
+      as4Response: document.apTransactionId
+        ? {
+            ok: true,
+            peppolMessageId: null,
+            peppolConversationId: null,
+            receivedPeppolSignalMessage: null,
+            sbdhInstanceIdentifier: null,
+            apTransactionId: document.apTransactionId,
+          }
+        : null,
+      peppolFailure: document.sentOverPeppol
+        ? null
+        : { category: "other", message: null, providerCode: null },
+    },
+    useTestNetwork: document.useTestNetwork,
+    now: document.createdAt,
+  }).map((row) => ({ ...row, createdAt: document.createdAt }));
+}
+
+export type BackfillBatchResult = {
+  documents: number;
+  deliveries: number;
+  /** The last document id of the batch, to continue after; null when nothing was left. */
+  lastId: string | null;
+};
+
+/** Where the batches come from and go to; the database in production, a fake in tests. */
+export type BackfillStore = {
+  /**
+   * Takes the next documents after `afterId`, in id order, that have no deliveries
+   * yet, writes their deliveries, and commits. Runs each batch as one transaction.
+   * Documents another transaction holds locked are left out, not waited for.
+   */
+  processBatch(afterId: string, limit: number): Promise<BackfillBatchResult>;
+  /**
+   * Whether any document without deliveries is left, counting the ones a batch
+   * would have left out because they were locked. A plain read, which waits for
+   * nobody.
+   */
+  hasRemaining(): Promise<boolean>;
+};
+
+export type BackfillState = {
+  /** The document id the next batch continues after; empty at the start of a pass. */
+  cursor: string;
+  /** How many deliveries the current pass has written so far. */
+  writtenThisPass: number;
+  /** Set once a full pass over the documents wrote nothing: there is nothing left. */
+  finished: boolean;
+};
+
+export function initialBackfillState(): BackfillState {
+  return { cursor: "", writtenThisPass: 0, finished: false };
+}
+
+const DEFAULT_BATCH_SIZE = 500;
+
+/**
+ * Works through the documents without deliveries until none are left or the deadline
+ * passes, keeping its place in `state` so the next run continues where this one
+ * stopped. A pass walks the documents in id order; reaching the end starts a new
+ * pass, so a batch that rolled back or a document another worker was holding is
+ * picked up. A pass that writes nothing is the last one, provided a read that skips
+ * no locked row agrees nothing is left; otherwise a document was locked throughout
+ * the pass, and the job stops for this run and walks again next time.
+ */
+export async function runDeliveryBackfill(
+  store: BackfillStore,
+  state: BackfillState,
+  options: { batchSize?: number; deadline?: Date; now?: () => Date } = {}
+): Promise<{ documents: number; deliveries: number; finished: boolean }> {
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const now = options.now ?? (() => new Date());
+  let documents = 0;
+  let deliveries = 0;
+
+  while (!state.finished && (!options.deadline || now() < options.deadline)) {
+    const batch = await store.processBatch(state.cursor, batchSize);
+    if (batch.lastId === null) {
+      // End of a pass. A pass that found nothing to write means every outgoing
+      // document has its deliveries, unless a locked one was skipped all along;
+      // otherwise walk once more from the start.
+      const nothingWritten = state.writtenThisPass === 0;
+      state.cursor = "";
+      state.writtenThisPass = 0;
+      if (!nothingWritten) {
+        continue;
+      }
+      if (await store.hasRemaining()) {
+        break;
+      }
+      state.finished = true;
+      continue;
+    }
+    state.cursor = batch.lastId;
+    state.writtenThisPass += batch.deliveries;
+    documents += batch.documents;
+    deliveries += batch.deliveries;
+  }
+  return { documents, deliveries, finished: state.finished };
+}
+
+const hasNoDeliveries = sql`not exists (select 1 from ${documentDeliveries} where ${documentDeliveries.transmittedDocumentId} = ${transmittedDocuments.id})`;
+
+/**
+ * The database as a backfill store. The documents of a batch are locked while their
+ * deliveries are written and skipped by any other worker on the same batch, so two
+ * instances running the job never write the same document twice.
+ */
+export const databaseBackfillStore: BackfillStore = {
+  async processBatch(afterId, limit) {
+    return await db.transaction(async (tx) => {
+      const documents = await tx
+        .select({
+          id: transmittedDocuments.id,
+          teamId: transmittedDocuments.teamId,
+          companyId: transmittedDocuments.companyId,
+          receiverId: transmittedDocuments.receiverId,
+          sentOverPeppol: transmittedDocuments.sentOverPeppol,
+          emailRecipients: transmittedDocuments.emailRecipients,
+          accessPointProvider: transmittedDocuments.accessPointProvider,
+          apTransactionId: transmittedDocuments.apTransactionId,
+          useTestNetwork: sql<boolean>`coalesce(${teamExtensions.useTestNetwork}, false)`,
+          createdAt: transmittedDocuments.createdAt,
+        })
+        .from(transmittedDocuments)
+        .leftJoin(teamExtensions, eq(teamExtensions.id, transmittedDocuments.teamId))
+        .where(
+          and(
+            eq(transmittedDocuments.direction, "outgoing"),
+            isNull(transmittedDocuments.externalReferenceId),
+            gt(transmittedDocuments.id, afterId),
+            hasNoDeliveries
+          )
+        )
+        .orderBy(asc(transmittedDocuments.id))
+        .limit(limit)
+        .for("update", { of: transmittedDocuments, skipLocked: true });
+      if (documents.length === 0) {
+        return { documents: 0, deliveries: 0, lastId: null };
+      }
+      const rows = documents.flatMap((document) =>
+        buildHistoricalDeliveries({ ...document, emailRecipients: document.emailRecipients ?? [] })
+      );
+      if (rows.length > 0) {
+        await tx.insert(documentDeliveries).values(rows);
+      }
+      return { documents: documents.length, deliveries: rows.length, lastId: documents.at(-1)!.id };
+    });
+  },
+
+  async hasRemaining() {
+    const [row] = await db
+      .select({ id: transmittedDocuments.id })
+      .from(transmittedDocuments)
+      .where(
+        and(
+          eq(transmittedDocuments.direction, "outgoing"),
+          isNull(transmittedDocuments.externalReferenceId),
+          hasNoDeliveries
+        )
+      )
+      .limit(1);
+    return row !== undefined;
+  },
+};
+
+// Each tick works for most of a minute and hands over to the next; the cron's guard
+// keeps a slow tick from overlapping with the next one in the same process.
+const TICK_BUDGET_MS = 45 * 1000;
+
+const state = initialBackfillState();
+
+export function initializeDeliveryBackfillCron(logger: Logger): void {
+  if (process.env.RUN_CRON !== "true") {
+    return;
+  }
+
+  new Cron(
+    "* * * * *",
+    {
+      name: "peppol.delivery-backfill",
+      protect: () => logger.warn("Skipping peppol.delivery-backfill tick: previous batch still running"),
+    },
+    async () => {
+      if (state.finished) {
+        return;
+      }
+      try {
+        const progress = await runDeliveryBackfill(databaseBackfillStore, state, {
+          deadline: new Date(Date.now() + TICK_BUDGET_MS),
+        });
+        if (progress.documents > 0) {
+          logger.info(
+            `Backfilled ${progress.deliveries} deliveries for ${progress.documents} documents`
+          );
+        }
+        if (progress.finished) {
+          logger.info("Delivery backfill complete: every outgoing document has its deliveries");
+          sendSystemAlert(
+            "Delivery Backfill Complete",
+            "Every outgoing document recorded before delivery tracking now has its deliveries. The job has nothing left to do.",
+            "info"
+          );
+        }
+      } catch (error) {
+        logger.error(
+          `Delivery backfill failed, continuing next tick: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  logger.info("Delivery backfill cron job initialized");
+}

--- a/data/deliveries/email-fallback-consume.ts
+++ b/data/deliveries/email-fallback-consume.ts
@@ -1,0 +1,121 @@
+import { and, eq, isNotNull, isNull, lt, or, sql } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { transmittedDocuments } from "@peppol/db/schema";
+
+/** When the run holding a document's request started, as the request records it. */
+const requestStartedAt = sql`(${transmittedDocuments.emailFallback}->>'startedAt')::timestamptz`;
+
+/**
+ * The statement that takes a document's email fallback request for a run: one round
+ * trip that locks the row while the request is there and not held by a live run,
+ * marks it started, and returns the request as it was before. Of two callers running
+ * it at the same time the second waits for the first's lock, then finds the request
+ * held and gets no row back. A run that started before `staleBefore` is taken to
+ * have died, and its request is taken over.
+ *
+ * `RETURNING` on an update yields the row after the update, so the value has to
+ * come from the locked selection instead, which is what the common table
+ * expression is for. Built as a function of the database so its SQL can be
+ * asserted without one.
+ */
+export function claimEmailFallbackStatement(
+  database: NodePgDatabase<Record<string, unknown>>,
+  documentId: string,
+  options: { now: Date; staleBefore: Date }
+) {
+  const taken = database.$with("taken").as(
+    database
+      .select({
+        id: transmittedDocuments.id,
+        teamId: transmittedDocuments.teamId,
+        companyId: transmittedDocuments.companyId,
+        type: transmittedDocuments.type,
+        senderId: transmittedDocuments.senderId,
+        receiverId: transmittedDocuments.receiverId,
+        envelopeId: transmittedDocuments.envelopeId,
+        emailRecipients: transmittedDocuments.emailRecipients,
+        request: transmittedDocuments.emailFallback,
+      })
+      .from(transmittedDocuments)
+      .where(
+        and(
+          eq(transmittedDocuments.id, documentId),
+          isNotNull(transmittedDocuments.emailFallback),
+          or(isNull(requestStartedAt), lt(requestStartedAt, options.staleBefore))
+        )
+      )
+      .for("update")
+  );
+  return database
+    .with(taken)
+    .update(transmittedDocuments)
+    .set({
+      emailFallback: sql`${taken.request} || jsonb_build_object('startedAt', ${options.now.toISOString()}::text)`,
+    })
+    .from(taken)
+    .where(eq(transmittedDocuments.id, taken.id))
+    .returning({
+      id: taken.id,
+      teamId: taken.teamId,
+      companyId: taken.companyId,
+      type: taken.type,
+      senderId: taken.senderId,
+      receiverId: taken.receiverId,
+      envelopeId: taken.envelopeId,
+      emailRecipients: taken.emailRecipients,
+      request: taken.request,
+    });
+}
+
+/** Notes in a document's open request that `address` is being mailed as `deliveryId`. */
+export function noteEmailFallbackAttemptStatement(
+  database: NodePgDatabase<Record<string, unknown>>,
+  documentId: string,
+  address: string,
+  deliveryId: string
+) {
+  const request = transmittedDocuments.emailFallback;
+  return database
+    .update(transmittedDocuments)
+    .set({
+      emailFallback: sql`jsonb_set(${request} || jsonb_build_object('attempts', coalesce(${request}->'attempts', '{}'::jsonb)), array['attempts', ${address}], ${JSON.stringify({ deliveryId })}::jsonb, true)`,
+    })
+    .where(and(eq(transmittedDocuments.id, documentId), isNotNull(request)));
+}
+
+/** Hands a document's request back after a failed run, keeping what it noted. */
+export function releaseEmailFallbackStatement(
+  database: NodePgDatabase<Record<string, unknown>>,
+  documentId: string
+) {
+  const request = transmittedDocuments.emailFallback;
+  return database
+    .update(transmittedDocuments)
+    .set({ emailFallback: sql`${request} - 'startedAt'` })
+    .where(and(eq(transmittedDocuments.id, documentId), isNotNull(request)));
+}
+
+/**
+ * The documents whose fallback a run started on and did not finish: the request is
+ * still there with attempts noted, and no live run holds it. A run that died left
+ * its start time; a run that failed and handed the request back left none.
+ */
+export function stalledEmailFallbacksStatement(
+  database: NodePgDatabase<Record<string, unknown>>,
+  staleBefore: Date,
+  limit: number
+) {
+  const request = transmittedDocuments.emailFallback;
+  return database
+    .select({ id: transmittedDocuments.id })
+    .from(transmittedDocuments)
+    .where(
+      and(
+        isNotNull(request),
+        sql`${request} ? 'attempts'`,
+        or(isNull(requestStartedAt), lt(requestStartedAt, staleBefore))
+      )
+    )
+    .orderBy(transmittedDocuments.id)
+    .limit(limit);
+}

--- a/data/deliveries/email-fallback-db.ts
+++ b/data/deliveries/email-fallback-db.ts
@@ -1,0 +1,240 @@
+import { writeAuditEvent } from "@core/lib/audit";
+import { publishEvent } from "@core/data/rules/events";
+import { sendDocumentEmail } from "@peppol/data/email/send-email";
+import {
+  resolveDocumentParsedWithAttachments,
+  resolveDocumentXml,
+} from "@peppol/data/offload/storage";
+import {
+  documentDeliveries,
+  teamExtensions,
+  transferEvents,
+  transmittedDocuments,
+} from "@peppol/db/schema";
+import { db } from "@recommand/db";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
+import {
+  claimEmailFallbackStatement,
+  noteEmailFallbackAttemptStatement,
+  releaseEmailFallbackStatement,
+  stalledEmailFallbacksStatement,
+} from "./email-fallback-consume";
+import {
+  EMAIL_FALLBACK_CLAIM_STALE_MS,
+  runEmailFallback,
+  type EmailFallbackDelivery,
+  type EmailFallbackDependencies,
+  type EmailFallbackOutcome,
+} from "./email-fallback";
+
+const deliverySelect = {
+  id: documentDeliveries.id,
+  address: documentDeliveries.address,
+  status: documentDeliveries.status,
+  failureCategory: documentDeliveries.failureCategory,
+  failureMessage: documentDeliveries.failureMessage,
+  provider: documentDeliveries.provider,
+  providerTransactionId: documentDeliveries.providerTransactionId,
+};
+
+const databaseDependencies: EmailFallbackDependencies = {
+  async claim(documentId, options) {
+    // Taken and marked started in one statement: the row is only returned to the
+    // one caller that found the request open (see email-fallback-consume).
+    const [document] = await claimEmailFallbackStatement(db, documentId, options);
+    if (!document || !document.request) {
+      return null;
+    }
+    const [team] = await db
+      .select({
+        isPlayground: teamExtensions.isPlayground,
+        useTestNetwork: teamExtensions.useTestNetwork,
+      })
+      .from(teamExtensions)
+      .where(eq(teamExtensions.id, document.teamId))
+      .limit(1);
+    return {
+      ...document,
+      request: document.request,
+      emailRecipients: document.emailRecipients ?? [],
+      isPlayground: team?.isPlayground ?? false,
+      useTestNetwork: team?.useTestNetwork ?? false,
+    };
+  },
+
+  async noteAttempt(documentId, address, deliveryId) {
+    await noteEmailFallbackAttemptStatement(db, documentId, address, deliveryId);
+  },
+
+  async recordedDelivery(deliveryId) {
+    const [row] = await db
+      .select(deliverySelect)
+      .from(documentDeliveries)
+      .where(eq(documentDeliveries.id, deliveryId))
+      .limit(1);
+    return row ?? null;
+  },
+
+  async loadPayload(documentId) {
+    const [document] = await db
+      .select({
+        xml: transmittedDocuments.xml,
+        xmlLocation: transmittedDocuments.xmlLocation,
+        parsed: transmittedDocuments.parsed,
+        attachmentsLocation: transmittedDocuments.attachmentsLocation,
+        s3KeyPrefix: transmittedDocuments.s3KeyPrefix,
+      })
+      .from(transmittedDocuments)
+      .where(eq(transmittedDocuments.id, documentId))
+      .limit(1);
+    if (!document) {
+      return { xml: null, parsed: null };
+    }
+    const [xml, parsed] = await Promise.all([
+      resolveDocumentXml(document),
+      resolveDocumentParsedWithAttachments(document),
+    ]);
+    return { xml, parsed: parsed ?? null };
+  },
+
+  async sendEmail(options) {
+    await sendDocumentEmail(options);
+  },
+
+  async recordDelivery(row) {
+    // A row with this id was written by a run that stopped right after; it stands.
+    await db.insert(documentDeliveries).values(row).onConflictDoNothing({ target: documentDeliveries.id });
+    const [written] = await db
+      .select(deliverySelect)
+      .from(documentDeliveries)
+      .where(eq(documentDeliveries.id, row.id!))
+      .limit(1);
+    return written!;
+  },
+
+  async finish({ document, deliveries, transferEvents: billing, sent }) {
+    return await db.transaction(async (tx) => {
+      // The request is cleared first, and only if it is still there: the run that
+      // finds it gone was beaten to it, and writes nothing. The document's own email
+      // fields keep telling the truth: it was mailed, to these addresses on top of
+      // any it was mailed to before.
+      const [closed] = await tx
+        .update(transmittedDocuments)
+        .set({
+          emailFallback: null,
+          ...(sent.length
+            ? {
+                sentOverEmail: true,
+                // A list interpolated straight into `sql` becomes one parameter per
+                // element; the addresses have to reach the statement as one array.
+                emailRecipients: sql`array_cat(${transmittedDocuments.emailRecipients}, ${sql.param(sent)}::text[])`,
+              }
+            : {}),
+        })
+        .where(
+          and(eq(transmittedDocuments.id, document.id), isNotNull(transmittedDocuments.emailFallback))
+        )
+        .returning({ id: transmittedDocuments.id });
+      if (!closed) {
+        return false;
+      }
+      if (billing.length) {
+        await tx.insert(transferEvents).values(billing);
+      }
+      for (const delivery of deliveries) {
+        await publishDeliveryEvent(tx, document, delivery);
+      }
+      return true;
+    });
+  },
+
+  async release(documentId) {
+    await releaseEmailFallbackStatement(db, documentId);
+  },
+
+  async audit({ documentId, teamId, sent, failed }) {
+    await writeAuditEvent({
+      action: "update",
+      subsystem: "peppol.documents",
+      objectType: "peppol.document",
+      objectId: documentId,
+      teamId,
+      reasonCode: "email_fallback_sent",
+      metadata: {
+        sent,
+        failed: failed.map((entry) => entry.address),
+      },
+    });
+  },
+};
+
+async function publishDeliveryEvent(
+  tx: Parameters<typeof publishEvent>[1]["tx"],
+  document: Parameters<EmailFallbackDependencies["finish"]>[0]["document"],
+  delivery: EmailFallbackDelivery
+) {
+  await publishEvent("peppol.document.delivery_status.v1", {
+    teamId: document.teamId,
+    aggregateType: "peppol.document",
+    aggregateId: document.id,
+    idempotencyKey: `peppol.document.delivery_status:${delivery.id}:${delivery.status}`,
+    payload: {
+      companyId: document.companyId,
+      docType: document.type,
+      senderId: document.senderId,
+      receiverId: document.receiverId,
+      envelopeId: document.envelopeId,
+      deliveryId: delivery.id,
+      channel: "email",
+      address: delivery.address,
+      status: delivery.status,
+      previousStatus: null,
+      failure:
+        delivery.status === "failed"
+          ? {
+              category: delivery.failureCategory ?? "transport",
+              message: delivery.failureMessage,
+              providerCode: null,
+            }
+          : null,
+    },
+    tx,
+  });
+}
+
+/**
+ * Sends the email fallback a document's sender asked for, now that its Peppol
+ * transmission has failed, or resumes a run of it that stopped. Nothing happens
+ * for a document without one, or whose fallback another run is sending right now.
+ */
+export async function runEmailFallbackForDocument(
+  documentId: string
+): Promise<EmailFallbackOutcome> {
+  return await runEmailFallback(documentId, databaseDependencies);
+}
+
+/**
+ * Resumes the fallbacks that a stopped run left half done, a few at a time. Each
+ * is resumed on its own, so one that fails again does not hold up the others.
+ */
+export async function resumeStalledEmailFallbacks(
+  limit = 20,
+  now: Date = new Date()
+): Promise<{ found: number; resumed: number }> {
+  const stalled = await stalledEmailFallbacksStatement(
+    db,
+    new Date(now.getTime() - EMAIL_FALLBACK_CLAIM_STALE_MS),
+    limit
+  );
+  let resumed = 0;
+  for (const { id } of stalled) {
+    try {
+      if ((await runEmailFallbackForDocument(id)).kind === "sent") {
+        resumed += 1;
+      }
+    } catch (error) {
+      console.error(`Failed to resume the email fallback of document ${id}:`, error);
+    }
+  }
+  return { found: stalled.length, resumed };
+}

--- a/data/deliveries/email-fallback.ts
+++ b/data/deliveries/email-fallback.ts
@@ -1,0 +1,282 @@
+import { ulid } from "ulid";
+import {
+  buildOutgoingTransferEvents,
+  type OutgoingDocumentPayload,
+} from "@peppol/data/outgoing-document-row";
+import type { documentDeliveries, transferEvents } from "@peppol/db/schema";
+import type { ParsedDocument } from "@peppol/utils/document-filename";
+import type { StoredDocumentType } from "@peppol/utils/type-repository/document-types/types";
+
+// The email a sender asked for in case the Peppol transmission fails. When the
+// access point refuses the transmission in the send itself the sending pipeline
+// mails it right away; when the access point accepts the transmission and reports
+// the failure later, the request waits with the document and is acted on here.
+// This is the one automatic action a failure triggers, it runs once, and it only
+// ever goes to the addresses the sender gave. Nothing is resent over Peppol.
+//
+// A run can stop halfway: the process dies, or the database refuses the write that
+// records what was mailed. A message the mail service accepted must then still be
+// recorded and billed, and must never be mailed a second time. So the request is
+// not deleted when a run takes it but marked as started, every address is noted in
+// it before its message leaves, the delivery row of an accepted message is written
+// on its own right away, and the bookkeeping that closes the request (billing, the
+// document's email fields, the events) is one transaction that only the run which
+// still finds the request open gets to commit. A later run, explicit or from the
+// drain of stalled requests, picks up where the stopped one left off.
+
+/** What a run noted about one address before mailing it. */
+export type EmailFallbackAttempt = {
+  /** The delivery the message is sent as; its row exists once the service accepted it. */
+  deliveryId: string;
+};
+
+export type EmailFallbackRequest = {
+  to: string[];
+  subject?: string;
+  htmlBody?: string;
+  /** Set while a run holds the request; a stopped run leaves it, and a later run takes over once it is stale. */
+  startedAt?: string;
+  /** Per address, the delivery it is or was sent as. Noted before mailing, so no address is ever mailed twice. */
+  attempts?: Record<string, EmailFallbackAttempt>;
+};
+
+/**
+ * How long a run may hold the request before another run may assume it died. A
+ * run mails a handful of messages and writes a few rows; minutes is generous.
+ */
+export const EMAIL_FALLBACK_CLAIM_STALE_MS = 15 * 60 * 1000;
+
+/**
+ * The fallback to keep with a document, or null when there is nothing to keep: the
+ * email was not asked for, was asked for unconditionally and has gone out, or the
+ * transmission was refused in the send and the email has gone out for that reason.
+ * An address named twice is mailed once.
+ */
+export function emailFallbackRequest(
+  email: { when: "always" | "on_peppol_failure"; to: string[]; subject?: string; htmlBody?: string } | null | undefined,
+  sentPeppol: boolean
+): EmailFallbackRequest | null {
+  if (!email || email.when !== "on_peppol_failure" || !sentPeppol || email.to.length === 0) {
+    return null;
+  }
+  return {
+    to: [...new Set(email.to)],
+    ...(email.subject !== undefined ? { subject: email.subject } : {}),
+    ...(email.htmlBody !== undefined ? { htmlBody: email.htmlBody } : {}),
+  };
+}
+
+/** The document a fallback is sent for, as taken together with its request. */
+export type EmailFallbackDocument = {
+  id: string;
+  teamId: string;
+  companyId: string;
+  type: StoredDocumentType;
+  senderId: string;
+  receiverId: string | null;
+  envelopeId: string | null;
+  emailRecipients: string[];
+  isPlayground: boolean;
+  useTestNetwork: boolean;
+  request: EmailFallbackRequest;
+};
+
+export type EmailFallbackDeliveryRow = typeof documentDeliveries.$inferInsert;
+export type EmailFallbackTransferEventRow = typeof transferEvents.$inferInsert;
+
+/** An email delivery the fallback wrote or found, as much of it as closing the request needs. */
+export type EmailFallbackDelivery = Pick<
+  typeof documentDeliveries.$inferSelect,
+  "id" | "address" | "status" | "failureCategory" | "failureMessage" | "provider" | "providerTransactionId"
+>;
+
+/** What the fallback needs from its surroundings; the database and the mail service in production. */
+export type EmailFallbackDependencies = {
+  /**
+   * Takes the document's fallback request for this run, marking it started in the
+   * same statement, so of two callers only one gets it. Null when the document has
+   * none, another run holds it and started after `staleBefore`, or it was finished.
+   */
+  claim(documentId: string, options: { now: Date; staleBefore: Date }): Promise<EmailFallbackDocument | null>;
+  /** Notes in the request that `address` is being mailed as `deliveryId`, before the message leaves. */
+  noteAttempt(documentId: string, address: string, deliveryId: string): Promise<void>;
+  /** The delivery a noted attempt produced, if its message was accepted or refused and recorded. */
+  recordedDelivery(deliveryId: string): Promise<EmailFallbackDelivery | null>;
+  /** The document's content as sent, with its attachments. */
+  loadPayload(documentId: string): Promise<{ xml: string | null; parsed: ParsedDocument | null }>;
+  sendEmail(options: {
+    to: string;
+    subject?: string;
+    htmlBody?: string;
+    xmlDocument: string | null;
+    type: StoredDocumentType;
+    parsedDocument: ParsedDocument | null;
+    isPlayground: boolean;
+  }): Promise<void>;
+  /** Writes one delivery row on its own, and leaves a row with that id alone if it exists. */
+  recordDelivery(row: EmailFallbackDeliveryRow): Promise<EmailFallbackDelivery>;
+  /**
+   * Closes the request, as one transaction: the transfer events that bill the
+   * messages that went out, the document's email fields, the events that announce
+   * each delivery, and the request itself cleared. Returns false without writing
+   * anything when the request was already closed by another run.
+   */
+  finish(outcome: {
+    document: EmailFallbackDocument;
+    deliveries: EmailFallbackDelivery[];
+    transferEvents: EmailFallbackTransferEventRow[];
+    sent: string[];
+  }): Promise<boolean>;
+  /** Gives the request up after a run failed, so a retry need not wait for the claim to go stale. */
+  release(documentId: string): Promise<void>;
+  audit(event: {
+    documentId: string;
+    teamId: string;
+    sent: string[];
+    failed: { address: string; message: string }[];
+  }): Promise<void>;
+};
+
+export type EmailFallbackOutcome =
+  /** No fallback was waiting on the document, another run holds it, or it was finished. */
+  | { kind: "none" }
+  | {
+      kind: "sent";
+      sent: string[];
+      failed: { address: string; message: string }[];
+      /** The email deliveries this fallback stands for, as written. */
+      deliveries: EmailFallbackDelivery[];
+    };
+
+/** The reason recorded for an address a stopped run had started on without recording the service's answer. */
+export const OUTCOME_NOT_RECORDED_MESSAGE =
+  "The message was handed to the mail service, but whether the service accepted it was not recorded before the run stopped.";
+
+export function newEmailDeliveryId(): string {
+  return "dlv_" + ulid();
+}
+
+/**
+ * Sends the email a document's sender asked for in case its Peppol transmission
+ * failed, exactly as the sending pipeline would have in the send itself, and records
+ * one email delivery per address: pending for an address the mail service accepted,
+ * failed for one it refused. Only the emails that went out are billed. Never sends
+ * twice: an address is noted in the request before it is mailed, and a run that
+ * resumes a stopped one only mails addresses no run has started on. An address a
+ * stopped run had started on without recording the service's answer is recorded as
+ * failed rather than mailed again.
+ */
+export async function runEmailFallback(
+  documentId: string,
+  deps: EmailFallbackDependencies,
+  now: Date = new Date()
+): Promise<EmailFallbackOutcome> {
+  const document = await deps.claim(documentId, {
+    now,
+    staleBefore: new Date(now.getTime() - EMAIL_FALLBACK_CLAIM_STALE_MS),
+  });
+  if (!document) {
+    return { kind: "none" };
+  }
+
+  try {
+    const payload = await deps.loadPayload(document.id);
+    const base = {
+      transmittedDocumentId: document.id,
+      teamId: document.teamId,
+      companyId: document.companyId,
+      channel: "email" as const,
+      statusChangedAt: now,
+      useTestNetwork: document.useTestNetwork,
+    };
+
+    const deliveries: EmailFallbackDelivery[] = [];
+    for (const address of document.request.to) {
+      const attempt = document.request.attempts?.[address];
+      if (attempt) {
+        const recorded = await deps.recordedDelivery(attempt.deliveryId);
+        if (recorded) {
+          deliveries.push(recorded);
+          continue;
+        }
+        // Started by a run that stopped before the service's answer was written.
+        // The message may or may not have gone out; mailing it again could deliver
+        // it twice, so the delivery is closed as failed with that reason.
+        deliveries.push(
+          await deps.recordDelivery({
+            ...base,
+            id: attempt.deliveryId,
+            address,
+            status: "failed",
+            failureCategory: "other",
+            failureMessage: OUTCOME_NOT_RECORDED_MESSAGE,
+          })
+        );
+        continue;
+      }
+
+      const deliveryId = newEmailDeliveryId();
+      await deps.noteAttempt(document.id, address, deliveryId);
+      let row: EmailFallbackDeliveryRow;
+      try {
+        await deps.sendEmail({
+          to: address,
+          subject: document.request.subject,
+          htmlBody: document.request.htmlBody,
+          xmlDocument: payload.xml,
+          type: document.type,
+          parsedDocument: payload.parsed,
+          isPlayground: document.isPlayground,
+        });
+        row = { ...base, id: deliveryId, address, status: "pending" };
+      } catch (error) {
+        console.error("Failed to send the fallback email:", error);
+        row = {
+          ...base,
+          id: deliveryId,
+          address,
+          status: "failed",
+          failureCategory: "transport",
+          failureMessage: error instanceof Error ? error.message : String(error),
+        };
+      }
+      // Written right away, so a run that stops after this point has left the
+      // service's answer behind for the run that resumes it.
+      deliveries.push(await deps.recordDelivery(row));
+    }
+
+    const sent = deliveries
+      .filter((delivery) => delivery.status === "pending")
+      .map((delivery) => delivery.address);
+    const failed = deliveries
+      .filter((delivery) => delivery.status === "failed")
+      .map((delivery) => ({ address: delivery.address, message: delivery.failureMessage ?? "" }));
+    // Billed the way the sending pipeline bills an email: one event per address the
+    // mail service accepted, none in a playground.
+    const transferEvents = document.isPlayground
+      ? []
+      : buildOutgoingTransferEvents({
+          teamId: document.teamId,
+          companyId: document.companyId,
+          transmittedDocumentId: document.id,
+          document: { type: document.type, parsed: payload.parsed } as Pick<OutgoingDocumentPayload, "type" | "parsed">,
+          delivery: { kind: "peppol", sentPeppol: false, emailRecipients: sent, as4Response: null },
+        });
+
+    const finished = await deps.finish({ document, deliveries, transferEvents, sent });
+    if (!finished) {
+      return { kind: "none" };
+    }
+    await deps.audit({ documentId: document.id, teamId: document.teamId, sent, failed });
+    return { kind: "sent", sent, failed, deliveries };
+  } catch (error) {
+    // Whatever was recorded stays; the request is handed back so the next run,
+    // explicit or from the drain, resumes without waiting for the claim to go stale.
+    try {
+      await deps.release(document.id);
+    } catch (releaseError) {
+      console.error("Failed to release the email fallback request:", releaseError);
+    }
+    throw error;
+  }
+}

--- a/data/deliveries/index.ts
+++ b/data/deliveries/index.ts
@@ -1,0 +1,365 @@
+import { writeAuditEvent } from "@core/lib/audit";
+import { publishEvent } from "@core/data/rules/events";
+import type { Tx } from "@core/data/rules/db";
+import {
+  documentDeliveries,
+  providerDeliveryReports,
+  transmittedDocuments,
+} from "@peppol/db/schema";
+import { sendSystemAlert } from "@peppol/utils/system-notifications/telegram";
+import { db } from "@recommand/db";
+import { and, eq, inArray, lt } from "drizzle-orm";
+import { runEmailFallbackForDocument } from "./email-fallback-db";
+import {
+  attachDeliveries,
+  deliveryStatusMoves,
+  type DeliveryRow,
+  type DocumentDelivery,
+  type ProviderDeliveryReport,
+  type WithDeliveries,
+} from "./model";
+
+export * from "./model";
+
+// A report waits for its document for as long as a send can plausibly take to
+// record it, with a wide margin. Older ones belong to transactions that will never
+// get a document here and are dropped.
+const STAGED_REPORT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type ProviderReportOutcome =
+  /** The delivery moved to the reported status, and its owner was told. */
+  | "applied"
+  /** The delivery was already in a final status: a repeat or a stale report. */
+  | "unchanged"
+  /** No delivery has been recorded for the transaction yet; the report waits for it. */
+  | "staged";
+
+/** The document a delivery belongs to, as much of it as a status change needs. */
+type DeliveryDocument = {
+  id: string;
+  type: string;
+  senderId: string;
+  receiverId: string | null;
+  envelopeId: string | null;
+};
+
+const deliveryRowSelect = {
+  id: documentDeliveries.id,
+  transmittedDocumentId: documentDeliveries.transmittedDocumentId,
+  channel: documentDeliveries.channel,
+  address: documentDeliveries.address,
+  status: documentDeliveries.status,
+  statusChangedAt: documentDeliveries.statusChangedAt,
+  failureCategory: documentDeliveries.failureCategory,
+  failureMessage: documentDeliveries.failureMessage,
+  failureProviderCode: documentDeliveries.failureProviderCode,
+};
+
+/**
+ * Writes the deliveries of a freshly recorded document. Runs inside the transaction
+ * that writes the document, so a document never exists without its deliveries.
+ */
+export async function insertDocumentDeliveries(
+  tx: Tx,
+  rows: (typeof documentDeliveries.$inferInsert)[]
+): Promise<DocumentDelivery[]> {
+  if (rows.length === 0) {
+    return [];
+  }
+  return await tx.insert(documentDeliveries).values(rows).returning();
+}
+
+export async function listDocumentDeliveries(
+  transmittedDocumentId: string
+): Promise<DocumentDelivery[]> {
+  return await db
+    .select()
+    .from(documentDeliveries)
+    .where(eq(documentDeliveries.transmittedDocumentId, transmittedDocumentId))
+    .orderBy(documentDeliveries.createdAt, documentDeliveries.id);
+}
+
+/**
+ * Adds to each document its deliveries and their summary, in one query for the
+ * whole page. Incoming documents never have any and are not looked up.
+ */
+export async function withDocumentDeliveries<
+  T extends {
+    id: string;
+    direction: "incoming" | "outgoing";
+    peppolMessageId?: string | null;
+    peppolConversationId?: string | null;
+    envelopeId?: string | null;
+  },
+>(documents: T[]): Promise<WithDeliveries<T>[]> {
+  const outgoingIds = documents
+    .filter((document) => document.direction === "outgoing")
+    .map((document) => document.id);
+  const rows: DeliveryRow[] = outgoingIds.length
+    ? await db
+        .select(deliveryRowSelect)
+        .from(documentDeliveries)
+        .where(inArray(documentDeliveries.transmittedDocumentId, outgoingIds))
+        .orderBy(documentDeliveries.createdAt, documentDeliveries.id)
+    : [];
+  return attachDeliveries(documents, rows);
+}
+
+async function findDeliveryByProviderTransaction(
+  providerTransactionId: string
+): Promise<{ delivery: DocumentDelivery; document: DeliveryDocument } | undefined> {
+  const [row] = await db
+    .select({
+      delivery: documentDeliveries,
+      document: {
+        id: transmittedDocuments.id,
+        type: transmittedDocuments.type,
+        senderId: transmittedDocuments.senderId,
+        receiverId: transmittedDocuments.receiverId,
+        envelopeId: transmittedDocuments.envelopeId,
+      },
+    })
+    .from(documentDeliveries)
+    .innerJoin(
+      transmittedDocuments,
+      eq(transmittedDocuments.id, documentDeliveries.transmittedDocumentId)
+    )
+    .where(eq(documentDeliveries.providerTransactionId, providerTransactionId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Moves a delivery to the status a report gives it, and tells the document's owner.
+ * The move is a conditional update on the status the delivery was read in, so of two
+ * callers applying reports to the same delivery only one gets to move it, and only
+ * that one publishes the event: the customer hears about a change exactly once.
+ * Returns false when the delivery was already final.
+ */
+async function applyReportToDelivery(
+  delivery: DocumentDelivery,
+  document: DeliveryDocument,
+  report: Pick<
+    ProviderDeliveryReport,
+    "status" | "failure" | "eventId" | "eventType" | "payload"
+  >
+): Promise<boolean> {
+  if (!deliveryStatusMoves(delivery.status, report.status)) {
+    return false;
+  }
+  const now = new Date();
+  const moved = await db.transaction(async (tx) => {
+    const [updated] = await tx
+      .update(documentDeliveries)
+      .set({
+        status: report.status,
+        statusChangedAt: now,
+        failureCategory: report.failure?.category ?? null,
+        failureMessage: report.failure?.message ?? null,
+        failureProviderCode: report.failure?.providerCode ?? null,
+        providerEventId: report.eventId,
+        providerEventType: report.eventType,
+        providerPayload: report.payload,
+        lastCheckedAt: now,
+      })
+      .where(
+        and(
+          eq(documentDeliveries.id, delivery.id),
+          eq(documentDeliveries.status, delivery.status)
+        )
+      )
+      .returning();
+    if (!updated) {
+      return null;
+    }
+    await publishEvent("peppol.document.delivery_status.v1", {
+      teamId: delivery.teamId,
+      aggregateType: "peppol.document",
+      aggregateId: document.id,
+      idempotencyKey: `peppol.document.delivery_status:${delivery.id}:${report.status}`,
+      payload: {
+        companyId: delivery.companyId,
+        docType: document.type,
+        senderId: document.senderId,
+        receiverId: document.receiverId,
+        envelopeId: document.envelopeId,
+        deliveryId: delivery.id,
+        channel: delivery.channel,
+        address: delivery.address,
+        status: report.status,
+        previousStatus: delivery.status,
+        failure: report.failure,
+      },
+      tx,
+    });
+    return updated;
+  });
+  if (!moved) {
+    return false;
+  }
+
+  await writeAuditEvent({
+    action: "update",
+    subsystem: "peppol.documents",
+    objectType: "peppol.document",
+    objectId: document.id,
+    teamId: delivery.teamId,
+    reasonCode: report.status === "failed" ? "delivery_failed" : "delivery_confirmed",
+    metadata: {
+      deliveryId: delivery.id,
+      channel: delivery.channel,
+      provider: delivery.provider,
+      providerTransactionId: delivery.providerTransactionId,
+      status: report.status,
+      previousStatus: delivery.status,
+      failureCategory: report.failure?.category ?? null,
+      failureProviderCode: report.failure?.providerCode ?? null,
+    },
+  });
+  if (report.status === "failed") {
+    sendSystemAlert(
+      "Document Delivery Failed",
+      `The ${delivery.channel} delivery of document ${document.id} (transaction ${delivery.providerTransactionId}) failed after the provider had accepted it.\n` +
+        `${report.failure?.providerCode ?? "no code"} ${report.failure?.category ?? "other"}: ${report.failure?.message ?? "no error details"}`,
+      "warning"
+    );
+    // The failure is committed above whatever happens here: the fallback email the
+    // sender asked for is sent now, once, and a problem with it is reported rather
+    // than allowed to fail the report that carried the failure.
+    if (delivery.channel === "peppol") {
+      await runEmailFallbackAfterFailure(document.id);
+    }
+  }
+  return true;
+}
+
+/**
+ * Sends, or resumes, the email fallback of a document whose Peppol delivery failed.
+ * A problem with it is logged and alerted, never thrown: the failure that triggered
+ * it is already committed, and the request stays with the document for a retry.
+ */
+async function runEmailFallbackAfterFailure(documentId: string): Promise<void> {
+  try {
+    await runEmailFallbackForDocument(documentId);
+  } catch (error) {
+    console.error("Failed to send the email fallback:", error);
+    sendSystemAlert(
+      "Email Fallback Failed",
+      `The email fallback for document ${documentId} could not be sent after its Peppol delivery failed: ${error instanceof Error ? error.message : String(error)}`,
+      "error"
+    );
+  }
+}
+
+/**
+ * Applies what a provider reported about a transaction to the delivery it belongs
+ * to. When no delivery has that transaction yet, because the report overtook the
+ * send that is still recording its document, the report is kept and applied once
+ * the document's deliveries are written. A retried report finds the delivery final
+ * and changes nothing. Nothing is ever resent: the document's owner is told and
+ * decides what to do.
+ */
+export async function applyProviderDeliveryReport(
+  report: ProviderDeliveryReport
+): Promise<ProviderReportOutcome> {
+  const found = await findDeliveryByProviderTransaction(report.providerTransactionId);
+  if (found) {
+    if (await applyReportToDelivery(found.delivery, found.document, report)) {
+      return "applied";
+    }
+    // A repeated failure report changes nothing, but the fallback its first
+    // arrival should have sent may not have gone out, or may have stopped halfway:
+    // the request is still with the document then, and this is its chance. When
+    // it went out and was closed, this finds nothing to do.
+    if (found.delivery.channel === "peppol" && found.delivery.status === "failed") {
+      await runEmailFallbackAfterFailure(found.document.id);
+    }
+    return "unchanged";
+  }
+
+  await db
+    .insert(providerDeliveryReports)
+    .values({
+      providerTransactionId: report.providerTransactionId,
+      channel: report.channel,
+      provider: report.provider,
+      useTestNetwork: report.useTestNetwork,
+      status: report.status,
+      failureCategory: report.failure?.category ?? null,
+      failureMessage: report.failure?.message ?? null,
+      failureProviderCode: report.failure?.providerCode ?? null,
+      eventId: report.eventId,
+      eventType: report.eventType,
+      payload: report.payload,
+    })
+    .onConflictDoNothing();
+
+  // The document may have been recorded between the lookup above and the insert.
+  // Its recording applies staged reports too, so whichever of the two finds the
+  // delivery first moves it and the other finds it final.
+  const applied = await applyStagedDeliveryReport(report.providerTransactionId);
+  if (applied === "staged") {
+    sendSystemAlert(
+      "Delivery Report For Unrecorded Transaction",
+      `The provider reported transaction ${report.providerTransactionId} as ${report.status} before any document was recorded for it. ` +
+        `The report is applied once the document is recorded.\n` +
+        `${report.failure?.providerCode ?? "no code"} ${report.failure?.category ?? ""}: ${report.failure?.message ?? "no error details"}`,
+      "warning"
+    );
+  }
+  return applied;
+}
+
+/**
+ * Applies the report a provider made for a transaction before its document existed,
+ * if there is one. Called after a document's deliveries are written, and after a
+ * report is staged in case the document arrived in the meantime.
+ */
+export async function applyStagedDeliveryReport(
+  providerTransactionId: string
+): Promise<ProviderReportOutcome> {
+  const [staged] = await db
+    .select()
+    .from(providerDeliveryReports)
+    .where(eq(providerDeliveryReports.providerTransactionId, providerTransactionId))
+    .limit(1);
+  if (!staged) {
+    return "unchanged";
+  }
+  const found = await findDeliveryByProviderTransaction(providerTransactionId);
+  if (!found) {
+    return "staged";
+  }
+  const applied = await applyReportToDelivery(found.delivery, found.document, {
+    status: staged.status as ProviderDeliveryReport["status"],
+    failure:
+      staged.status === "failed"
+        ? {
+            category: staged.failureCategory ?? "other",
+            message: staged.failureMessage,
+            providerCode: staged.failureProviderCode,
+          }
+        : null,
+    eventId: staged.eventId,
+    eventType: staged.eventType,
+    payload: staged.payload,
+  });
+  // Applied or found final: either way the report has reached its delivery.
+  await db
+    .delete(providerDeliveryReports)
+    .where(eq(providerDeliveryReports.providerTransactionId, providerTransactionId));
+  return applied ? "applied" : "unchanged";
+}
+
+export async function pruneStagedDeliveryReports(): Promise<number> {
+  const deleted = await db
+    .delete(providerDeliveryReports)
+    .where(
+      lt(
+        providerDeliveryReports.reportedAt,
+        new Date(Date.now() - STAGED_REPORT_RETENTION_MS)
+      )
+    )
+    .returning({ providerTransactionId: providerDeliveryReports.providerTransactionId });
+  return deleted.length;
+}

--- a/data/deliveries/model.ts
+++ b/data/deliveries/model.ts
@@ -1,0 +1,266 @@
+import type {
+  deliveryChannels,
+  deliveryFailureCategories,
+  deliveryStatuses,
+  documentDeliveries,
+} from "@peppol/db/schema";
+
+// The pure part of the deliveries model: what a delivery is, how a channel's report
+// moves it on, and how a document's deliveries are summarised. Nothing here touches
+// the database, so every rule can be asserted directly (see data/deliveries).
+
+export type DeliveryChannel = (typeof deliveryChannels)[number];
+export type DeliveryStatus = (typeof deliveryStatuses)[number];
+export type DeliveryFailureCategory = (typeof deliveryFailureCategories)[number];
+
+export type DocumentDelivery = typeof documentDeliveries.$inferSelect;
+
+/** The columns of a delivery its API shape is built from. */
+export type DeliveryRow = Pick<
+  DocumentDelivery,
+  | "id"
+  | "transmittedDocumentId"
+  | "channel"
+  | "address"
+  | "status"
+  | "statusChangedAt"
+  | "failureCategory"
+  | "failureMessage"
+  | "failureProviderCode"
+>;
+
+export type DeliveryFailure = {
+  category: DeliveryFailureCategory;
+  message: string | null;
+  /** The provider's own code for the failure, when it reported one. */
+  providerCode: string | null;
+};
+
+/** Identifiers of a transmission on its channel, as the API exposes them. */
+export type DeliveryReferences = {
+  peppolMessageId?: string | null;
+  peppolConversationId?: string | null;
+  envelopeId?: string | null;
+};
+
+/** A delivery as the API and the dashboard see it. */
+export type DeliverySummary = {
+  id: string;
+  channel: DeliveryChannel;
+  address: string;
+  status: DeliveryStatus;
+  statusChangedAt: string;
+  failure: DeliveryFailure | null;
+  references: DeliveryReferences;
+};
+
+/**
+ * What a provider says became of a transmission it had accepted. Reported through its
+ * webhook or fetched by the reconciliation poll; either way applied the same.
+ */
+export type ProviderDeliveryReport = {
+  channel: DeliveryChannel;
+  provider: string;
+  providerTransactionId: string;
+  useTestNetwork: boolean;
+  status: Exclude<DeliveryStatus, "pending">;
+  failure: DeliveryFailure | null;
+  /** The provider's id and name for the event that carried the report; null for a poll. */
+  eventId: string | null;
+  eventType: string | null;
+  /** The report as received, kept for support. */
+  payload: Record<string, unknown>;
+};
+
+/** The statuses a delivery can still move on from. */
+const OPEN_STATUSES: ReadonlySet<DeliveryStatus> = new Set(["pending"]);
+
+export function isOpenDeliveryStatus(status: DeliveryStatus): boolean {
+  return OPEN_STATUSES.has(status);
+}
+
+/**
+ * Whether a report moves a delivery from its current status to the reported one.
+ * Only an open delivery moves: a final status is never overwritten by a report that
+ * arrives late or twice, so a retried or out-of-order report changes nothing.
+ */
+export function deliveryStatusMoves(
+  current: DeliveryStatus,
+  reported: DeliveryStatus
+): boolean {
+  return isOpenDeliveryStatus(current) && current !== reported;
+}
+
+/**
+ * A document's delivery status, summarised across its deliveries: `delivered` when
+ * it reached the recipient over at least one channel, `failed` when every delivery
+ * failed, `pending` while any is still open, and null for a document with none.
+ */
+export function summarizeDeliveryStatus(
+  statuses: readonly DeliveryStatus[]
+): DeliveryStatus | null {
+  if (statuses.length === 0) {
+    return null;
+  }
+  if (statuses.some((status) => status === "delivered")) {
+    return "delivered";
+  }
+  if (statuses.every((status) => status === "failed")) {
+    return "failed";
+  }
+  return "pending";
+}
+
+export function deliveryFailureOf(
+  delivery: Pick<
+    DocumentDelivery,
+    "status" | "failureCategory" | "failureMessage" | "failureProviderCode"
+  >
+): DeliveryFailure | null {
+  if (delivery.status !== "failed") {
+    return null;
+  }
+  return {
+    category: delivery.failureCategory ?? "other",
+    message: delivery.failureMessage,
+    providerCode: delivery.failureProviderCode,
+  };
+}
+
+/**
+ * The references a delivery is known by on its channel. They live on the document,
+ * which is where every Peppol transmission records them; other channels have none.
+ */
+export function deliveryReferences(
+  channel: DeliveryChannel,
+  document: {
+    peppolMessageId?: string | null;
+    peppolConversationId?: string | null;
+    envelopeId?: string | null;
+  }
+): DeliveryReferences {
+  if (channel !== "peppol") {
+    return {};
+  }
+  return {
+    peppolMessageId: document.peppolMessageId ?? null,
+    peppolConversationId: document.peppolConversationId ?? null,
+    envelopeId: document.envelopeId ?? null,
+  };
+}
+
+export function toDeliverySummary(
+  delivery: Omit<DeliveryRow, "transmittedDocumentId">,
+  document: Parameters<typeof deliveryReferences>[1]
+): DeliverySummary {
+  return {
+    id: delivery.id,
+    channel: delivery.channel,
+    address: delivery.address,
+    status: delivery.status,
+    statusChangedAt: delivery.statusChangedAt.toISOString(),
+    failure: deliveryFailureOf(delivery),
+    references: deliveryReferences(delivery.channel, document),
+  };
+}
+
+export type WithDeliveries<T> = T & {
+  deliveries: DeliverySummary[];
+  deliveryStatus: DeliveryStatus | null;
+};
+
+/**
+ * Attaches to each document its deliveries and their summary. Documents without any
+ * (incoming ones, filed reports) get an empty list and a null status.
+ */
+export function attachDeliveries<
+  T extends {
+    id: string;
+    peppolMessageId?: string | null;
+    peppolConversationId?: string | null;
+    envelopeId?: string | null;
+  },
+>(documents: T[], deliveries: DeliveryRow[]): WithDeliveries<T>[] {
+  const byDocument = new Map<string, DeliverySummary[]>();
+  const documentsById = new Map(documents.map((document) => [document.id, document]));
+  for (const delivery of deliveries) {
+    const document = documentsById.get(delivery.transmittedDocumentId);
+    if (!document) continue;
+    const list = byDocument.get(document.id) ?? [];
+    list.push(toDeliverySummary(delivery, document));
+    byDocument.set(document.id, list);
+  }
+  return documents.map((document) => {
+    const list = byDocument.get(document.id) ?? [];
+    return {
+      ...document,
+      deliveries: list,
+      deliveryStatus: summarizeDeliveryStatus(list.map((delivery) => delivery.status)),
+    };
+  });
+}
+
+// --- Provider-specific interpretation -------------------------------------------
+
+/**
+ * The categories the Arratech API reports a failed transaction under, mapped to
+ * ours. Mapped by category rather than by the finer-grained code, which stays next to
+ * the failure as the provider code. Anything not listed is `other`.
+ */
+const ARRATECH_FAILURE_CATEGORIES: Record<string, DeliveryFailureCategory> = {
+  RECIPIENT_NOT_FOUND: "recipient_not_found",
+  NETWORK_LOOKUP_ERROR: "recipient_not_found",
+  DOCUMENT_TYPE_NOT_SUPPORTED: "document_not_supported",
+  VALIDATION_ERROR: "validation",
+  POLICY_VIOLATION: "validation",
+  TRANSPORT_ERROR: "transport",
+  CERTIFICATE_ERROR: "transport",
+  RECIPIENT_REJECTED: "recipient_rejected",
+  DUPLICATE: "duplicate",
+};
+
+export function categorizeArratechServiceError(
+  category: string | null | undefined
+): DeliveryFailureCategory {
+  if (!category) {
+    return "other";
+  }
+  return ARRATECH_FAILURE_CATEGORIES[category.toUpperCase()] ?? "other";
+}
+
+export type ArratechServiceError = {
+  code: string;
+  message: string;
+  category: string;
+};
+
+export function arratechFailure(
+  error: ArratechServiceError | null | undefined
+): DeliveryFailure {
+  return {
+    category: categorizeArratechServiceError(error?.category),
+    message: error?.message ?? null,
+    providerCode: error?.code ?? null,
+  };
+}
+
+/**
+ * What an Arratech transaction's status says about its delivery. `COMPLETED` is a
+ * delivery; `FAILED` and `REJECTED` are failures. Every other status, including
+ * `COMPLETED_NO_DELIVERY` whose meaning is not settled, leaves the delivery as it is
+ * and is returned as null so the caller can log it.
+ */
+export function interpretArratechTransactionStatus(transaction: {
+  transactionStatus?: string | null;
+  serviceError?: ArratechServiceError | null;
+}): Pick<ProviderDeliveryReport, "status" | "failure"> | null {
+  switch (transaction.transactionStatus?.toUpperCase()) {
+    case "COMPLETED":
+      return { status: "delivered", failure: null };
+    case "FAILED":
+    case "REJECTED":
+      return { status: "failed", failure: arratechFailure(transaction.serviceError) };
+    default:
+      return null;
+  }
+}

--- a/data/deliveries/reconcile.ts
+++ b/data/deliveries/reconcile.ts
@@ -1,0 +1,171 @@
+import { Cron } from "croner";
+import { and, eq, isNotNull, lt, or, isNull, sql } from "drizzle-orm";
+import type { Logger } from "@recommand/lib/logger";
+import { db } from "@recommand/db";
+import { documentDeliveries } from "@peppol/db/schema";
+import { fetchArratechJson, getArratechConfig } from "@peppol/data/at/client";
+import {
+  applyProviderDeliveryReport,
+  interpretArratechTransactionStatus,
+  pruneStagedDeliveryReports,
+  type ArratechServiceError,
+} from "@peppol/data/deliveries";
+import { resumeStalledEmailFallbacks } from "@peppol/data/deliveries/email-fallback-db";
+
+// The access point that reports delivery outcomes after accepting a send, and so the
+// only one whose deliveries can be left pending by a report that never arrived.
+const ARRATECH_ACCESS_POINT_PROVIDER = "at-shared-ap-fr";
+
+// A report normally follows the send within minutes. A delivery still pending an hour
+// later is one whose report was missed, and is asked about at most once an hour so
+// a transaction the provider cannot answer for does not get asked about every tick.
+const PENDING_GRACE_MS = 60 * 60 * 1000;
+const BATCH_SIZE = 100;
+// The deliveries are asked about one after the other, so a provider that keeps a
+// request open would hold up the whole batch and every tick after it. Each request
+// gets this long, response body included.
+const REQUEST_TIMEOUT_MS = 15 * 1000;
+
+type ArratechTransaction = {
+  transactionStatus?: string | null;
+  serviceError?: ArratechServiceError | null;
+};
+
+/**
+ * Asks the access point what became of the deliveries it never reported on, and
+ * applies the answer the same way its webhook would. This is also what settles the
+ * deliveries created for documents that predate delivery tracking.
+ */
+export async function reconcilePendingArratechDeliveries(
+  logger: Logger,
+  now: Date = new Date(),
+  options: { requestTimeoutMs?: number } = {}
+): Promise<{ checked: number; applied: number }> {
+  const cutoff = new Date(now.getTime() - PENDING_GRACE_MS);
+  const requestTimeoutMs = options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
+  const due = await db
+    .select({
+      id: documentDeliveries.id,
+      providerTransactionId: documentDeliveries.providerTransactionId,
+      useTestNetwork: documentDeliveries.useTestNetwork,
+    })
+    .from(documentDeliveries)
+    .where(
+      and(
+        eq(documentDeliveries.channel, "peppol"),
+        eq(documentDeliveries.status, "pending"),
+        eq(documentDeliveries.provider, ARRATECH_ACCESS_POINT_PROVIDER),
+        isNotNull(documentDeliveries.providerTransactionId),
+        lt(documentDeliveries.statusChangedAt, cutoff),
+        or(
+          isNull(documentDeliveries.lastCheckedAt),
+          lt(documentDeliveries.lastCheckedAt, cutoff)
+        )
+      )
+    )
+    .orderBy(
+      sql`coalesce(${documentDeliveries.lastCheckedAt}, ${documentDeliveries.statusChangedAt})`
+    )
+    .limit(BATCH_SIZE);
+
+  let applied = 0;
+  for (const delivery of due) {
+    const transactionId = delivery.providerTransactionId!;
+    try {
+      const config = getArratechConfig(delivery.useTestNetwork);
+      const transaction = await fetchArratechJson<ArratechTransaction>(
+        `/orgs/${config.orgId}/transactions/${encodeURIComponent(transactionId)}`,
+        {
+          method: "GET",
+          useTestNetwork: delivery.useTestNetwork,
+          signal: AbortSignal.timeout(requestTimeoutMs),
+        }
+      );
+      const outcome = interpretArratechTransactionStatus(transaction);
+      if (!outcome) {
+        logger.info(
+          `Delivery ${delivery.id} still pending: transaction ${transactionId} is ${transaction.transactionStatus ?? "without status"}`
+        );
+        continue;
+      }
+      const result = await applyProviderDeliveryReport({
+        channel: "peppol",
+        provider: ARRATECH_ACCESS_POINT_PROVIDER,
+        providerTransactionId: transactionId,
+        useTestNetwork: delivery.useTestNetwork,
+        status: outcome.status,
+        failure: outcome.failure,
+        eventId: null,
+        eventType: null,
+        payload: transaction as Record<string, unknown>,
+      });
+      if (result === "applied") {
+        applied += 1;
+      }
+    } catch (error) {
+      logger.error(
+        `Could not reconcile delivery ${delivery.id} (transaction ${transactionId}): ${error instanceof Error ? error.message : String(error)}`
+      );
+    } finally {
+      // Noting the check is bookkeeping for the next tick; a delivery whose note
+      // cannot be written is asked about again, and must not stop the rest.
+      try {
+        await db
+          .update(documentDeliveries)
+          .set({ lastCheckedAt: now })
+          .where(eq(documentDeliveries.id, delivery.id));
+      } catch (error) {
+        logger.error(
+          `Could not note the check of delivery ${delivery.id}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  }
+  return { checked: due.length, applied };
+}
+
+/**
+ * One tick of the reconciliation: ask the access point about the deliveries it never
+ * reported on, drop the reports that never found a document, and finish the email
+ * fallbacks a stopped run left half done. The three are independent, so a tick does
+ * all of them; only an error thrown out of one stops the rest, and the next tick
+ * starts over.
+ */
+export async function runDeliveryReconciliationTick(logger: Logger): Promise<void> {
+  try {
+    const { checked, applied } = await reconcilePendingArratechDeliveries(logger);
+    if (checked > 0) {
+      logger.info(`Reconciled ${applied} of ${checked} pending deliveries`);
+    }
+    const pruned = await pruneStagedDeliveryReports();
+    if (pruned > 0) {
+      logger.info(`Dropped ${pruned} delivery reports that never found a document`);
+    }
+    const stalled = await resumeStalledEmailFallbacks();
+    if (stalled.found > 0) {
+      logger.info(`Resumed ${stalled.resumed} of ${stalled.found} stalled email fallbacks`);
+    }
+  } catch (error) {
+    logger.error(
+      `Delivery reconciliation failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+export function initializeDeliveryReconciliationCron(logger: Logger): void {
+  if (process.env.RUN_CRON !== "true") {
+    return;
+  }
+
+  new Cron(
+    "*/10 * * * *",
+    {
+      name: "peppol.delivery-reconciliation",
+      protect: () =>
+        logger.warn("Skipping peppol.delivery-reconciliation tick: previous batch still running"),
+    },
+    async () => await runDeliveryReconciliationTick(logger)
+  );
+
+  logger.info("Delivery reconciliation cron job initialized");
+}

--- a/data/outgoing-document-row.ts
+++ b/data/outgoing-document-row.ts
@@ -1,10 +1,17 @@
 import type { Company } from "@peppol/data/companies";
 import type { SendAs4Response } from "@peppol/data/access-point-providers";
+import type { DeliveryFailure, DeliveryStatus } from "@peppol/data/deliveries/model";
+import type { EmailFallbackRequest } from "@peppol/data/deliveries/email-fallback";
+import { accessPointConfirmsDeliveryOnSend } from "@peppol/data/peppol-providers";
 import {
   parsedHasAttachments,
   type OriginalPayloadContainerFormat,
 } from "@peppol/data/offload/storage";
-import type { transferEvents, transmittedDocuments } from "@peppol/db/schema";
+import type {
+  documentDeliveries,
+  transferEvents,
+  transmittedDocuments,
+} from "@peppol/db/schema";
 import type { ParsedDocument } from "@peppol/utils/document-filename";
 import type { ParsedOrUnknownDocumentType } from "@peppol/utils/type-repository/document-types/types";
 import { getDocumentType } from "@peppol/utils/type-repository/document-types";
@@ -22,6 +29,18 @@ export type OutgoingDocumentDelivery =
       sentPeppol: boolean;
       emailRecipients: string[];
       as4Response: SendAs4Response | null;
+      /**
+       * Why the Peppol transmission was refused, when it was and the document was
+       * still stored because an email fallback applied. Null or absent when the
+       * document went over Peppol or was never addressed on the network.
+       */
+      peppolFailure?: DeliveryFailure | null;
+      /**
+       * The email to send if the transmission fails after the access point accepted
+       * it, kept with the document until the outcome is known. Null when no such
+       * email was asked for, or when it went out in the send itself.
+       */
+      emailFallback?: EmailFallbackRequest | null;
     }
   | {
       kind: "reporting";
@@ -67,6 +86,8 @@ export function deliveryFacts(delivery: OutgoingDocumentDelivery) {
     receivedPeppolSignalMessage: as4Response?.receivedPeppolSignalMessage ?? null,
     envelopeId: as4Response?.sbdhInstanceIdentifier ?? null,
     apTransactionId: as4Response?.apTransactionId ?? null,
+    peppolFailure: isReporting ? null : delivery.peppolFailure ?? null,
+    emailFallback: isReporting ? null : delivery.emailFallback ?? null,
   };
 }
 
@@ -130,6 +151,7 @@ export function buildOutgoingDocumentRow(options: {
     sentOverPeppol: facts.sentOverPeppol,
     sentOverEmail: facts.sentOverEmail,
     emailRecipients: facts.emailRecipients,
+    emailFallback: facts.emailFallback,
 
     type: document.type,
     parsed: document.parsed,
@@ -182,4 +204,78 @@ export function buildOutgoingTransferEvents(options: {
     events.push({ ...base, type: "reporting" });
   }
   return events;
+}
+
+/**
+ * Builds the delivery rows for an outgoing document: one `peppol` delivery when the
+ * document was addressed on the network, and one `email` delivery per address it
+ * was mailed to. A filed report has no recipient and gets none.
+ *
+ * A Peppol delivery starts out `delivered` when the access point returned the
+ * recipient's receipt in the send itself, which our own access point and a
+ * simulated send both do, and `pending` when the access point only reports the
+ * outcome later. A transmission that was refused before it left, with the document
+ * stored because an email fallback applied, is a `failed` delivery with the reason
+ * the refusal gave. Email deliveries start out `pending`: the mail was accepted for
+ * delivery, and nothing confirms its arrival yet.
+ */
+export function buildOutgoingDocumentDeliveries(options: {
+  transmittedDocumentId: string;
+  teamId: string;
+  company: Pick<Company, "id" | "accessPointProvider">;
+  document: Pick<OutgoingDocumentPayload, "receiverId">;
+  delivery: OutgoingDocumentDelivery;
+  useTestNetwork: boolean;
+  now?: Date;
+}): (typeof documentDeliveries.$inferInsert)[] {
+  const { company, document, useTestNetwork } = options;
+  const now = options.now ?? new Date();
+  const facts = deliveryFacts(options.delivery);
+  if (facts.isReporting) {
+    return [];
+  }
+
+  const base = {
+    transmittedDocumentId: options.transmittedDocumentId,
+    teamId: options.teamId,
+    companyId: company.id,
+    statusChangedAt: now,
+    useTestNetwork,
+  };
+
+  const rows: (typeof documentDeliveries.$inferInsert)[] = [];
+  if (document.receiverId) {
+    // A transmission the access point recorded has a transaction of its own; a
+    // simulated one has neither a transaction nor a provider.
+    const transmitted = options.delivery.kind === "peppol" && options.delivery.as4Response !== null;
+    let status: DeliveryStatus;
+    if (!facts.sentOverPeppol) {
+      status = "failed";
+    } else if (transmitted && !accessPointConfirmsDeliveryOnSend(company.accessPointProvider)) {
+      status = "pending";
+    } else {
+      status = "delivered";
+    }
+    const failure = status === "failed" ? facts.peppolFailure ?? { category: "other", message: null, providerCode: null } : null;
+    rows.push({
+      ...base,
+      channel: "peppol",
+      address: document.receiverId,
+      status,
+      failureCategory: failure?.category ?? null,
+      failureMessage: failure?.message ?? null,
+      failureProviderCode: failure?.providerCode ?? null,
+      provider: transmitted ? company.accessPointProvider : null,
+      providerTransactionId: facts.apTransactionId,
+    });
+  }
+  for (const address of facts.emailRecipients) {
+    rows.push({
+      ...base,
+      channel: "email",
+      address,
+      status: "pending",
+    });
+  }
+  return rows;
 }

--- a/data/peppol-providers.ts
+++ b/data/peppol-providers.ts
@@ -18,3 +18,15 @@ export function resolveDefaultPeppolProviders(country: string): {
     smpProvider: "recommand-smp1",
   };
 }
+
+/**
+ * Whether an access point confirms delivery in the send itself. Our own access point
+ * returns the recipient's AS4 receipt in the same request, so a send that succeeded
+ * is a delivery. A shared access point accepts the document first and reports what
+ * became of it later, so its deliveries start out pending.
+ */
+export function accessPointConfirmsDeliveryOnSend(
+  provider: AccessPointProviderId
+): boolean {
+  return provider !== "at-shared-ap-fr";
+}

--- a/data/phase4-ap/client.ts
+++ b/data/phase4-ap/client.ts
@@ -11,6 +11,8 @@ export function fetchPhase4Ap(url: string, options: { useTestNetwork?: boolean }
   });
 }
 
+import type { DeliveryFailureCategory } from "@peppol/data/deliveries/model";
+
 export type SendAs4Response = {
   ok: boolean;
   peppolMessageId: string | null;
@@ -21,6 +23,9 @@ export type SendAs4Response = {
   apTransactionId?: string | null;
   sendingException?: {
     message: string;
+    // Why the send was refused, when the adapter can tell. Left out when all it has
+    // is the access point's free-text message, which counts as a transport failure.
+    category?: DeliveryFailureCategory;
   };
 };
 

--- a/data/playground/simulate-ap.ts
+++ b/data/playground/simulate-ap.ts
@@ -2,6 +2,13 @@ import { UserFacingError } from "@directory/utils/util";
 import { receivingPipeline } from "@peppol/utils/pipelines/receiving";
 import { getCompanyByPeppolId } from "../companies";
 
+/**
+ * The playground's counterpart of a recipient the network does not know: a send to
+ * one of the addresses reserved for it fails the way a lookup of an unregistered
+ * participant would.
+ */
+export class PlaygroundRecipientNotFoundError extends UserFacingError {}
+
 export async function simulateSendAs4(options: {
   senderId: string;
   receiverId: string;
@@ -16,7 +23,7 @@ export async function simulateSendAs4(options: {
 
   // If the recipientId is "404:404" or "0208:1234567894", throw an error
   if (options.receiverId === "404:404" || options.receiverId === "0208:1234567894") {
-    throw new UserFacingError("This document was sent to recipient 404:404 or 0208:1234567894, simulating the sending of a document to a Peppol address that does not exist.");
+    throw new PlaygroundRecipientNotFoundError("This document was sent to recipient 404:404 or 0208:1234567894, simulating the sending of a document to a Peppol address that does not exist.");
   }
 
   // Check if the receiverId is registered as a company in this playground team, search by enterprise number

--- a/data/record-outgoing-document.ts
+++ b/data/record-outgoing-document.ts
@@ -2,6 +2,7 @@ import { audit, writeAuditEvent, type AuditEventInput } from "@core/lib/audit";
 import { publishEvent } from "@core/data/rules/events";
 import type { Company } from "@peppol/data/companies";
 import {
+  buildOutgoingDocumentDeliveries,
   buildOutgoingDocumentRow,
   buildOutgoingTransferEvents,
   deliveryFacts,
@@ -13,6 +14,13 @@ import {
   uploadDocumentOriginalPayload,
   type OriginalPayloadContainerFormat,
 } from "@peppol/data/offload/storage";
+import {
+  applyStagedDeliveryReport,
+  insertDocumentDeliveries,
+  listDocumentDeliveries,
+  summarizeDeliveryStatus,
+  type DocumentDelivery,
+} from "@peppol/data/deliveries";
 import { sendOutgoingDocumentNotifications } from "@peppol/data/send-document-notifications";
 import { transferEvents, transmittedDocuments } from "@peppol/db/schema";
 import { isUniqueViolation } from "@peppol/utils/db-errors";
@@ -26,11 +34,22 @@ export type {
   OutgoingDocumentPayload,
 } from "@peppol/data/outgoing-document-row";
 
+export type RecordedOutgoingDocument = {
+  id: string;
+  /**
+   * The document's deliveries as read back after recording, so a report that overtook
+   * the send is reflected whichever path applied it. A snapshot: a later report
+   * changes the database and notifies the owner, not this value.
+   */
+  deliveries: DocumentDelivery[];
+};
+
 /**
- * Persists an outgoing document and runs everything that follows from it: the sent
- * event, billing, notification emails, and the audit trail. Shared by every endpoint
- * that produces an outgoing document, so a document reaches the platform the same way
- * whether it was transmitted over Peppol or filed with a tax administration.
+ * Persists an outgoing document with its deliveries and runs everything that follows
+ * from it: the sent event, billing, notification emails, and the audit trail. Shared
+ * by every endpoint that produces an outgoing document, so a document reaches the
+ * platform the same way whether it was transmitted over Peppol or filed with a tax
+ * administration.
  */
 export async function recordOutgoingDocument(options: {
   /** The request that produced the document, for the audit trail. Null when a
@@ -40,6 +59,8 @@ export async function recordOutgoingDocument(options: {
   teamId: string;
   company: Company;
   isPlayground?: boolean;
+  /** Whether the document went over the Peppol test network, for the deliveries. */
+  useTestNetwork?: boolean;
   inputFormat: string;
   document: OutgoingDocumentPayload;
   delivery: OutgoingDocumentDelivery;
@@ -47,7 +68,7 @@ export async function recordOutgoingDocument(options: {
     content: Buffer;
     containerFormat: Exclude<OriginalPayloadContainerFormat, "none">;
   } | null;
-}): Promise<{ id: string }> {
+}): Promise<RecordedOutgoingDocument> {
   const { c, id, teamId, company, document, delivery } = options;
   const facts = deliveryFacts(delivery);
 
@@ -83,22 +104,38 @@ export async function recordOutgoingDocument(options: {
     }
   }
 
-  let transmittedDocument: { id: string };
+  // The document and its deliveries are one write: a document never exists without
+  // the deliveries that say where it stands.
+  let transmittedDocument: RecordedOutgoingDocument;
   try {
-    transmittedDocument = await db
-      .insert(transmittedDocuments)
-      .values(
-        buildOutgoingDocumentRow({
-          id,
+    transmittedDocument = await db.transaction(async (tx) => {
+      const [inserted] = await tx
+        .insert(transmittedDocuments)
+        .values(
+          buildOutgoingDocumentRow({
+            id,
+            teamId,
+            company,
+            document,
+            delivery,
+            storage,
+          })
+        )
+        .returning({ id: transmittedDocuments.id });
+      const deliveries = await insertDocumentDeliveries(
+        tx,
+        buildOutgoingDocumentDeliveries({
+          transmittedDocumentId: inserted!.id,
           teamId,
           company,
           document,
           delivery,
-          storage,
+          useTestNetwork: options.useTestNetwork ?? false,
+          now: storage.createdAt,
         })
-      )
-      .returning({ id: transmittedDocuments.id })
-      .then((rows) => rows[0]);
+      );
+      return { id: inserted!.id, deliveries };
+    });
   } catch (error) {
     // ap_transaction_id is unique, so a conflict means this exact transaction was
     // already recorded from the access point's report of it (see data/provider-sent),
@@ -117,7 +154,7 @@ export async function recordOutgoingDocument(options: {
         .limit(1)
         .then((rows) => rows[0]);
       if (existingFiling) {
-        return existingFiling;
+        return { ...existingFiling, deliveries: await listDocumentDeliveries(existingFiling.id) };
       }
     }
     const existing =
@@ -138,7 +175,7 @@ export async function recordOutgoingDocument(options: {
         `The access point's report of this transaction was not matched to its envelope claim.`,
       "warning"
     );
-    return existing;
+    return { ...existing, deliveries: await listDocumentDeliveries(existing.id) };
   }
 
   await publishEvent("peppol.document.sent.v1", {
@@ -155,6 +192,11 @@ export async function recordOutgoingDocument(options: {
       peppolConversationId: facts.peppolConversationId,
       envelopeId: facts.envelopeId,
       countryC1: document.countryC1,
+      // As recorded with the document: pending when the access point confirms
+      // later, delivered when the receipt came with the send, null for a report.
+      deliveryStatus: summarizeDeliveryStatus(
+        transmittedDocument.deliveries.map((delivery) => delivery.status)
+      ),
     },
   });
 
@@ -170,6 +212,34 @@ export async function recordOutgoingDocument(options: {
     if (te.length > 0) {
       await db.insert(transferEvents).values(te);
     }
+  }
+
+  // The access point may already have reported what became of this transaction, if
+  // its report overtook the send that produced the document. That report is applied
+  // now so the delivery is never left pending; nothing above is undone, the document
+  // did leave the platform and its transmission was made.
+  if (facts.apTransactionId) {
+    try {
+      await applyStagedDeliveryReport(facts.apTransactionId);
+    } catch (error) {
+      console.error("Failed to apply a staged delivery report:", error);
+      sendSystemAlert(
+        "Delivery Report Not Applied",
+        `Could not check for a delivery report for transaction ${facts.apTransactionId} of document ${transmittedDocument.id}.`,
+        "error"
+      );
+    }
+  }
+
+  // The deliveries are read back rather than returned as inserted: a report may have
+  // been applied in the meantime by whoever got to it first, this call or the webhook
+  // that received it, and the response should say what the database says. It is a
+  // snapshot as of this read; a report that arrives later reaches the owner through
+  // the delivery status event, not through this response.
+  try {
+    transmittedDocument.deliveries = await listDocumentDeliveries(transmittedDocument.id);
+  } catch (error) {
+    console.error("Failed to read back the deliveries of a recorded document:", error);
   }
 
   // Send notification emails to configured addresses

--- a/data/transmitted-documents.ts
+++ b/data/transmitted-documents.ts
@@ -1,9 +1,10 @@
-import { supportedDocumentTypeEnum, transmittedDocuments, transmittedDocumentLabels } from "@peppol/db/schema";
+import { documentDeliveries, supportedDocumentTypeEnum, transmittedDocuments, transmittedDocumentLabels } from "@peppol/db/schema";
 import { labels } from "@directory/db/schema";
 import { db } from "@recommand/db";
 import { eq, and, or, sql, desc, isNull, isNotNull, inArray, ilike, gte, lt } from "drizzle-orm";
 import type { Label } from "@directory/data/labels";
 import type { FrenchReportingStatusSummary } from "./fr-reporting-submissions";
+import type { DeliveryStatus, DeliverySummary } from "./deliveries/model";
 import { removeAttachmentsFromParsedDocument } from "@peppol/utils/parsing/remove-attachments";
 import {
   offloadedDocumentS3Prefixes,
@@ -22,7 +23,7 @@ export type TransmittedDocument = typeof transmittedDocuments.$inferSelect;
 export type InsertTransmittedDocument = typeof transmittedDocuments.$inferInsert;
 type TransmittedDocumentSearchField = "senderName" | "receiverName" | "documentNumber" | "searchText";
 type TransmittedDocumentLabel = Omit<Label, "teamId" | "createdAt" | "updatedAt">;
-type InternalProviderField = "accessPointProvider" | "smpProvider" | "apTransactionId" | "externalReferenceId";
+type InternalProviderField = "accessPointProvider" | "smpProvider" | "apTransactionId" | "externalReferenceId" | "emailFallback";
 export type PublicTransmittedDocument = Omit<
   TransmittedDocument,
   TransmittedDocumentSearchField | InternalProviderField | "offloadClaimedAt"
@@ -31,6 +32,9 @@ export type PublicTransmittedDocumentWithLabels = PublicTransmittedDocument & {
   labels?: TransmittedDocumentLabel[];
   /** Present on filed reports once the API has attached where they stand. */
   reporting?: FrenchReportingStatusSummary | null;
+  /** Present once the API has attached where the document stands with each recipient. */
+  deliveries?: DeliverySummary[];
+  deliveryStatus?: DeliveryStatus | null;
 };
 
 // Internal storage-location fields that must never be exposed to API consumers.
@@ -40,6 +44,8 @@ type InternalStorageField = "xmlLocation" | "attachmentsLocation" | "originalPay
 export type TransmittedDocumentWithoutBody = Omit<PublicTransmittedDocument, "xml" | InternalStorageField> & {
   labels?: TransmittedDocumentLabel[];
   reporting?: FrenchReportingStatusSummary | null;
+  deliveries?: DeliverySummary[];
+  deliveryStatus?: DeliveryStatus | null;
 };
 type InboxTransmittedDocument = Omit<PublicTransmittedDocument, "xml" | InternalStorageField | "parsed"> & {
   labels?: TransmittedDocumentLabel[];
@@ -146,10 +152,12 @@ export async function getTransmittedDocuments(
     envelopeId?: string | null;
     peppolMessageId?: string | null;
     peppolConversationId?: string | null;
+    deliveryStatus?: DeliveryStatus;
+    deliveryFailed?: boolean;
     excludeAttachments?: boolean;
   } = {}
 ): Promise<{ documents: TransmittedDocumentWithoutBody[]; total: number }> {
-  const { page = 1, limit = 10, companyId, labelId, direction, search, type, from, to, isUnread, envelopeId, peppolMessageId, peppolConversationId, excludeAttachments = false } = options;
+  const { page = 1, limit = 10, companyId, labelId, direction, search, type, from, to, isUnread, envelopeId, peppolMessageId, peppolConversationId, deliveryStatus, deliveryFailed, excludeAttachments = false } = options;
   const offset = (page - 1) * limit;
   const trimmedSearch = search?.trim();
   const normalizedLabelIds = labelId ? [...new Set(labelId)] : undefined;
@@ -219,6 +227,24 @@ export async function getTransmittedDocuments(
     whereClause.push(eq(transmittedDocuments.peppolConversationId, peppolConversationId));
   }else if (peppolConversationId === null) {
     whereClause.push(isNull(transmittedDocuments.peppolConversationId));
+  }
+  // The same summary rule as summarizeDeliveryStatus, expressed over the deliveries
+  // table: delivered if any delivery is, failed if all are, pending otherwise.
+  const hasDeliveryWithStatus = (status: DeliveryStatus) =>
+    sql`exists (select 1 from ${documentDeliveries} where ${documentDeliveries.transmittedDocumentId} = ${transmittedDocuments.id} and ${documentDeliveries.status} = ${status})`;
+  const hasDeliveryNotInStatus = (status: DeliveryStatus) =>
+    sql`exists (select 1 from ${documentDeliveries} where ${documentDeliveries.transmittedDocumentId} = ${transmittedDocuments.id} and ${documentDeliveries.status} <> ${status})`;
+  if (deliveryStatus === "delivered") {
+    whereClause.push(hasDeliveryWithStatus("delivered"));
+  } else if (deliveryStatus === "failed") {
+    whereClause.push(hasDeliveryWithStatus("failed"), sql`not ${hasDeliveryNotInStatus("failed")}`);
+  } else if (deliveryStatus === "pending") {
+    whereClause.push(hasDeliveryWithStatus("pending"), sql`not ${hasDeliveryWithStatus("delivered")}`);
+  }
+  if (deliveryFailed === true) {
+    whereClause.push(hasDeliveryWithStatus("failed"));
+  } else if (deliveryFailed === false) {
+    whereClause.push(sql`not ${hasDeliveryWithStatus("failed")}`);
   }
 
   // Get total count

--- a/db/drizzle/20260909202241_document_deliveries.sql
+++ b/db/drizzle/20260909202241_document_deliveries.sql
@@ -1,0 +1,47 @@
+CREATE TYPE "public"."peppol_delivery_channel" AS ENUM('peppol', 'email');--> statement-breakpoint
+CREATE TYPE "public"."peppol_delivery_failure_category" AS ENUM('recipient_not_found', 'document_not_supported', 'validation', 'transport', 'recipient_rejected', 'duplicate', 'other');--> statement-breakpoint
+CREATE TYPE "public"."peppol_delivery_status" AS ENUM('pending', 'delivered', 'failed');--> statement-breakpoint
+CREATE TABLE "peppol_document_deliveries" (
+	"id" text PRIMARY KEY NOT NULL,
+	"transmitted_document_id" text NOT NULL,
+	"team_id" text NOT NULL,
+	"company_id" text NOT NULL,
+	"channel" "peppol_delivery_channel" NOT NULL,
+	"address" text NOT NULL,
+	"status" "peppol_delivery_status" NOT NULL,
+	"status_changed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"failure_category" "peppol_delivery_failure_category",
+	"failure_message" text,
+	"failure_provider_code" text,
+	"provider" text,
+	"use_test_network" boolean DEFAULT false NOT NULL,
+	"provider_transaction_id" text,
+	"provider_event_id" text,
+	"provider_event_type" text,
+	"provider_payload" jsonb,
+	"last_checked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "peppol_provider_delivery_reports" (
+	"provider_transaction_id" text PRIMARY KEY NOT NULL,
+	"channel" "peppol_delivery_channel" NOT NULL,
+	"provider" text NOT NULL,
+	"use_test_network" boolean DEFAULT false NOT NULL,
+	"status" "peppol_delivery_status" NOT NULL,
+	"failure_category" "peppol_delivery_failure_category",
+	"failure_message" text,
+	"failure_provider_code" text,
+	"event_id" text,
+	"event_type" text,
+	"payload" jsonb NOT NULL,
+	"reported_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "peppol_transmitted_documents" ADD COLUMN "email_fallback" jsonb;--> statement-breakpoint
+ALTER TABLE "peppol_document_deliveries" ADD CONSTRAINT "peppol_document_deliveries_transmitted_document_id_peppol_transmitted_documents_id_fk" FOREIGN KEY ("transmitted_document_id") REFERENCES "public"."peppol_transmitted_documents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "peppol_document_deliveries_document_idx" ON "peppol_document_deliveries" USING btree ("transmitted_document_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "peppol_document_deliveries_provider_transaction_idx" ON "peppol_document_deliveries" USING btree ("provider_transaction_id") WHERE "peppol_document_deliveries"."provider_transaction_id" is not null;--> statement-breakpoint
+CREATE INDEX "peppol_document_deliveries_pending_idx" ON "peppol_document_deliveries" USING btree ("status","channel","status_changed_at");--> statement-breakpoint
+CREATE INDEX "peppol_transmitted_documents_email_fallback_idx" ON "peppol_transmitted_documents" USING btree ("id") WHERE "peppol_transmitted_documents"."email_fallback" is not null;

--- a/db/drizzle/meta/20260909202241_snapshot.json
+++ b/db/drizzle/meta/20260909202241_snapshot.json
@@ -1,0 +1,3527 @@
+{
+  "id": "159d0b1b-7d05-4591-aeec-06d61ddfbc42",
+  "prevId": "14ef12c4-1428-452e-bd99-c77240aca379",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activated_integrations": {
+      "name": "activated_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activated_integrations_team_id_idx": {
+          "name": "activated_integrations_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activated_integrations_team_id_teams_id_fk": {
+          "name": "activated_integrations_team_id_teams_id_fk",
+          "tableFrom": "activated_integrations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activated_integrations_company_id_peppol_companies_id_fk": {
+          "name": "activated_integrations_company_id_peppol_companies_id_fk",
+          "tableFrom": "activated_integrations",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_billing_profiles": {
+      "name": "peppol_billing_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mollie_customer_id": {
+          "name": "mollie_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_payment_id": {
+          "name": "first_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_payment_status": {
+          "name": "first_payment_status",
+          "type": "peppol_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "is_mandate_validated": {
+          "name": "is_mandate_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile_standing": {
+          "name": "profile_standing",
+          "type": "peppol_profile_standing",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "grace_started_at": {
+          "name": "grace_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_reason": {
+          "name": "grace_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_peppol_address": {
+          "name": "billing_peppol_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_manually_billed": {
+          "name": "is_manually_billed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "peppol_billing_profiles_team_id_unique": {
+          "name": "peppol_billing_profiles_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_companies": {
+      "name": "peppol_companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enterprise_number_scheme": {
+          "name": "enterprise_number_scheme",
+          "type": "peppol_valid_iso_icd_scheme_identifiers",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_smp_recipient": {
+          "name": "is_smp_recipient",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "access_point_provider": {
+          "name": "access_point_provider",
+          "type": "peppol_access_point_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-ap1'"
+        },
+        "smp_provider": {
+          "name": "smp_provider",
+          "type": "peppol_smp_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-smp1'"
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_proof_reference": {
+          "name": "verification_proof_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_companies_team_id_teams_id_fk": {
+          "name": "peppol_companies_team_id_teams_id_fk",
+          "tableFrom": "peppol_companies",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_document_types": {
+      "name": "peppol_company_document_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type_id": {
+          "name": "doc_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_document_types_unique": {
+          "name": "peppol_company_document_types_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doc_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "process_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_document_types_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_document_types_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_document_types",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_identifiers": {
+      "name": "peppol_company_identifiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_identifiers_unique": {
+          "name": "peppol_company_identifiers_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"scheme\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"identifier\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_identifiers_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_identifiers_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_identifiers",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_company_notification_email_addresses": {
+      "name": "peppol_company_notification_email_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notify_incoming": {
+          "name": "notify_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_outgoing": {
+          "name": "notify_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_auto_generated_pdf_incoming": {
+          "name": "include_auto_generated_pdf_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_auto_generated_pdf_outgoing": {
+          "name": "include_auto_generated_pdf_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_document_json_incoming": {
+          "name": "include_document_json_incoming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_document_json_outgoing": {
+          "name": "include_document_json_outgoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_company_notification_email_addresses_unique": {
+          "name": "peppol_company_notification_email_addresses_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_company_notification_email_addresses_company_id_peppol_companies_id_fk": {
+          "name": "peppol_company_notification_email_addresses_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_company_notification_email_addresses",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_verification_log": {
+      "name": "company_verification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opened'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_specific": {
+          "name": "country_specific",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_proof_reference": {
+          "name": "verification_proof_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mandate_accepted_at": {
+          "name": "mandate_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arratech_onboarding": {
+          "name": "arratech_onboarding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_verification_log_company_id_peppol_companies_id_fk": {
+          "name": "company_verification_log_company_id_peppol_companies_id_fk",
+          "tableFrom": "company_verification_log",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_document_deliveries": {
+      "name": "peppol_document_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "peppol_delivery_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "peppol_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "failure_category": {
+          "name": "failure_category",
+          "type": "peppol_delivery_failure_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_provider_code": {
+          "name": "failure_provider_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_test_network": {
+          "name": "use_test_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_transaction_id": {
+          "name": "provider_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_payload": {
+          "name": "provider_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_document_deliveries_document_idx": {
+          "name": "peppol_document_deliveries_document_idx",
+          "columns": [
+            {
+              "expression": "transmitted_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_document_deliveries_provider_transaction_idx": {
+          "name": "peppol_document_deliveries_provider_transaction_idx",
+          "columns": [
+            {
+              "expression": "provider_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"peppol_document_deliveries\".\"provider_transaction_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_document_deliveries_pending_idx": {
+          "name": "peppol_document_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status_changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_document_deliveries_transmitted_document_id_peppol_transmitted_documents_id_fk": {
+          "name": "peppol_document_deliveries_transmitted_document_id_peppol_transmitted_documents_id_fk",
+          "tableFrom": "peppol_document_deliveries",
+          "tableTo": "peppol_transmitted_documents",
+          "columnsFrom": [
+            "transmitted_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enterprise_data_cache": {
+      "name": "enterprise_data_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enterprise_number": {
+          "name": "enterprise_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "peppol_valid_country_codes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "begin_date": {
+          "name": "begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_code": {
+          "name": "juridical_form_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_description": {
+          "name": "juridical_form_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "juridical_form_begin_date": {
+          "name": "juridical_form_begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_code": {
+          "name": "denomination_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_description": {
+          "name": "denomination_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denomination_begin_date": {
+          "name": "denomination_begin_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "enterprise_data_cache_unique": {
+          "name": "enterprise_data_cache_unique",
+          "columns": [
+            {
+              "expression": "enterprise_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_fr_reporting_declarants": {
+      "name": "peppol_fr_reporting_declarants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "peppol_fr_reporting_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_name": {
+          "name": "issuer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_regime": {
+          "name": "vat_regime",
+          "type": "peppol_fr_vat_regime",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_exigibility": {
+          "name": "vat_exigibility",
+          "type": "peppol_fr_vat_exigibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "simulated": {
+          "name": "simulated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "peppol_fr_reporting_declarant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partner_snapshot": {
+          "name": "partner_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_fr_reporting_declarants_company_environment_idx": {
+          "name": "peppol_fr_reporting_declarants_company_environment_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_fr_reporting_declarants_due_idx": {
+          "name": "peppol_fr_reporting_declarants_due_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_fr_reporting_declarants_company_id_peppol_companies_id_fk": {
+          "name": "peppol_fr_reporting_declarants_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_fr_reporting_declarants",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_fr_reporting_submissions": {
+      "name": "peppol_fr_reporting_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declarant_id": {
+          "name": "declarant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "peppol_fr_reporting_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_flux": {
+          "name": "sub_flux",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmission_type": {
+          "name": "transmission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulated": {
+          "name": "simulated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ledger_status": {
+          "name": "ledger_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporting_status": {
+          "name": "reporting_status",
+          "type": "peppol_fr_reporting_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_date": {
+          "name": "operation_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_code": {
+          "name": "outcome_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_at": {
+          "name": "outcome_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_attempts": {
+          "name": "check_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_fr_reporting_submissions_flow_id_idx": {
+          "name": "peppol_fr_reporting_submissions_flow_id_idx",
+          "columns": [
+            {
+              "expression": "flow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_fr_reporting_submissions_document_idx": {
+          "name": "peppol_fr_reporting_submissions_document_idx",
+          "columns": [
+            {
+              "expression": "transmitted_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_fr_reporting_submissions_due_idx": {
+          "name": "peppol_fr_reporting_submissions_due_idx",
+          "columns": [
+            {
+              "expression": "next_check_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_fr_reporting_submissions_transmitted_document_id_peppol_transmitted_documents_id_fk": {
+          "name": "peppol_fr_reporting_submissions_transmitted_document_id_peppol_transmitted_documents_id_fk",
+          "tableFrom": "peppol_fr_reporting_submissions",
+          "tableTo": "peppol_transmitted_documents",
+          "columnsFrom": [
+            "transmitted_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_fr_reporting_submissions_declarant_id_peppol_fr_reporting_declarants_id_fk": {
+          "name": "peppol_fr_reporting_submissions_declarant_id_peppol_fr_reporting_declarants_id_fk",
+          "tableFrom": "peppol_fr_reporting_submissions",
+          "tableTo": "peppol_fr_reporting_declarants",
+          "columnsFrom": [
+            "declarant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_task_logs": {
+      "name": "integration_task_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integration_task_logs_integration_id_activated_integrations_id_fk": {
+          "name": "integration_task_logs_integration_id_activated_integrations_id_fk",
+          "tableFrom": "integration_task_logs",
+          "tableTo": "activated_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_outgoing_envelope_claims": {
+      "name": "peppol_outgoing_envelope_claims",
+      "schema": "",
+      "columns": {
+        "instance_identifier": {
+          "name": "instance_identifier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_outgoing_envelope_claims_created_at_idx": {
+          "name": "peppol_outgoing_envelope_claims_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_payment_failure_reminders": {
+      "name": "peppol_payment_failure_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_event_id": {
+          "name": "billing_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_addresses": {
+          "name": "email_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_payment_failure_reminders_billing_event_id_peppol_subscription_billing_events_id_fk": {
+          "name": "peppol_payment_failure_reminders_billing_event_id_peppol_subscription_billing_events_id_fk",
+          "tableFrom": "peppol_payment_failure_reminders",
+          "tableTo": "peppol_subscription_billing_events",
+          "columnsFrom": [
+            "billing_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_s3_deletions": {
+      "name": "pending_s3_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_s3_deletions_claim_idx": {
+          "name": "pending_s3_deletions_claim_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_provider_delivery_reports": {
+      "name": "peppol_provider_delivery_reports",
+      "schema": "",
+      "columns": {
+        "provider_transaction_id": {
+          "name": "provider_transaction_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "peppol_delivery_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_test_network": {
+          "name": "use_test_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "peppol_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_category": {
+          "name": "failure_category",
+          "type": "peppol_delivery_failure_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_provider_code": {
+          "name": "failure_provider_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscription_billing_event_lines": {
+      "name": "peppol_subscription_billing_event_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_billing_event_id": {
+          "name": "subscription_billing_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_start_date": {
+          "name": "subscription_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_end_date": {
+          "name": "subscription_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_last_billed_at": {
+          "name": "subscription_last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_config": {
+          "name": "billing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included_monthly_documents": {
+          "name": "included_monthly_documents",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_document_overage_price": {
+          "name": "incoming_document_overage_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outgoing_document_overage_price": {
+          "name": "outgoing_document_overage_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty": {
+          "name": "used_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_incoming": {
+          "name": "used_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_outgoing": {
+          "name": "used_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_incoming": {
+          "name": "overage_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_outgoing": {
+          "name": "overage_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_excl": {
+          "name": "total_amount_excl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_subscription_billing_event_lines_subscription_billing_event_id_peppol_subscription_billing_events_id_fk": {
+          "name": "peppol_subscription_billing_event_lines_subscription_billing_event_id_peppol_subscription_billing_events_id_fk",
+          "tableFrom": "peppol_subscription_billing_event_lines",
+          "tableTo": "peppol_subscription_billing_events",
+          "columnsFrom": [
+            "subscription_billing_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscription_billing_events": {
+      "name": "peppol_subscription_billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_profile_id": {
+          "name": "billing_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_date": {
+          "name": "billing_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_start": {
+          "name": "billing_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_end": {
+          "name": "billing_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_excl": {
+          "name": "total_amount_excl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_amount": {
+          "name": "vat_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_category": {
+          "name": "vat_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_percentage": {
+          "name": "vat_percentage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_incl": {
+          "name": "total_amount_incl",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty": {
+          "name": "used_qty",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_incoming": {
+          "name": "used_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_qty_outgoing": {
+          "name": "used_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_incoming": {
+          "name": "overage_qty_incoming",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_qty_outgoing": {
+          "name": "overage_qty_outgoing",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_due": {
+          "name": "amount_due",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "peppol_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_reference": {
+          "name": "invoice_reference",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_subscription_billing_events_billing_profile_id_peppol_billing_profiles_id_fk": {
+          "name": "peppol_subscription_billing_events_billing_profile_id_peppol_billing_profiles_id_fk",
+          "tableFrom": "peppol_subscription_billing_events",
+          "tableTo": "peppol_billing_profiles",
+          "columnsFrom": [
+            "billing_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "peppol_subscription_billing_events_invoice_id_unique": {
+          "name": "peppol_subscription_billing_events_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_id"
+          ]
+        },
+        "peppol_subscription_billing_events_invoice_reference_unique": {
+          "name": "peppol_subscription_billing_events_invoice_reference_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_reference"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_subscriptions": {
+      "name": "peppol_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_config": {
+          "name": "billing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_billed_at": {
+          "name": "last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_team_extensions": {
+      "name": "peppol_team_extensions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_playground": {
+          "name": "is_playground",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_test_network": {
+          "name": "use_test_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_requirements": {
+          "name": "verification_requirements",
+          "type": "verification_requirements",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lax'"
+        },
+        "company_verification_extension_until": {
+          "name": "company_verification_extension_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_email_address": {
+          "name": "support_email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_team_extensions_id_teams_id_fk": {
+          "name": "peppol_team_extensions_id_teams_id_fk",
+          "tableFrom": "peppol_team_extensions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transfer_events": {
+      "name": "peppol_transfer_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "peppol_transfer_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'peppol'"
+        },
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "peppol_transfer_event_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transmitted_document_labels": {
+      "name": "peppol_transmitted_document_labels",
+      "schema": "",
+      "columns": {
+        "transmitted_document_id": {
+          "name": "transmitted_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_transmitted_document_labels_transmitted_document_id_peppol_transmitted_documents_id_fk": {
+          "name": "peppol_transmitted_document_labels_transmitted_document_id_peppol_transmitted_documents_id_fk",
+          "tableFrom": "peppol_transmitted_document_labels",
+          "tableTo": "peppol_transmitted_documents",
+          "columnsFrom": [
+            "transmitted_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_transmitted_document_labels_label_id_peppol_labels_id_fk": {
+          "name": "peppol_transmitted_document_labels_label_id_peppol_labels_id_fk",
+          "tableFrom": "peppol_transmitted_document_labels",
+          "tableTo": "peppol_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "peppol_transmitted_document_labels_pkey": {
+          "name": "peppol_transmitted_document_labels_pkey",
+          "columns": [
+            "transmitted_document_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_transmitted_documents": {
+      "name": "peppol_transmitted_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "peppol_transfer_event_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_type_id": {
+          "name": "doc_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_c1": {
+          "name": "country_c1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_point_provider": {
+          "name": "access_point_provider",
+          "type": "peppol_access_point_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-ap1'"
+        },
+        "smp_provider": {
+          "name": "smp_provider",
+          "type": "peppol_smp_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommand-smp1'"
+        },
+        "xml": {
+          "name": "xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_location": {
+          "name": "xml_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'db'"
+        },
+        "attachments_location": {
+          "name": "attachments_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'db'"
+        },
+        "original_payload_location": {
+          "name": "original_payload_location",
+          "type": "peppol_payload_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "original_payload_container_format": {
+          "name": "original_payload_container_format",
+          "type": "peppol_original_payload_container_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "s3_key_prefix": {
+          "name": "s3_key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offload_claimed_at": {
+          "name": "offload_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_over_peppol": {
+          "name": "sent_over_peppol",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sent_over_email": {
+          "name": "sent_over_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_recipients": {
+          "name": "email_recipients",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "email_fallback": {
+          "name": "email_fallback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "peppol_supported_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "parsed": {
+          "name": "parsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation": {
+          "name": "validation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_name": {
+          "name": "receiver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peppol_message_id": {
+          "name": "peppol_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peppol_conversation_id": {
+          "name": "peppol_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_peppol_signal_message": {
+          "name": "received_peppol_signal_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envelope_id": {
+          "name": "envelope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ap_transaction_id": {
+          "name": "ap_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_reference_id": {
+          "name": "external_reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "peppol_transmitted_documents_offload_idx": {
+          "name": "peppol_transmitted_documents_offload_idx",
+          "columns": [
+            {
+              "expression": "xml_location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "offload_claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_transmitted_documents_email_fallback_idx": {
+          "name": "peppol_transmitted_documents_email_fallback_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"peppol_transmitted_documents\".\"email_fallback\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_transmitted_documents_ap_transaction_id_idx": {
+          "name": "peppol_transmitted_documents_ap_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "ap_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"peppol_transmitted_documents\".\"ap_transaction_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peppol_transmitted_documents_external_reference_id_idx": {
+          "name": "peppol_transmitted_documents_external_reference_id_idx",
+          "columns": [
+            {
+              "expression": "external_reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"peppol_transmitted_documents\".\"external_reference_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "peppol_transmitted_documents_team_id_teams_id_fk": {
+          "name": "peppol_transmitted_documents_team_id_teams_id_fk",
+          "tableFrom": "peppol_transmitted_documents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_transmitted_documents_company_id_peppol_companies_id_fk": {
+          "name": "peppol_transmitted_documents_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_transmitted_documents",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.peppol_webhooks": {
+      "name": "peppol_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "peppol_webhooks_team_id_teams_id_fk": {
+          "name": "peppol_webhooks_team_id_teams_id_fk",
+          "tableFrom": "peppol_webhooks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "peppol_webhooks_company_id_peppol_companies_id_fk": {
+          "name": "peppol_webhooks_company_id_peppol_companies_id_fk",
+          "tableFrom": "peppol_webhooks",
+          "tableTo": "peppol_companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.peppol_access_point_provider": {
+      "name": "peppol_access_point_provider",
+      "schema": "public",
+      "values": [
+        "recommand-ap1",
+        "at-shared-ap-fr"
+      ]
+    },
+    "public.peppol_delivery_channel": {
+      "name": "peppol_delivery_channel",
+      "schema": "public",
+      "values": [
+        "peppol",
+        "email"
+      ]
+    },
+    "public.peppol_delivery_failure_category": {
+      "name": "peppol_delivery_failure_category",
+      "schema": "public",
+      "values": [
+        "recipient_not_found",
+        "document_not_supported",
+        "validation",
+        "transport",
+        "recipient_rejected",
+        "duplicate",
+        "other"
+      ]
+    },
+    "public.peppol_delivery_status": {
+      "name": "peppol_delivery_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "delivered",
+        "failed"
+      ]
+    },
+    "public.peppol_fr_reporting_declarant_state": {
+      "name": "peppol_fr_reporting_declarant_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "registered",
+        "blocked"
+      ]
+    },
+    "public.peppol_fr_reporting_environment": {
+      "name": "peppol_fr_reporting_environment",
+      "schema": "public",
+      "values": [
+        "PROD",
+        "TEST"
+      ]
+    },
+    "public.peppol_fr_reporting_status": {
+      "name": "peppol_fr_reporting_status",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "pending_rectificative",
+        "filed",
+        "filed_rectificative",
+        "superseded",
+        "rejected"
+      ]
+    },
+    "public.peppol_fr_vat_exigibility": {
+      "name": "peppol_fr_vat_exigibility",
+      "schema": "public",
+      "values": [
+        "ENCAISSEMENTS",
+        "DEBITS"
+      ]
+    },
+    "public.peppol_fr_vat_regime": {
+      "name": "peppol_fr_vat_regime",
+      "schema": "public",
+      "values": [
+        "REEL_NORMAL_MENSUEL",
+        "REEL_SIMPLIFIE",
+        "FRANCHISE_EN_BASE"
+      ]
+    },
+    "public.peppol_original_payload_container_format": {
+      "name": "peppol_original_payload_container_format",
+      "schema": "public",
+      "values": [
+        "none",
+        "pdf"
+      ]
+    },
+    "public.peppol_payload_location": {
+      "name": "peppol_payload_location",
+      "schema": "public",
+      "values": [
+        "none",
+        "db",
+        "s3"
+      ]
+    },
+    "public.peppol_payment_status": {
+      "name": "peppol_payment_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "open",
+        "pending",
+        "authorized",
+        "paid",
+        "canceled",
+        "expired",
+        "failed"
+      ]
+    },
+    "public.peppol_profile_standing": {
+      "name": "peppol_profile_standing",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "grace",
+        "suspended"
+      ]
+    },
+    "public.peppol_smp_provider": {
+      "name": "peppol_smp_provider",
+      "schema": "public",
+      "values": [
+        "recommand-smp1",
+        "at-shared-smp-fr"
+      ]
+    },
+    "public.peppol_supported_document_type": {
+      "name": "peppol_supported_document_type",
+      "schema": "public",
+      "values": [
+        "invoice",
+        "creditNote",
+        "selfBillingInvoice",
+        "selfBillingCreditNote",
+        "messageLevelResponse",
+        "frenchInvoicingCdar",
+        "frenchB2CSalesReport",
+        "frenchB2CPaymentReport",
+        "frenchB2BiInvoiceReport",
+        "frenchB2BiPaymentReport",
+        "unknown"
+      ]
+    },
+    "public.peppol_transfer_event_direction": {
+      "name": "peppol_transfer_event_direction",
+      "schema": "public",
+      "values": [
+        "incoming",
+        "outgoing"
+      ]
+    },
+    "public.peppol_transfer_event_type": {
+      "name": "peppol_transfer_event_type",
+      "schema": "public",
+      "values": [
+        "peppol",
+        "email",
+        "reporting"
+      ]
+    },
+    "public.peppol_valid_country_codes": {
+      "name": "peppol_valid_country_codes",
+      "schema": "public",
+      "values": [
+        "AU",
+        "AT",
+        "BE",
+        "BG",
+        "CA",
+        "HR",
+        "DK",
+        "EE",
+        "FI",
+        "FR",
+        "DE",
+        "GR",
+        "HK",
+        "HU",
+        "IS",
+        "IE",
+        "IT",
+        "JP",
+        "LV",
+        "LU",
+        "MY",
+        "NL",
+        "NZ",
+        "NO",
+        "PL",
+        "PT",
+        "RO",
+        "SG",
+        "SK",
+        "SI",
+        "ES",
+        "SE",
+        "AE",
+        "GB",
+        "US"
+      ]
+    },
+    "public.peppol_valid_iso_icd_scheme_identifiers": {
+      "name": "peppol_valid_iso_icd_scheme_identifiers",
+      "schema": "public",
+      "values": [
+        "0002",
+        "0003",
+        "0004",
+        "0005",
+        "0006",
+        "0007",
+        "0008",
+        "0009",
+        "0010",
+        "0011",
+        "0012",
+        "0013",
+        "0014",
+        "0015",
+        "0016",
+        "0017",
+        "0018",
+        "0019",
+        "0020",
+        "0021",
+        "0022",
+        "0023",
+        "0024",
+        "0025",
+        "0026",
+        "0027",
+        "0028",
+        "0029",
+        "0030",
+        "0031",
+        "0032",
+        "0033",
+        "0034",
+        "0035",
+        "0036",
+        "0037",
+        "0038",
+        "0039",
+        "0040",
+        "0041",
+        "0042",
+        "0043",
+        "0044",
+        "0045",
+        "0046",
+        "0047",
+        "0048",
+        "0049",
+        "0050",
+        "0051",
+        "0052",
+        "0053",
+        "0054",
+        "0055",
+        "0056",
+        "0057",
+        "0058",
+        "0059",
+        "0060",
+        "0061",
+        "0062",
+        "0063",
+        "0064",
+        "0065",
+        "0066",
+        "0067",
+        "0068",
+        "0069",
+        "0070",
+        "0071",
+        "0072",
+        "0073",
+        "0074",
+        "0075",
+        "0076",
+        "0077",
+        "0078",
+        "0079",
+        "0080",
+        "0081",
+        "0082",
+        "0083",
+        "0084",
+        "0085",
+        "0086",
+        "0087",
+        "0088",
+        "0089",
+        "0090",
+        "0091",
+        "0093",
+        "0094",
+        "0095",
+        "0096",
+        "0097",
+        "0098",
+        "0099",
+        "0100",
+        "0101",
+        "0102",
+        "0104",
+        "0105",
+        "0106",
+        "0107",
+        "0108",
+        "0109",
+        "0110",
+        "0111",
+        "0112",
+        "0113",
+        "0114",
+        "0115",
+        "0116",
+        "0117",
+        "0118",
+        "0119",
+        "0120",
+        "0121",
+        "0122",
+        "0123",
+        "0124",
+        "0125",
+        "0126",
+        "0127",
+        "0128",
+        "0129",
+        "0130",
+        "0131",
+        "0132",
+        "0133",
+        "0134",
+        "0135",
+        "0136",
+        "0137",
+        "0138",
+        "0139",
+        "0140",
+        "0141",
+        "0142",
+        "0143",
+        "0144",
+        "0145",
+        "0146",
+        "0147",
+        "0148",
+        "0149",
+        "0150",
+        "0151",
+        "0152",
+        "0153",
+        "0154",
+        "0155",
+        "0156",
+        "0157",
+        "0158",
+        "0159",
+        "0160",
+        "0161",
+        "0162",
+        "0163",
+        "0164",
+        "0165",
+        "0166",
+        "0167",
+        "0168",
+        "0169",
+        "0170",
+        "0171",
+        "0172",
+        "0173",
+        "0174",
+        "0175",
+        "0176",
+        "0177",
+        "0178",
+        "0179",
+        "0180",
+        "0183",
+        "0184",
+        "0185",
+        "0186",
+        "0187",
+        "0188",
+        "0189",
+        "0190",
+        "0191",
+        "0192",
+        "0193",
+        "0194",
+        "0195",
+        "0196",
+        "0197",
+        "0198",
+        "0199",
+        "0200",
+        "0201",
+        "0202",
+        "0203",
+        "0204",
+        "0205",
+        "0206",
+        "0207",
+        "0208",
+        "0209",
+        "0210",
+        "0211",
+        "0212",
+        "0213",
+        "0214",
+        "0215",
+        "0216",
+        "0217",
+        "0218",
+        "0219",
+        "0220",
+        "0221",
+        "0222",
+        "0223",
+        "0224",
+        "0225",
+        "0226",
+        "0227",
+        "0228",
+        "0229",
+        "0230",
+        "0231",
+        "0232",
+        "0233",
+        "0234",
+        "0235",
+        "0236",
+        "0237",
+        "0238",
+        "0239",
+        "0240"
+      ]
+    },
+    "public.peppol_validation_result": {
+      "name": "peppol_validation_result",
+      "schema": "public",
+      "values": [
+        "valid",
+        "invalid",
+        "not_supported",
+        "error"
+      ]
+    },
+    "public.verification_requirements": {
+      "name": "verification_requirements",
+      "schema": "public",
+      "values": [
+        "strict",
+        "trusted",
+        "lax"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "opened",
+        "idVerificationRequested",
+        "inReview",
+        "verified",
+        "rejected",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/drizzle/meta/_journal.json
+++ b/db/drizzle/meta/_journal.json
@@ -743,6 +743,13 @@
       "when": 1788859469135,
       "tag": "20260908092429_fr_reporting_submissions",
       "breakpoints": true
+    },
+    {
+      "idx": 106,
+      "version": "7",
+      "when": 1788985361719,
+      "tag": "20260909202241_document_deliveries",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -33,6 +33,7 @@ import { STORED_DOCUMENT_TYPE_KEYS } from "@peppol/utils/type-repository/documen
 import type { ParsedDocument } from "@peppol/utils/type-repository/document-types/parsed";
 import { zodValidIsoIcdSchemeIdentifiers } from "@peppol/utils/iso-icd-scheme-identifiers";
 import type { Representative } from "@peppol/data/cbe-public-search/types";
+import type { EmailFallbackRequest } from "@peppol/data/deliveries/email-fallback";
 import { labels } from "@directory/db/schema";
 
 export const paymentStatusEnum = pgEnum("peppol_payment_status", [
@@ -622,6 +623,12 @@ export const transmittedDocuments = pgTable(
     sentOverPeppol: boolean("sent_over_peppol").notNull().default(true),
     sentOverEmail: boolean("sent_over_email").notNull().default(false),
     emailRecipients: text("email_recipients").notNull().array().default([]),
+    // The email the sender asked for in case the Peppol transmission fails, when the
+    // access point accepted the transmission and has not yet said whether it arrived.
+    // Marked started when it is acted on and cleared when that is done, so a failure
+    // reported twice sends it once and a run that stops can be resumed (see
+    // data/deliveries/email-fallback).
+    emailFallback: jsonb("email_fallback").$type<EmailFallbackRequest>(),
 
     type: supportedDocumentTypeEnum("type").notNull().default("unknown"),
     parsed: jsonb("parsed").$type<ParsedDocument>(),
@@ -665,6 +672,11 @@ export const transmittedDocuments = pgTable(
     // sending pipeline and the provider webhooks write this id, and the
     // constraint is what makes a transaction impossible to record twice
     // instead of merely unlikely to be.
+    // The few documents with a fallback waiting or under way, for the drain that
+    // resumes stopped runs.
+    index("peppol_transmitted_documents_email_fallback_idx")
+      .on(table.id)
+      .where(isNotNull(table.emailFallback)),
     uniqueIndex("peppol_transmitted_documents_ap_transaction_id_idx")
       .on(table.apTransactionId)
       .where(isNotNull(table.apTransactionId)),
@@ -796,6 +808,116 @@ export const outgoingEnvelopeClaims = pgTable("peppol_outgoing_envelope_claims",
 }, (table) => [
   index("peppol_outgoing_envelope_claims_created_at_idx").on(table.createdAt),
 ]);
+
+// How a document was handed to one recipient. A document is the content; a delivery
+// is one attempt to get it to one address over one channel, so a document sent over
+// Peppol and to two email addresses has three. New channels are added here.
+export const deliveryChannels = ["peppol", "email"] as const;
+export const deliveryChannelEnum = pgEnum("peppol_delivery_channel", deliveryChannels);
+
+// Where a delivery stands, in the same words for every channel. `pending` means the
+// channel accepted the document and has not said whether it arrived; `delivered`
+// means it confirmed arrival (for Peppol the recipient's access point acknowledged
+// the message, for email the recipient's mail server accepted it); `failed` is final.
+// A recipient-side rejection, reported after delivery, is a later addition.
+export const deliveryStatuses = ["pending", "delivered", "failed"] as const;
+export const deliveryStatusEnum = pgEnum("peppol_delivery_status", deliveryStatuses);
+
+// Why a delivery failed, in the channel's own terms rather than a provider's. The
+// provider's own code is kept next to it.
+export const deliveryFailureCategories = [
+  "recipient_not_found",
+  "document_not_supported",
+  "validation",
+  "transport",
+  "recipient_rejected",
+  "duplicate",
+  "other",
+] as const;
+export const deliveryFailureCategoryEnum = pgEnum(
+  "peppol_delivery_failure_category",
+  deliveryFailureCategories
+);
+
+// One row per delivery of an outgoing document (see data/deliveries). Written with
+// the document, and moved on by what the channel reports afterwards: an access point
+// that only confirms or fails a transmission later does so through its webhook or
+// the reconciliation poll. Incoming documents and filed reports have none. The
+// transport references (message, conversation and envelope ids) stay on the document.
+export const documentDeliveries = pgTable(
+  "peppol_document_deliveries",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => "dlv_" + ulid()),
+    transmittedDocumentId: text("transmitted_document_id")
+      .references(() => transmittedDocuments.id, { onDelete: "cascade" })
+      .notNull(),
+    teamId: text("team_id").notNull(),
+    companyId: text("company_id").notNull(),
+    channel: deliveryChannelEnum("channel").notNull(),
+    // The Peppol address or email address the document was delivered to.
+    address: text("address").notNull(),
+    status: deliveryStatusEnum("status").notNull(),
+    statusChangedAt: timestamp("status_changed_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    failureCategory: deliveryFailureCategoryEnum("failure_category"),
+    failureMessage: text("failure_message"),
+    failureProviderCode: text("failure_provider_code"),
+    // The service that carried the delivery: the access point provider for Peppol.
+    // Null for a simulated transmission and for channels without a provider record.
+    provider: text("provider"),
+    useTestNetwork: boolean("use_test_network").notNull().default(false),
+    // The provider's own reference for the transmission, which is what its later
+    // reports are matched on. Unique so a report can only ever land on one delivery.
+    providerTransactionId: text("provider_transaction_id"),
+    // The provider's id and name for the last report applied, and that report's
+    // payload as received, for support.
+    providerEventId: text("provider_event_id"),
+    providerEventType: text("provider_event_type"),
+    providerPayload: jsonb("provider_payload").$type<Record<string, unknown>>(),
+    // When the provider was last asked about a delivery that was still pending.
+    lastCheckedAt: timestamp("last_checked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: autoUpdateTimestamp(),
+  },
+  (table) => [
+    index("peppol_document_deliveries_document_idx").on(table.transmittedDocumentId),
+    uniqueIndex("peppol_document_deliveries_provider_transaction_idx")
+      .on(table.providerTransactionId)
+      .where(isNotNull(table.providerTransactionId)),
+    index("peppol_document_deliveries_pending_idx").on(
+      table.status,
+      table.channel,
+      table.statusChangedAt
+    ),
+  ]
+);
+
+// A delivery outcome a provider reported for a transaction that has no delivery yet.
+// The report can arrive before the send that produced the transaction has recorded
+// its document, so it waits here, keyed by the transaction, and is applied when the
+// document's deliveries are written (see data/deliveries). One row per transaction,
+// however many times the provider retries the report.
+export const providerDeliveryReports = pgTable("peppol_provider_delivery_reports", {
+  providerTransactionId: text("provider_transaction_id").primaryKey(),
+  channel: deliveryChannelEnum("channel").notNull(),
+  provider: text("provider").notNull(),
+  useTestNetwork: boolean("use_test_network").notNull().default(false),
+  status: deliveryStatusEnum("status").notNull(),
+  failureCategory: deliveryFailureCategoryEnum("failure_category"),
+  failureMessage: text("failure_message"),
+  failureProviderCode: text("failure_provider_code"),
+  eventId: text("event_id"),
+  eventType: text("event_type"),
+  payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+  reportedAt: timestamp("reported_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
 
 export const transmittedDocumentLabels = pgTable(
   "peppol_transmitted_document_labels",

--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,8 @@ import { initializeS3DeletionCronJobs } from "./data/s3-deletion/cron";
 import { initializeArratechOnboardingCron } from "./data/at/kyc-onboarding";
 import { initializeFrenchReportingDeclarantCron } from "./data/fr-reporting-declarants";
 import { initializeFrenchReportingStatusCron } from "./data/fr-reporting-submissions";
+import { initializeDeliveryReconciliationCron } from "./data/deliveries/reconcile";
+import { initializeDeliveryBackfillCron } from "./data/deliveries/backfill";
 import { createMarkdownFromOpenApi } from "@scalar/openapi-to-markdown";
 import { onTeamCreated, onTeamBeforeDelete } from "./lib/backend-events";
 import { addBackendEventListener, CORE_BACKEND_EVENTS } from "@core/lib/backend-events";
@@ -64,6 +66,8 @@ export async function init(app: RecommandApp, server: Server) {
   initializeArratechOnboardingCron(logger);
   initializeFrenchReportingDeclarantCron(logger);
   initializeFrenchReportingStatusCron(logger);
+  initializeDeliveryReconciliationCron(logger);
+  initializeDeliveryBackfillCron(logger);
 
   initializeMetricsServer(logger);
 

--- a/lib/event-types.ts
+++ b/lib/event-types.ts
@@ -13,6 +13,11 @@ import {
   STORED_DOCUMENT_TYPE_KEYS,
   type StoredDocumentType,
 } from "@peppol/utils/type-repository/document-types/keys";
+import {
+  deliveryChannels,
+  deliveryFailureCategories,
+  deliveryStatuses,
+} from "@peppol/db/schema";
 
 const receivedDocumentTypes = STORED_DOCUMENT_TYPE_KEYS;
 
@@ -65,6 +70,9 @@ const documentSentPayloadSchema = z.object({
   peppolConversationId: z.string().nullable().optional(),
   envelopeId: z.string().nullable().optional(),
   countryC1: z.string(),
+  // Where the document stood when it was recorded: delivered when the receipt came
+  // with the send, pending when the access point confirms later, null for a report.
+  deliveryStatus: z.enum(deliveryStatuses).nullable().optional(),
 });
 
 const documentLabelPayloadSchema = z.object({
@@ -104,6 +112,47 @@ const documentReportingStatusPayloadSchema = z.object({
   periodEnd: z.string().nullable().optional(),
   submissionId: z.string().nullable().optional(),
   outcomeCode: z.string().nullable().optional(),
+});
+
+const deliveryStatusLabels: Record<(typeof deliveryStatuses)[number], string> = {
+  pending: "Pending",
+  delivered: "Delivered",
+  failed: "Failed",
+};
+
+const deliveryFailureCategoryLabels: Record<(typeof deliveryFailureCategories)[number], string> = {
+  recipient_not_found: "Recipient not found",
+  document_not_supported: "Document not supported by recipient",
+  validation: "Validation",
+  transport: "Transport",
+  recipient_rejected: "Rejected by recipient",
+  duplicate: "Duplicate",
+  other: "Other",
+};
+
+// One delivery of a document moved to a new status: a channel confirmed arrival, or
+// failed a document it had accepted. Sent once per change.
+const documentDeliveryStatusPayloadSchema = z.object({
+  companyId: z.string(),
+  docType: z.string(),
+  senderId: z.string(),
+  receiverId: z.string().nullable(),
+  envelopeId: z.string().nullable().optional(),
+  deliveryId: z.string(),
+  channel: z.enum(deliveryChannels),
+  address: z.string(),
+  status: z.enum(deliveryStatuses),
+  // Null for a delivery that did not exist before, such as an email sent as the
+  // fallback for a Peppol transmission that failed after it was accepted.
+  previousStatus: z.enum(deliveryStatuses).nullable(),
+  failure: z
+    .object({
+      category: z.enum(deliveryFailureCategories),
+      message: z.string().nullable(),
+      providerCode: z.string().nullable(),
+    })
+    .nullable()
+    .optional(),
 });
 
 const companyVerificationPayloadSchema = z.object({
@@ -169,15 +218,20 @@ export function registerPeppolEventTypes() {
       documentTypeField,
       { path: "payload.senderId", label: "Sender address", valueType: "string", operators: ["eq", "neq", "in", "notIn"] },
       { path: "payload.receiverId", label: "Receiver address", valueType: "string", operators: ["eq", "neq", "in", "notIn"] },
+      { path: "payload.deliveryStatus", label: "Delivery status", valueType: "enum", operators: ["eq", "neq", "in", "notIn"], enumValues: [...deliveryStatuses], enumLabels: deliveryStatusLabels },
     ],
     webhook: {
       eventType: "document.sent",
-      project: (event) => ({
-        eventType: "document.sent",
-        documentId: event.aggregateId,
-        teamId: event.teamId,
-        companyId: (event.payload as z.infer<typeof documentSentPayloadSchema>).companyId,
-      }),
+      project: (event) => {
+        const payload = event.payload as z.infer<typeof documentSentPayloadSchema>;
+        return {
+          eventType: "document.sent",
+          documentId: event.aggregateId,
+          teamId: event.teamId,
+          companyId: payload.companyId,
+          deliveryStatus: payload.deliveryStatus ?? null,
+        };
+      },
     },
     email: {
       template: "document-outgoing-notification",
@@ -187,7 +241,7 @@ export function registerPeppolEventTypes() {
     },
     ui: {
       label: "Document sent",
-      description: "A document was sent by a company",
+      description: "A document was handed to the network or mailed; its delivery status says whether the recipient has confirmed it yet",
       group: "Documents",
     },
   });
@@ -262,6 +316,44 @@ export function registerPeppolEventTypes() {
     },
     ui: {
       label: "Document label unassigned",
+      group: "Documents",
+    },
+  });
+
+  registerEventType({
+    type: "peppol.document.delivery_status.v1",
+    aggregateType: "peppol.document",
+    payload: documentDeliveryStatusPayloadSchema,
+    conditionFields: [
+      { path: "payload.companyId", label: "Company", valueType: "string", operators: ["eq", "neq", "in"], picker: "company" },
+      documentTypeField,
+      { path: "payload.senderId", label: "Sender address", valueType: "string", operators: ["eq", "neq", "in", "notIn"] },
+      { path: "payload.receiverId", label: "Receiver address", valueType: "string", operators: ["eq", "neq", "in", "notIn"] },
+      { path: "payload.channel", label: "Channel", valueType: "enum", operators: ["eq", "neq"], enumValues: [...deliveryChannels] },
+      { path: "payload.status", label: "Delivery status", valueType: "enum", operators: ["eq", "neq", "in", "notIn"], enumValues: [...deliveryStatuses], enumLabels: deliveryStatusLabels },
+      { path: "payload.failure.category", label: "Failure category", valueType: "enum", operators: ["eq", "neq", "in", "notIn"], enumValues: [...deliveryFailureCategories], enumLabels: deliveryFailureCategoryLabels },
+    ],
+    webhook: {
+      eventType: "document.delivery_status_changed",
+      project: (event) => {
+        const payload = event.payload as z.infer<typeof documentDeliveryStatusPayloadSchema>;
+        return {
+          eventType: "document.delivery_status_changed",
+          documentId: event.aggregateId,
+          teamId: event.teamId,
+          companyId: payload.companyId,
+          deliveryId: payload.deliveryId,
+          channel: payload.channel,
+          address: payload.address,
+          status: payload.status,
+          previousStatus: payload.previousStatus,
+          failure: payload.failure ?? null,
+        };
+      },
+    },
+    ui: {
+      label: "Delivery status changed",
+      description: "A delivery of a sent document was confirmed, or failed after the channel had accepted it",
       group: "Documents",
     },
   });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "db:generate": "drizzle-kit generate",
     "test": "bun test ./test/*.test.ts",
-    "test:unit": "SKIP_E2E=1 bun test ./test/*.test.ts && SKIP_E2E=1 bun test ./test/arratech/onboarding.test.ts",
+    "test:unit": "SKIP_E2E=1 bun test ./test/*.test.ts && SKIP_E2E=1 bun test ./test/arratech/onboarding.test.ts && for f in ./test/persistence/*.test.ts; do SKIP_E2E=1 bun test $f || exit 1; done && bun run test:db",
+    "test:db": "for f in ./test/db/*.db.test.ts; do SKIP_E2E=1 bun test $f || exit 1; done",
     "test:e2e": "bun test --timeout 120000 ./test/e2e/",
     "test:regression": "bun test --timeout 120000 --only-failures --max-concurrency 20 ./test/regression/",
     "email:dev": "email dev --port 3002"

--- a/test/arratech-request-deadline.test.ts
+++ b/test/arratech-request-deadline.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { fetchArratechJson } from "../data/at/client";
+
+// A request to the access point is bounded by the signal the caller passes, and the
+// bound has to cover reading the response body: a response whose body never ends
+// leaves the read pending, and the serial poll behind it would wait forever.
+
+const realFetch = globalThis.fetch;
+const environment = {
+  ARRATECH_API_URL: "https://provider.invalid",
+  ARRATECH_API_KEY: "key",
+  ARRATECH_ORG_ID: "org-1",
+  ARRATECH_SMP_REF: "smp",
+  ARRATECH_AP_REF: "ap",
+};
+const previous: Record<string, string | undefined> = {};
+
+/** A response whose headers arrived and whose body never does. */
+function trickling(ok: boolean): Response {
+  const never = new Promise<never>(() => {});
+  return {
+    ok,
+    statusText: "OK",
+    json: () => never,
+    text: () => never,
+  } as unknown as Response;
+}
+
+beforeAll(() => {
+  for (const [name, value] of Object.entries(environment)) {
+    previous[name] = process.env[name];
+    process.env[name] = value;
+  }
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+  for (const [name, value] of Object.entries(previous)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+});
+
+describe("a request to the access point with a deadline", () => {
+  it("gives up when the response body never ends", async () => {
+    globalThis.fetch = (async () => trickling(true)) as unknown as typeof fetch;
+
+    await expect(
+      fetchArratechJson("/orgs/org-1/transactions/tx-1", {
+        method: "GET",
+        useTestNetwork: false,
+        signal: AbortSignal.timeout(20),
+      })
+    ).rejects.toThrow(/timed out|aborted/i);
+  });
+
+  it("gives up on an error response whose body never ends either", async () => {
+    globalThis.fetch = (async () => trickling(false)) as unknown as typeof fetch;
+
+    await expect(
+      fetchArratechJson("/orgs/org-1/transactions/tx-1", {
+        method: "GET",
+        useTestNetwork: false,
+        signal: AbortSignal.timeout(20),
+      })
+    ).rejects.toThrow(/timed out|aborted/i);
+  });
+
+  it("returns the body of a response that arrives in time", async () => {
+    globalThis.fetch = (async () =>
+      ({ ok: true, json: async () => ({ transactionStatus: "COMPLETED" }) }) as unknown as Response) as unknown as typeof fetch;
+
+    expect(
+      await fetchArratechJson<{ transactionStatus: string }>("/orgs/org-1/transactions/tx-1", {
+        method: "GET",
+        useTestNetwork: false,
+        signal: AbortSignal.timeout(1_000),
+      })
+    ).toEqual({ transactionStatus: "COMPLETED" });
+  });
+
+  it("waits as long as it takes when the caller sets no deadline", async () => {
+    globalThis.fetch = (async () =>
+      ({ ok: true, json: async () => ({ transactionStatus: "COMPLETED" }) }) as unknown as Response) as unknown as typeof fetch;
+
+    expect(
+      await fetchArratechJson<{ transactionStatus: string }>("/orgs/org-1/transactions/tx-1", {
+        method: "GET",
+        useTestNetwork: false,
+      })
+    ).toEqual({ transactionStatus: "COMPLETED" });
+  });
+});

--- a/test/db/backfill-locks.db.test.ts
+++ b/test/db/backfill-locks.db.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { drizzle } from "drizzle-orm/node-postgres";
+import type { Pool } from "pg";
+import {
+  connectTestDatabase,
+  deliveryRows,
+  seedDocument,
+  seedTeamAndCompany,
+  testDatabaseUrl,
+  truncateDocumentData,
+} from "./harness";
+
+// The backfill selects its documents with SKIP LOCKED, so a row another transaction
+// holds is left out of the batch rather than waited for. An empty batch is therefore
+// not proof that every document has its deliveries, and the job may not declare
+// itself done on one. Only a real PostgreSQL can hold a row lock, so that is where
+// this is asserted.
+
+let pool: Pool;
+let backfill: typeof import("../../data/deliveries/backfill");
+
+describe.skipIf(!testDatabaseUrl)("the delivery backfill under a held row lock", () => {
+  beforeAll(async () => {
+    pool = await connectTestDatabase();
+    mock.module("@recommand/db", () => ({ db: drizzle(pool) }));
+    mock.module("@peppol/utils/system-notifications/telegram", () => ({ sendSystemAlert: () => {} }));
+    backfill = await import("../../data/deliveries/backfill");
+    await seedTeamAndCompany(pool);
+  }, 60_000);
+
+  afterAll(async () => {
+    await pool?.end();
+  });
+
+  beforeEach(async () => {
+    await truncateDocumentData(pool);
+  });
+
+  it("does not finish while a locked document is uncovered, and covers it once the lock is released", async () => {
+    await seedDocument(pool, { id: "doc_01" });
+    await seedDocument(pool, { id: "doc_02" });
+    await seedDocument(pool, { id: "doc_03" });
+
+    const holder = await pool.connect();
+    const state = backfill.initialBackfillState();
+    try {
+      // A normal update of the document holds its row while the backfill runs.
+      await holder.query("BEGIN");
+      await holder.query(
+        "SELECT id FROM peppol_transmitted_documents WHERE id = 'doc_03' FOR UPDATE"
+      );
+
+      const held = await backfill.runDeliveryBackfill(backfill.databaseBackfillStore, state, {
+        batchSize: 2,
+      });
+
+      expect(held.documents).toBe(2);
+      // The pass that could not see doc_03 wrote nothing at its end, but the read
+      // that waits for nobody still finds it uncovered.
+      expect(held.finished).toBe(false);
+      expect(state.finished).toBe(false);
+      expect(await deliveryRows(pool, "doc_03")).toEqual([]);
+    } finally {
+      await holder.query("COMMIT");
+      holder.release();
+    }
+
+    const released = await backfill.runDeliveryBackfill(backfill.databaseBackfillStore, state, {
+      batchSize: 2,
+    });
+
+    expect(released.documents).toBe(1);
+    expect(released.finished).toBe(true);
+    expect(state.finished).toBe(true);
+    expect((await deliveryRows(pool, "doc_03")).map((row) => [row.channel, row.status])).toEqual([
+      ["peppol", "delivered"],
+    ]);
+    expect(await deliveryRows(pool)).toHaveLength(3);
+  });
+});

--- a/test/db/email-fallback-recovery.db.test.ts
+++ b/test/db/email-fallback-recovery.db.test.ts
@@ -1,0 +1,213 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { drizzle } from "drizzle-orm/node-postgres";
+import type { Pool } from "pg";
+import {
+  connectTestDatabase,
+  deliveryRows,
+  deliveryStatusEventRows,
+  seedDeliveryStatusRule,
+  seedDocument,
+  seedTeamAndCompany,
+  testDatabaseUrl,
+  truncateDocumentData,
+} from "./harness";
+
+// A fallback run hands messages to the mail service and then writes what became of
+// them. Between the two the process can die and the database can refuse the write,
+// and neither may cost the recipient's message its delivery row, its bill or its
+// place in the document's own email fields. What survives such a stop is a property
+// of what is committed and when, so it is asserted against a real PostgreSQL.
+
+const mailed: string[] = [];
+let pool: Pool;
+let runEmailFallbackForDocument: typeof import("../../data/deliveries/email-fallback-db").runEmailFallbackForDocument;
+let resumeStalledEmailFallbacks: typeof import("../../data/deliveries/email-fallback-db").resumeStalledEmailFallbacks;
+
+/** Makes every write of the customer's copy of an event fail, as a full event store would. */
+async function refuseEventWrites(pool: Pool) {
+  await pool.query(`
+    CREATE FUNCTION refuse_event_write() RETURNS trigger AS $$
+    BEGIN RAISE EXCEPTION 'event storage unavailable'; END;
+    $$ LANGUAGE plpgsql;
+    CREATE TRIGGER refuse_event_write BEFORE INSERT ON rule_action_deliveries
+      FOR EACH ROW EXECUTE FUNCTION refuse_event_write();
+  `);
+}
+
+async function allowEventWrites(pool: Pool) {
+  await pool.query(
+    "DROP TRIGGER refuse_event_write ON rule_action_deliveries; DROP FUNCTION refuse_event_write()"
+  );
+}
+
+async function documentRow(pool: Pool, id: string) {
+  const { rows } = await pool.query(
+    `SELECT sent_over_email AS "sentOverEmail", email_recipients AS "emailRecipients",
+            email_fallback AS "emailFallback"
+     FROM peppol_transmitted_documents WHERE id = $1`,
+    [id]
+  );
+  return rows[0] as {
+    sentOverEmail: boolean;
+    emailRecipients: string[];
+    emailFallback: { to: string[]; startedAt?: string; attempts?: Record<string, { deliveryId: string }> } | null;
+  };
+}
+
+async function billedEmails(pool: Pool, documentId: string) {
+  const { rows } = await pool.query(
+    `SELECT id, type FROM peppol_transfer_events WHERE transmitted_document_id = $1 ORDER BY id`,
+    [documentId]
+  );
+  return rows as { id: string; type: string }[];
+}
+
+describe.skipIf(!testDatabaseUrl)("recovering an email fallback against PostgreSQL", () => {
+  beforeAll(async () => {
+    pool = await connectTestDatabase();
+    mock.module("@recommand/db", () => ({ db: drizzle(pool) }));
+    mock.module("@peppol/utils/system-notifications/telegram", () => ({ sendSystemAlert: () => {} }));
+    mock.module("@peppol/data/email/send-email", () => ({
+      sendDocumentEmail: async ({ to }: { to: string }) => {
+        mailed.push(to);
+      },
+    }));
+    // The rules engine only writes for an event type it knows, so the real
+    // registration runs and the payload is validated by the schema the product ships.
+    (await import("../../lib/event-types")).registerPeppolEventTypes();
+    const module = await import("../../data/deliveries/email-fallback-db");
+    runEmailFallbackForDocument = module.runEmailFallbackForDocument;
+    resumeStalledEmailFallbacks = module.resumeStalledEmailFallbacks;
+    await seedTeamAndCompany(pool);
+    await seedDeliveryStatusRule(pool);
+  }, 60_000);
+
+  afterAll(async () => {
+    await pool?.end();
+  });
+
+  beforeEach(async () => {
+    mailed.length = 0;
+    await truncateDocumentData(pool);
+  });
+
+  it("records and bills a message the mail service accepted exactly once when the first run could not write the event", async () => {
+    await seedDocument(pool, {
+      id: "doc_fallback",
+      emailFallback: { to: ["a@example.com"], subject: "Invoice 1" },
+    });
+
+    await refuseEventWrites(pool);
+    try {
+      await expect(runEmailFallbackForDocument("doc_fallback")).rejects.toThrow(
+        /rule_action_deliveries|event storage unavailable/
+      );
+    } finally {
+      await allowEventWrites(pool);
+    }
+
+    // The message went out and its delivery row was written as the service accepted
+    // it; everything the closing transaction would have written rolled back.
+    expect(mailed).toEqual(["a@example.com"]);
+    const afterFailure = await deliveryRows(pool, "doc_fallback");
+    expect(afterFailure.map((row) => [row.channel, row.address, row.status])).toEqual([
+      ["email", "a@example.com", "pending"],
+    ]);
+    expect(await billedEmails(pool, "doc_fallback")).toEqual([]);
+    const stopped = await documentRow(pool, "doc_fallback");
+    expect(stopped.sentOverEmail).toBe(false);
+    expect(stopped.emailRecipients).toEqual([]);
+    // The request is still there, with the address noted and no run holding it.
+    expect(stopped.emailFallback).toMatchObject({
+      to: ["a@example.com"],
+      attempts: { "a@example.com": { deliveryId: afterFailure[0]!.id } },
+    });
+    expect(stopped.emailFallback?.startedAt).toBeUndefined();
+
+    const outcome = await runEmailFallbackForDocument("doc_fallback");
+
+    expect(outcome).toMatchObject({ kind: "sent", sent: ["a@example.com"], failed: [] });
+    // Nothing was mailed again, and the accepted message is billed once.
+    expect(mailed).toEqual(["a@example.com"]);
+    expect((await deliveryRows(pool, "doc_fallback")).map((row) => row.id)).toEqual([
+      afterFailure[0]!.id,
+    ]);
+    expect((await billedEmails(pool, "doc_fallback")).map((event) => event.type)).toEqual(["email"]);
+    const recorded = await documentRow(pool, "doc_fallback");
+    expect(recorded.sentOverEmail).toBe(true);
+    expect(recorded.emailRecipients).toEqual(["a@example.com"]);
+    expect(recorded.emailFallback).toBeNull();
+    expect(await deliveryStatusEventRows(pool)).toHaveLength(1);
+
+    // A third report finds the request closed and does nothing at all.
+    expect(await runEmailFallbackForDocument("doc_fallback")).toEqual({ kind: "none" });
+    expect(mailed).toEqual(["a@example.com"]);
+    expect((await billedEmails(pool, "doc_fallback")).map((event) => event.type)).toEqual(["email"]);
+  });
+
+  it("leaves a request another run started on recently alone", async () => {
+    await seedDocument(pool, {
+      id: "doc_held",
+      emailFallback: { to: ["a@example.com"], startedAt: new Date().toISOString() },
+    });
+
+    expect(await runEmailFallbackForDocument("doc_held")).toEqual({ kind: "none" });
+    expect(mailed).toEqual([]);
+    expect(await deliveryRows(pool, "doc_held")).toEqual([]);
+  });
+
+  it("finishes, from the drain, a run whose process died after the mail service accepted the message", async () => {
+    const deliveryId = "dlv_stalled";
+    await seedDocument(pool, {
+      id: "doc_stalled",
+      emailFallback: {
+        to: ["a@example.com"],
+        // Long enough ago that the run that left this is taken to have died.
+        startedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        attempts: { "a@example.com": { deliveryId } },
+      },
+    });
+    await pool.query(
+      `INSERT INTO peppol_document_deliveries
+         (id, transmitted_document_id, team_id, company_id, channel, address, status)
+       SELECT $1, id, team_id, company_id, 'email', 'a@example.com', 'pending'
+       FROM peppol_transmitted_documents WHERE id = 'doc_stalled'`,
+      [deliveryId]
+    );
+
+    expect(await resumeStalledEmailFallbacks()).toEqual({ found: 1, resumed: 1 });
+
+    expect(mailed).toEqual([]);
+    expect((await deliveryRows(pool, "doc_stalled")).map((row) => row.id)).toEqual([deliveryId]);
+    expect((await billedEmails(pool, "doc_stalled")).map((event) => event.type)).toEqual(["email"]);
+    const recorded = await documentRow(pool, "doc_stalled");
+    expect(recorded.sentOverEmail).toBe(true);
+    expect(recorded.emailRecipients).toEqual(["a@example.com"]);
+    expect(recorded.emailFallback).toBeNull();
+
+    // Nothing is left for the next drain.
+    expect(await resumeStalledEmailFallbacks()).toEqual({ found: 0, resumed: 0 });
+  });
+
+  it("closes an address whose answer was never written as failed rather than mailing it again", async () => {
+    await seedDocument(pool, {
+      id: "doc_unknown",
+      emailFallback: {
+        to: ["a@example.com"],
+        startedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        attempts: { "a@example.com": { deliveryId: "dlv_unknown" } },
+      },
+    });
+
+    const outcome = await runEmailFallbackForDocument("doc_unknown");
+
+    expect(mailed).toEqual([]);
+    expect(outcome).toMatchObject({ kind: "sent", sent: [] });
+    expect((await deliveryRows(pool, "doc_unknown")).map((row) => [row.id, row.status, row.failureCategory])).toEqual([
+      ["dlv_unknown", "failed", "other"],
+    ]);
+    // Nothing went out, so nothing is billed and the document's fields are untouched.
+    expect(await billedEmails(pool, "doc_unknown")).toEqual([]);
+    expect((await documentRow(pool, "doc_unknown")).sentOverEmail).toBe(false);
+  });
+});

--- a/test/db/harness.ts
+++ b/test/db/harness.ts
@@ -1,0 +1,216 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Pool } from "pg";
+
+// The shared setup for the tests that run against a real PostgreSQL. What they are
+// for is the part of the deliveries model that only a database can show: what two
+// callers racing for the same row see, what survives a rollback, and what a query
+// returns over rows that were actually written. The unit tests next to them fake the
+// database module and can only show how the code reacts to answers it is handed.
+//
+// The tests skip themselves unless PEPPOL_TEST_DATABASE_URL points at a disposable
+// database. To run them:
+//
+//   docker run -d --rm --name peppol-deliveries-test \
+//     -e POSTGRES_PASSWORD=deliveries -e POSTGRES_DB=peppol_test \
+//     -p 127.0.0.1:5439:5432 postgres:16-alpine
+//   PEPPOL_TEST_DATABASE_URL=postgres://postgres:deliveries@127.0.0.1:5439/peppol_test \
+//     bun run test:db
+//   docker stop peppol-deliveries-test
+
+export const testDatabaseUrl = process.env.PEPPOL_TEST_DATABASE_URL;
+
+const packageDirectory = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const packagesDirectory = join(packageDirectory, "..");
+
+// The packages this one's tables need: the framework's migration bookkeeping, the
+// core tables peppol's foreign keys point at, and peppol's own. The other packages
+// are left out because they are not needed here and some of them own tables peppol
+// also creates, which the server resolves by loading only one of the two.
+const MIGRATED_PACKAGES = ["framework", "core", "peppol"] as const;
+
+/**
+ * The migrations in the order the server applies them: the framework's first, then
+ * the rest by filename, so a package that references another's tables finds them.
+ * Reading them from the packages themselves keeps the test schema the one production
+ * has rather than a hand-kept copy.
+ */
+async function migrationFiles(): Promise<string[]> {
+  const collect = async (name: string) => {
+    const directory = join(packagesDirectory, name, "db", "drizzle");
+    const files = await readdir(directory);
+    return files.filter((file) => file.endsWith(".sql")).sort().map((file) => join(directory, file));
+  };
+  const framework = await collect("framework");
+  const others = (
+    await Promise.all(MIGRATED_PACKAGES.filter((name) => name !== "framework").map(collect))
+  )
+    .flat()
+    .sort((left, right) => left.localeCompare(right));
+  return [...framework, ...others];
+}
+
+/**
+ * An empty database with the current schema. The connection is refused unless it
+ * names a local database whose name ends in `_test`: everything here drops and
+ * truncates, and it must never be able to do that to a database someone uses.
+ */
+export async function connectTestDatabase(): Promise<Pool> {
+  const url = new URL(testDatabaseUrl!);
+  if (!["localhost", "127.0.0.1"].includes(url.hostname) || !url.pathname.endsWith("_test")) {
+    throw new Error("Use a disposable database on localhost whose name ends in _test");
+  }
+  const pool = new Pool({ connectionString: testDatabaseUrl });
+  await pool.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public");
+  for (const file of await migrationFiles()) {
+    await pool.query(await readFile(file, "utf-8"));
+  }
+  return pool;
+}
+
+export const TEAM_ID = "team_db_test";
+export const COMPANY_ID = "cmp_db_test";
+
+/** The one team and company every document in these tests belongs to. */
+export async function seedTeamAndCompany(pool: Pool, options: { useTestNetwork?: boolean } = {}) {
+  await pool.query(
+    `INSERT INTO teams (id, name) VALUES ($1, 'Delivery tests') ON CONFLICT (id) DO NOTHING`,
+    [TEAM_ID]
+  );
+  await pool.query(
+    `INSERT INTO peppol_team_extensions (id, is_playground, use_test_network) VALUES ($1, false, $2)
+     ON CONFLICT (id) DO UPDATE SET use_test_network = excluded.use_test_network`,
+    [TEAM_ID, options.useTestNetwork ?? false]
+  );
+  await pool.query(
+    `INSERT INTO peppol_companies (id, team_id, name, address, postal_code, city, country, access_point_provider, smp_provider)
+     VALUES ($1, $2, 'Example SARL', '1 Rue', '75001', 'Paris', 'FR', 'at-shared-ap-fr', 'at-shared-smp-fr')
+     ON CONFLICT (id) DO NOTHING`,
+    [COMPANY_ID, TEAM_ID]
+  );
+}
+
+/** A rule whose webhook action turns every delivery status event into a stored row. */
+export async function seedDeliveryStatusRule(pool: Pool, id = "rule_delivery_status") {
+  await pool.query(
+    `INSERT INTO rules (id, team_id, name, enabled, event_type, condition, actions, schema_version)
+     VALUES ($1, $2, 'Delivery status', true, 'peppol.document.delivery_status.v1', null, $3, 1)
+     ON CONFLICT (id) DO NOTHING`,
+    [
+      id,
+      TEAM_ID,
+      JSON.stringify([
+        { type: "webhook", version: 1, config: { url: "https://example.com/hook" } },
+      ]),
+    ]
+  );
+  return id;
+}
+
+/** Everything the tests write, emptied between them; the team and company stay. */
+export async function truncateDocumentData(pool: Pool) {
+  await pool.query(
+    `TRUNCATE peppol_transmitted_documents, peppol_document_deliveries, peppol_provider_delivery_reports,
+              rule_action_deliveries, audit_events, peppol_transfer_events CASCADE`
+  );
+}
+
+export type SeedDocument = {
+  id: string;
+  direction?: "incoming" | "outgoing";
+  receiverId?: string | null;
+  sentOverPeppol?: boolean;
+  sentOverEmail?: boolean;
+  emailRecipients?: string[];
+  emailFallback?: Record<string, unknown> | null;
+  accessPointProvider?: string;
+  apTransactionId?: string | null;
+  externalReferenceId?: string | null;
+  envelopeId?: string | null;
+  createdAt?: Date;
+};
+
+export async function seedDocument(pool: Pool, document: SeedDocument) {
+  await pool.query(
+    `INSERT INTO peppol_transmitted_documents
+       (id, team_id, company_id, direction, sender_id, receiver_id, doc_type_id, process_id, country_c1,
+        access_point_provider, smp_provider, sent_over_peppol, sent_over_email, email_recipients, email_fallback,
+        ap_transaction_id, external_reference_id, envelope_id, type, xml_location, attachments_location, created_at)
+     VALUES ($1, $2, $3, $4, '0225:123456789', $5, 'doc-type', 'process', 'FR',
+             $6, 'at-shared-smp-fr', $7, $8, $9, $10, $11, $12, $13, 'invoice', 'none', 'none', $14)`,
+    [
+      document.id,
+      TEAM_ID,
+      COMPANY_ID,
+      document.direction ?? "outgoing",
+      document.receiverId === undefined ? "0208:987654321" : document.receiverId,
+      document.accessPointProvider ?? "recommand-ap1",
+      document.sentOverPeppol ?? true,
+      document.sentOverEmail ?? false,
+      document.emailRecipients ?? [],
+      document.emailFallback ? JSON.stringify(document.emailFallback) : null,
+      document.apTransactionId ?? null,
+      document.externalReferenceId ?? null,
+      document.envelopeId ?? null,
+      document.createdAt ?? new Date("2026-03-01T10:00:00Z"),
+    ]
+  );
+}
+
+export type SeedDelivery = {
+  id: string;
+  documentId: string;
+  channel?: "peppol" | "email";
+  address?: string;
+  status?: "pending" | "delivered" | "failed";
+  provider?: string | null;
+  providerTransactionId?: string | null;
+  failureCategory?: string | null;
+};
+
+export async function seedDelivery(pool: Pool, delivery: SeedDelivery) {
+  await pool.query(
+    `INSERT INTO peppol_document_deliveries
+       (id, transmitted_document_id, team_id, company_id, channel, address, status, provider, provider_transaction_id, failure_category)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+    [
+      delivery.id,
+      delivery.documentId,
+      TEAM_ID,
+      COMPANY_ID,
+      delivery.channel ?? "peppol",
+      delivery.address ?? "0208:987654321",
+      delivery.status ?? "pending",
+      delivery.provider ?? null,
+      delivery.providerTransactionId ?? null,
+      delivery.failureCategory ?? null,
+    ]
+  );
+}
+
+export async function deliveryRows(pool: Pool, documentId?: string) {
+  const { rows } = documentId
+    ? await pool.query(
+        `SELECT id, channel, address, status, provider, provider_transaction_id AS "providerTransactionId",
+                failure_category AS "failureCategory", failure_message AS "failureMessage",
+                failure_provider_code AS "failureProviderCode", status_changed_at AS "statusChangedAt",
+                created_at AS "createdAt", use_test_network AS "useTestNetwork"
+         FROM peppol_document_deliveries WHERE transmitted_document_id = $1 ORDER BY channel, address`,
+        [documentId]
+      )
+    : await pool.query(
+        `SELECT id, transmitted_document_id AS "documentId", channel, address, status
+         FROM peppol_document_deliveries ORDER BY transmitted_document_id, channel, address`
+      );
+  return rows;
+}
+
+/** The rows the rules engine wrote for delivery status events: the customer's copy. */
+export async function deliveryStatusEventRows(pool: Pool) {
+  const { rows } = await pool.query(
+    `SELECT id, event_id AS "eventId", idempotency_key AS "idempotencyKey", payload
+     FROM rule_action_deliveries WHERE event_type = 'peppol.document.delivery_status.v1' ORDER BY created_at, id`
+  );
+  return rows as { id: string; eventId: string; idempotencyKey: string; payload: { payload: Record<string, unknown> } }[];
+}

--- a/test/deliveries-backfill.test.ts
+++ b/test/deliveries-backfill.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, mock } from "bun:test";
+
+// The row rules and the batch loop are pure; the database store is exercised against
+// a real Postgres separately, so the connection is never opened here.
+mock.module("@recommand/db", () => ({ db: {} }));
+
+const {
+  buildHistoricalDeliveries,
+  initialBackfillState,
+  runDeliveryBackfill,
+} = await import("../data/deliveries/backfill");
+type BackfillStore = import("../data/deliveries/backfill").BackfillStore;
+type HistoricalOutgoingDocument = import("../data/deliveries/backfill").HistoricalOutgoingDocument;
+
+const createdAt = new Date("2026-03-01T10:00:00Z");
+
+function document(overrides: Partial<HistoricalOutgoingDocument> & { id: string }): HistoricalOutgoingDocument {
+  return {
+    teamId: "team_1",
+    companyId: "cmp_1",
+    receiverId: "0208:1",
+    sentOverPeppol: true,
+    emailRecipients: [],
+    accessPointProvider: "recommand-ap1",
+    apTransactionId: null,
+    useTestNetwork: false,
+    createdAt,
+    ...overrides,
+  };
+}
+
+describe("deliveries for documents recorded before delivery tracking", () => {
+  it("marks a transmission through our own access point delivered, dated with the document", () => {
+    const rows = buildHistoricalDeliveries(document({ id: "doc_1" }));
+    expect(rows).toEqual([
+      expect.objectContaining({
+        transmittedDocumentId: "doc_1",
+        channel: "peppol",
+        address: "0208:1",
+        status: "delivered",
+        provider: null,
+        providerTransactionId: null,
+        statusChangedAt: createdAt,
+        createdAt,
+      }),
+    ]);
+  });
+
+  it("leaves a transmission through the shared access point pending for the poll, on the document's network", () => {
+    const [row] = buildHistoricalDeliveries(
+      document({ id: "doc_2", accessPointProvider: "at-shared-ap-fr", apTransactionId: "tx-1", useTestNetwork: true })
+    );
+    expect(row).toMatchObject({
+      status: "pending",
+      provider: "at-shared-ap-fr",
+      providerTransactionId: "tx-1",
+      useTestNetwork: true,
+    });
+  });
+
+  it("marks a simulated send delivered even for a company on the shared access point", () => {
+    const [row] = buildHistoricalDeliveries(document({ id: "doc_3", accessPointProvider: "at-shared-ap-fr" }));
+    expect(row).toMatchObject({ status: "delivered", provider: null, providerTransactionId: null });
+  });
+
+  it("marks a refused transmission that fell back to email failed, with one pending email delivery per address", () => {
+    const rows = buildHistoricalDeliveries(
+      document({ id: "doc_4", sentOverPeppol: false, emailRecipients: ["b@example.com", "c@example.com"] })
+    );
+    expect(rows.map((row) => [row.channel, row.address, row.status, row.failureCategory ?? null])).toEqual([
+      ["peppol", "0208:1", "failed", "other"],
+      ["email", "b@example.com", "pending", null],
+      ["email", "c@example.com", "pending", null],
+    ]);
+  });
+
+  it("creates only email deliveries for a document that was never addressed on the network", () => {
+    const rows = buildHistoricalDeliveries(
+      document({ id: "doc_5", receiverId: null, sentOverPeppol: false, emailRecipients: ["d@example.com"] })
+    );
+    expect(rows.map((row) => row.channel)).toEqual(["email"]);
+  });
+});
+
+/**
+ * An in-memory store with the same selection rule as the database one: outgoing
+ * documents in id order after the cursor that have no deliveries yet. A document in
+ * `locked` is held by another transaction: a batch skips it, as `SKIP LOCKED` does,
+ * while the read that waits for nobody still sees it.
+ */
+function fakeStore(
+  documents: HistoricalOutgoingDocument[],
+  failOnBatch?: number,
+  locked: Set<string> = new Set()
+) {
+  const deliveries: { transmittedDocumentId: string; channel: string }[] = [];
+  const batches: string[][] = [];
+  const remainingChecks: boolean[] = [];
+  const uncovered = () => {
+    const withDeliveries = new Set(deliveries.map((delivery) => delivery.transmittedDocumentId));
+    return documents.filter((candidate) => !withDeliveries.has(candidate.id));
+  };
+  const store: BackfillStore = {
+    async hasRemaining() {
+      const remaining = uncovered().length > 0;
+      remainingChecks.push(remaining);
+      return remaining;
+    },
+
+    async processBatch(afterId, limit) {
+      const withDeliveries = new Set(deliveries.map((delivery) => delivery.transmittedDocumentId));
+      const batch = documents
+        .filter(
+          (candidate) =>
+            candidate.id > afterId && !withDeliveries.has(candidate.id) && !locked.has(candidate.id)
+        )
+        .sort((a, b) => (a.id < b.id ? -1 : 1))
+        .slice(0, limit);
+      batches.push(batch.map((candidate) => candidate.id));
+      if (failOnBatch !== undefined && batches.length === failOnBatch) {
+        throw new Error("batch rolled back");
+      }
+      if (batch.length === 0) {
+        return { documents: 0, deliveries: 0, lastId: null };
+      }
+      const rows = batch.flatMap(buildHistoricalDeliveries);
+      deliveries.push(...rows.map((row) => ({ transmittedDocumentId: row.transmittedDocumentId, channel: row.channel })));
+      return { documents: batch.length, deliveries: rows.length, lastId: batch.at(-1)!.id };
+    },
+  };
+  return { store, deliveries, batches, remainingChecks };
+}
+
+describe("the delivery backfill job", () => {
+  const documents = [
+    document({ id: "doc_01" }),
+    document({ id: "doc_02", accessPointProvider: "at-shared-ap-fr", apTransactionId: "tx-2" }),
+    document({ id: "doc_03", sentOverPeppol: false, emailRecipients: ["a@example.com"] }),
+    document({ id: "doc_04", receiverId: null, sentOverPeppol: false, emailRecipients: ["b@example.com"] }),
+    document({ id: "doc_05" }),
+  ];
+
+  it("walks the documents in bounded batches after the cursor and stops when a full pass writes nothing", async () => {
+    const { store, deliveries, batches } = fakeStore(documents);
+    const state = initialBackfillState();
+
+    const progress = await runDeliveryBackfill(store, state, { batchSize: 2 });
+
+    expect(progress).toEqual({ documents: 5, deliveries: 6, finished: true });
+    expect(deliveries).toHaveLength(6);
+    // Three batches of work, the end of the first pass, then one empty pass that
+    // proves nothing is left.
+    expect(batches).toEqual([
+      ["doc_01", "doc_02"],
+      ["doc_03", "doc_04"],
+      ["doc_05"],
+      [],
+      [],
+    ]);
+    expect(state.finished).toBe(true);
+  });
+
+  it("adds nothing when run again", async () => {
+    const { store, deliveries } = fakeStore(documents);
+    await runDeliveryBackfill(store, initialBackfillState(), { batchSize: 2 });
+    const before = deliveries.length;
+
+    const again = await runDeliveryBackfill(store, initialBackfillState(), { batchSize: 2 });
+
+    expect(again).toEqual({ documents: 0, deliveries: 0, finished: true });
+    expect(deliveries).toHaveLength(before);
+  });
+
+  it("only touches documents that have no deliveries yet", async () => {
+    const { store, deliveries } = fakeStore(documents);
+    // A document recorded after the deploy already has its deliveries.
+    deliveries.push({ transmittedDocumentId: "doc_03", channel: "peppol" });
+
+    await runDeliveryBackfill(store, initialBackfillState(), { batchSize: 10 });
+
+    expect(deliveries.filter((delivery) => delivery.transmittedDocumentId === "doc_03")).toHaveLength(1);
+    expect(new Set(deliveries.map((delivery) => delivery.transmittedDocumentId))).toEqual(
+      new Set(["doc_01", "doc_02", "doc_03", "doc_04", "doc_05"])
+    );
+  });
+
+  it("stops at the deadline and continues from its cursor on the next run", async () => {
+    const { store, deliveries } = fakeStore(documents);
+    const state = initialBackfillState();
+    let ticks = 0;
+    const now = () => new Date(2026, 0, 1, 0, 0, ticks++);
+
+    const first = await runDeliveryBackfill(store, state, {
+      batchSize: 2,
+      now,
+      deadline: new Date(2026, 0, 1, 0, 0, 2),
+    });
+    expect(first.finished).toBe(false);
+    expect(first.documents).toBe(4);
+    expect(state.cursor).toBe("doc_04");
+
+    const second = await runDeliveryBackfill(store, state, { batchSize: 2 });
+    expect(second).toEqual({ documents: 1, deliveries: 1, finished: true });
+    expect(deliveries).toHaveLength(6);
+  });
+
+  it("keeps going while a document another transaction holds is still uncovered, and covers it once the lock is gone", async () => {
+    // A pass that writes nothing is not proof that nothing is left: the batch skips
+    // a locked row rather than waiting for it, so the read that waits for nobody is
+    // what decides whether the job is done.
+    const locked = new Set(["doc_05"]);
+    const { store, deliveries, remainingChecks } = fakeStore(documents, undefined, locked);
+    const state = initialBackfillState();
+
+    const held = await runDeliveryBackfill(store, state, { batchSize: 2 });
+
+    expect(held.finished).toBe(false);
+    expect(state.finished).toBe(false);
+    expect(remainingChecks.at(-1)).toBe(true);
+    expect(deliveries.map((delivery) => delivery.transmittedDocumentId)).not.toContain("doc_05");
+
+    locked.clear();
+    const released = await runDeliveryBackfill(store, state, { batchSize: 2 });
+
+    expect(released.documents).toBe(1);
+    expect(released.finished).toBe(true);
+    expect(new Set(deliveries.map((delivery) => delivery.transmittedDocumentId))).toEqual(
+      new Set(["doc_01", "doc_02", "doc_03", "doc_04", "doc_05"])
+    );
+  });
+
+  it("picks up a batch that rolled back on the next pass", async () => {
+    const { store, deliveries } = fakeStore(documents, 2);
+    const state = initialBackfillState();
+
+    await expect(runDeliveryBackfill(store, state, { batchSize: 2 })).rejects.toThrow("batch rolled back");
+    expect(state.cursor).toBe("doc_02");
+
+    const resumed = await runDeliveryBackfill(store, state, { batchSize: 2 });
+    expect(resumed.finished).toBe(true);
+    expect(new Set(deliveries.map((delivery) => delivery.transmittedDocumentId))).toEqual(
+      new Set(["doc_01", "doc_02", "doc_03", "doc_04", "doc_05"])
+    );
+  });
+});

--- a/test/deliveries-reconcile.test.ts
+++ b/test/deliveries-reconcile.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+// The reconciliation poll asks the access point about deliveries it never reported
+// on, one after the other. What is under test here is what the loop does when a
+// single item misbehaves: the provider hangs, or the note that the delivery was
+// checked cannot be written. Neither may cost the rest of the batch, and the tick
+// must still get to the work that follows the poll.
+
+/** A query builder that accepts any chain of calls and resolves to `result`. */
+function chain(result: unknown): any {
+  const proxy: any = new Proxy(() => proxy, {
+    get(_target, property) {
+      if (property === "then") {
+        return (resolve: (value: unknown) => void) => resolve(result);
+      }
+      return () => proxy;
+    },
+  });
+  return proxy;
+}
+
+const due = [
+  { id: "dlv_1", providerTransactionId: "tx-1", useTestNetwork: false },
+  { id: "dlv_2", providerTransactionId: "tx-2", useTestNetwork: false },
+  { id: "dlv_3", providerTransactionId: "tx-3", useTestNetwork: false },
+];
+
+const checked: string[] = [];
+const requested: string[] = [];
+const applied: string[] = [];
+const pruned: number[] = [];
+const resumed: number[] = [];
+let failCheckNoteFor: string[] = [];
+let notes = 0;
+let respond: (transactionId: string, signal: AbortSignal | null | undefined) => Promise<unknown> =
+  async () => ({ transactionStatus: "COMPLETED" });
+
+mock.module("@recommand/db", () => ({
+  db: {
+    select: () => chain(due),
+    update: () => ({
+      set: () => ({
+        // The loop is serial, so the note being written is the one for the delivery
+        // the poll has just dealt with.
+        where: async () => {
+          const id = due[notes++]!.id;
+          if (failCheckNoteFor.includes(id)) {
+            throw new Error(`could not note ${id}`);
+          }
+          checked.push(id);
+        },
+      }),
+    }),
+  },
+}));
+mock.module("@peppol/data/at/client", () => ({
+  getArratechConfig: () => ({ orgId: "org-1" }),
+  fetchArratechJson: async (path: string, options: { signal?: AbortSignal | null }) => {
+    const transactionId = path.split("/").at(-1)!;
+    requested.push(transactionId);
+    return await respond(transactionId, options.signal);
+  },
+}));
+const model = await import("../data/deliveries/model");
+mock.module("@peppol/data/deliveries", () => ({
+  ...model,
+  applyProviderDeliveryReport: async (report: { providerTransactionId: string }) => {
+    applied.push(report.providerTransactionId);
+    return "applied";
+  },
+  pruneStagedDeliveryReports: async () => {
+    pruned.push(1);
+    return 1;
+  },
+}));
+mock.module("@peppol/data/deliveries/email-fallback-db", () => ({
+  resumeStalledEmailFallbacks: async () => {
+    resumed.push(1);
+    return { found: 1, resumed: 1 };
+  },
+}));
+
+const { reconcilePendingArratechDeliveries, runDeliveryReconciliationTick } = await import(
+  "../data/deliveries/reconcile"
+);
+
+const errors: string[] = [];
+const logger = {
+  info: () => {},
+  warn: () => {},
+  error: (message: string) => errors.push(message),
+} as never;
+
+afterEach(() => {
+  checked.length = 0;
+  requested.length = 0;
+  applied.length = 0;
+  pruned.length = 0;
+  resumed.length = 0;
+  errors.length = 0;
+  failCheckNoteFor = [];
+  notes = 0;
+  respond = async () => ({ transactionStatus: "COMPLETED" });
+});
+
+describe("a delivery whose check cannot be noted", () => {
+  it("is logged and left for the next tick, and the rest of the batch is still asked about", async () => {
+    failCheckNoteFor = ["dlv_1"];
+
+    const result = await reconcilePendingArratechDeliveries(logger, new Date(), {
+      requestTimeoutMs: 50,
+    });
+
+    expect(requested).toEqual(["tx-1", "tx-2", "tx-3"]);
+    expect(applied).toEqual(["tx-1", "tx-2", "tx-3"]);
+    expect(result).toEqual({ checked: 3, applied: 3 });
+    // Only the deliveries whose note was written are marked checked.
+    expect(checked).toEqual(["dlv_2", "dlv_3"]);
+    expect(errors).toEqual([expect.stringContaining("Could not note the check of delivery dlv_1")]);
+  });
+
+  it("does not keep the tick from the work that follows the poll", async () => {
+    failCheckNoteFor = ["dlv_1", "dlv_2", "dlv_3"];
+
+    await runDeliveryReconciliationTick(logger);
+
+    expect(requested).toHaveLength(3);
+    expect(pruned).toEqual([1]);
+    expect(resumed).toEqual([1]);
+  });
+});
+
+describe("a provider that never answers", () => {
+  it("gives up on that delivery when its deadline passes and carries on with the rest", async () => {
+    respond = (transactionId, signal) =>
+      transactionId === "tx-1"
+        ? new Promise((_resolve, reject) => {
+            // What the client's deadline does: reject as soon as the signal aborts,
+            // however long the provider would have taken.
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          })
+        : Promise.resolve({ transactionStatus: "COMPLETED" });
+
+    const result = await reconcilePendingArratechDeliveries(logger, new Date(), {
+      requestTimeoutMs: 20,
+    });
+
+    expect(requested).toEqual(["tx-1", "tx-2", "tx-3"]);
+    expect(applied).toEqual(["tx-2", "tx-3"]);
+    expect(result).toEqual({ checked: 3, applied: 2 });
+    // The delivery that timed out is noted as checked, so it waits its turn again.
+    expect(checked).toEqual(["dlv_1", "dlv_2", "dlv_3"]);
+    expect(errors).toEqual([expect.stringContaining("Could not reconcile delivery dlv_1")]);
+  });
+
+  it("is asked with a deadline even when the caller names none", async () => {
+    const signals: (AbortSignal | null | undefined)[] = [];
+    respond = async (_transactionId, signal) => {
+      signals.push(signal);
+      return { transactionStatus: "COMPLETED" };
+    };
+
+    await reconcilePendingArratechDeliveries(logger);
+
+    expect(signals).toHaveLength(3);
+    for (const signal of signals) {
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal!.aborted).toBe(false);
+    }
+  });
+});

--- a/test/deliveries.test.ts
+++ b/test/deliveries.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "bun:test";
+import {
+  attachDeliveries,
+  categorizeArratechServiceError,
+  deliveryStatusMoves,
+  interpretArratechTransactionStatus,
+  summarizeDeliveryStatus,
+  toDeliverySummary,
+} from "../data/deliveries/model";
+import { deliveryResponse, transmittedDocumentResponse } from "../api/documents/shared";
+
+describe("delivery failure categories", () => {
+  it("maps the access point's categories onto ours and leaves the code alongside", () => {
+    expect(categorizeArratechServiceError("RECIPIENT_NOT_FOUND")).toBe("recipient_not_found");
+    expect(categorizeArratechServiceError("NETWORK_LOOKUP_ERROR")).toBe("recipient_not_found");
+    expect(categorizeArratechServiceError("DOCUMENT_TYPE_NOT_SUPPORTED")).toBe("document_not_supported");
+    expect(categorizeArratechServiceError("VALIDATION_ERROR")).toBe("validation");
+    expect(categorizeArratechServiceError("POLICY_VIOLATION")).toBe("validation");
+    expect(categorizeArratechServiceError("TRANSPORT_ERROR")).toBe("transport");
+    expect(categorizeArratechServiceError("CERTIFICATE_ERROR")).toBe("transport");
+    expect(categorizeArratechServiceError("RECIPIENT_REJECTED")).toBe("recipient_rejected");
+    expect(categorizeArratechServiceError("DUPLICATE")).toBe("duplicate");
+  });
+
+  it("files internal, security and unknown categories under other", () => {
+    expect(categorizeArratechServiceError("INTERNAL_ERROR")).toBe("other");
+    expect(categorizeArratechServiceError("SECURITY_ALERT")).toBe("other");
+    expect(categorizeArratechServiceError("SOMETHING_NEW")).toBe("other");
+    expect(categorizeArratechServiceError(null)).toBe("other");
+    expect(categorizeArratechServiceError(undefined)).toBe("other");
+  });
+});
+
+describe("document delivery status", () => {
+  it("is delivered as soon as one channel confirmed arrival", () => {
+    expect(summarizeDeliveryStatus(["delivered"])).toBe("delivered");
+    expect(summarizeDeliveryStatus(["failed", "delivered"])).toBe("delivered");
+    expect(summarizeDeliveryStatus(["pending", "delivered", "failed"])).toBe("delivered");
+  });
+
+  it("is failed only when every delivery failed", () => {
+    expect(summarizeDeliveryStatus(["failed"])).toBe("failed");
+    expect(summarizeDeliveryStatus(["failed", "failed"])).toBe("failed");
+    expect(summarizeDeliveryStatus(["failed", "pending"])).toBe("pending");
+  });
+
+  it("is pending while anything is still open, and null without deliveries", () => {
+    expect(summarizeDeliveryStatus(["pending"])).toBe("pending");
+    expect(summarizeDeliveryStatus(["pending", "pending"])).toBe("pending");
+    expect(summarizeDeliveryStatus([])).toBeNull();
+  });
+});
+
+describe("applying a provider's report", () => {
+  it("moves a pending delivery to what was reported", () => {
+    expect(deliveryStatusMoves("pending", "delivered")).toBe(true);
+    expect(deliveryStatusMoves("pending", "failed")).toBe(true);
+  });
+
+  it("never overwrites a final status with a stale or repeated report", () => {
+    expect(deliveryStatusMoves("delivered", "failed")).toBe(false);
+    expect(deliveryStatusMoves("failed", "delivered")).toBe(false);
+    expect(deliveryStatusMoves("delivered", "delivered")).toBe(false);
+    expect(deliveryStatusMoves("failed", "failed")).toBe(false);
+    expect(deliveryStatusMoves("pending", "pending")).toBe(false);
+  });
+});
+
+describe("reconciling a transaction with the access point", () => {
+  it("confirms a completed transaction and fails a failed or rejected one", () => {
+    expect(interpretArratechTransactionStatus({ transactionStatus: "COMPLETED" })).toEqual({
+      status: "delivered",
+      failure: null,
+    });
+    expect(
+      interpretArratechTransactionStatus({
+        transactionStatus: "FAILED",
+        serviceError: { code: "TXE-1005", message: "Schematron failed", category: "VALIDATION_ERROR" },
+      })
+    ).toEqual({
+      status: "failed",
+      failure: { category: "validation", message: "Schematron failed", providerCode: "TXE-1005" },
+    });
+    expect(interpretArratechTransactionStatus({ transactionStatus: "rejected" })).toEqual({
+      status: "failed",
+      failure: { category: "other", message: null, providerCode: null },
+    });
+  });
+
+  it("leaves a delivery pending on a status whose meaning is not settled", () => {
+    expect(interpretArratechTransactionStatus({ transactionStatus: "COMPLETED_NO_DELIVERY" })).toBeNull();
+    expect(interpretArratechTransactionStatus({ transactionStatus: "PENDING" })).toBeNull();
+    expect(interpretArratechTransactionStatus({ transactionStatus: null })).toBeNull();
+    expect(interpretArratechTransactionStatus({})).toBeNull();
+  });
+});
+
+describe("deliveries on documents", () => {
+  const changedAt = new Date("2026-09-09T10:00:00Z");
+  const documents = [
+    { id: "doc_1", direction: "outgoing", peppolMessageId: "msg-1", peppolConversationId: "conv-1", envelopeId: "env-1" },
+    { id: "doc_2", direction: "outgoing", peppolMessageId: null, peppolConversationId: null, envelopeId: null },
+    { id: "doc_3", direction: "incoming", peppolMessageId: "msg-3", peppolConversationId: null, envelopeId: null },
+  ] as const;
+  const rows = [
+    { id: "dlv_1", transmittedDocumentId: "doc_1", channel: "peppol", address: "0208:1", status: "delivered", statusChangedAt: changedAt, failureCategory: null, failureMessage: null, failureProviderCode: null },
+    { id: "dlv_2", transmittedDocumentId: "doc_1", channel: "email", address: "a@example.com", status: "pending", statusChangedAt: changedAt, failureCategory: null, failureMessage: null, failureProviderCode: null },
+    { id: "dlv_3", transmittedDocumentId: "doc_2", channel: "peppol", address: "0208:2", status: "failed", statusChangedAt: changedAt, failureCategory: "validation", failureMessage: "Schematron failed", failureProviderCode: "TXE-1005" },
+  ] as const;
+
+  it("groups deliveries under their document with the document's transport references", () => {
+    const [first, second, third] = attachDeliveries([...documents], [...rows]);
+
+    expect(first!.deliveryStatus).toBe("delivered");
+    expect(first!.deliveries).toEqual([
+      {
+        id: "dlv_1",
+        channel: "peppol",
+        address: "0208:1",
+        status: "delivered",
+        statusChangedAt: "2026-09-09T10:00:00.000Z",
+        failure: null,
+        references: { peppolMessageId: "msg-1", peppolConversationId: "conv-1", envelopeId: "env-1" },
+      },
+      {
+        id: "dlv_2",
+        channel: "email",
+        address: "a@example.com",
+        status: "pending",
+        statusChangedAt: "2026-09-09T10:00:00.000Z",
+        failure: null,
+        references: {},
+      },
+    ]);
+
+    expect(second!.deliveryStatus).toBe("failed");
+    expect(second!.deliveries[0]!.failure).toEqual({
+      category: "validation",
+      message: "Schematron failed",
+      providerCode: "TXE-1005",
+    });
+
+    expect(third!.deliveries).toEqual([]);
+    expect(third!.deliveryStatus).toBeNull();
+  });
+
+  it("only reports a failure on a failed delivery, defaulting an unclassified one to other", () => {
+    const summary = toDeliverySummary(
+      { id: "dlv_4", channel: "peppol", address: "0208:4", status: "failed", statusChangedAt: changedAt, failureCategory: null, failureMessage: null, failureProviderCode: null },
+      {}
+    );
+    expect(summary.failure).toEqual({ category: "other", message: null, providerCode: null });
+    expect(summary.references).toEqual({ peppolMessageId: null, peppolConversationId: null, envelopeId: null });
+  });
+
+  it("exposes deliveries and their summary on the document API, and nothing older", () => {
+    const shape = transmittedDocumentResponse.shape;
+    expect(shape.deliveries).toBeDefined();
+    expect(shape.deliveryStatus).toBeDefined();
+    expect("deliveryFailure" in shape).toBe(false);
+
+    const parsed = deliveryResponse.parse({
+      id: "dlv_1",
+      channel: "peppol",
+      address: "0208:1",
+      status: "failed",
+      statusChangedAt: "2026-09-09T10:00:00.000Z",
+      failure: { category: "transport", message: null, providerCode: null },
+      references: { peppolMessageId: null, peppolConversationId: null, envelopeId: "env-1" },
+    });
+    expect(parsed.status).toBe("failed");
+    expect(() => deliveryResponse.parse({ ...parsed, status: "not_sent" })).toThrow();
+  });
+});

--- a/test/email-fallback-consume.test.ts
+++ b/test/email-fallback-consume.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test";
+import { drizzle } from "drizzle-orm/node-postgres";
+import {
+  claimEmailFallbackStatement,
+  noteEmailFallbackAttemptStatement,
+  releaseEmailFallbackStatement,
+  stalledEmailFallbacksStatement,
+} from "../data/deliveries/email-fallback-consume";
+
+// The shape of these statements is what makes taking a request atomic and correct:
+// the request must be read from a locked selection made before the update, because
+// an update's RETURNING clause yields the row after the update, and the claim must
+// exclude a request another run is holding. The database is not needed to assert the
+// shape; a container run asserts the behaviour (see test/db).
+
+const now = new Date("2026-09-10T12:00:00Z");
+const staleBefore = new Date("2026-09-10T11:45:00Z");
+
+function compact(statement: { toSQL(): { sql: string; params: unknown[] } }) {
+  const { sql, params } = statement.toSQL();
+  return { sql: sql.replace(/\s+/g, " "), params };
+}
+
+describe("the statement that takes a document's email fallback for a run", () => {
+  const { sql, params } = compact(
+    claimEmailFallbackStatement(drizzle.mock(), "doc_1", { now, staleBefore })
+  );
+
+  it("locks the row while the request is there and unheld, in a common table expression", () => {
+    expect(sql).toMatch(
+      /^with "taken" as \(select .*"email_fallback" from "peppol_transmitted_documents" where \("peppol_transmitted_documents"\."id" = \$1 and "peppol_transmitted_documents"\."email_fallback" is not null and .*\) for update\) update /
+    );
+    expect(params[0]).toBe("doc_1");
+  });
+
+  it("passes over a request a run started on recently, and takes over one left by a run that died", () => {
+    expect(sql).toContain(
+      `(("peppol_transmitted_documents"."email_fallback"->>'startedAt')::timestamptz is null or ("peppol_transmitted_documents"."email_fallback"->>'startedAt')::timestamptz < $2)`
+    );
+    expect(params[1]).toEqual(staleBefore);
+  });
+
+  it("marks the request started rather than clearing it, and returns the value read before the update", () => {
+    expect(sql).toContain(
+      `set "email_fallback" = "taken"."email_fallback" || jsonb_build_object('startedAt', $3::text)`
+    );
+    expect(params[2]).toBe(now.toISOString());
+    expect(sql).toContain('from "taken" where "peppol_transmitted_documents"."id" = "taken"."id"');
+    expect(sql).toMatch(/returning .*"taken"\."email_fallback"$/);
+    // Nothing is returned from the updated row itself.
+    expect(sql.split(" returning ")[1]).not.toContain('"peppol_transmitted_documents"."');
+  });
+});
+
+describe("the statement that notes an address before its message leaves", () => {
+  const { sql, params } = compact(
+    noteEmailFallbackAttemptStatement(drizzle.mock(), "doc_1", "a@example.com", "dlv_1")
+  );
+
+  it("adds the address to the request's attempts without touching the rest of it", () => {
+    expect(sql).toContain(
+      `set "email_fallback" = jsonb_set("peppol_transmitted_documents"."email_fallback" || jsonb_build_object('attempts', coalesce("peppol_transmitted_documents"."email_fallback"->'attempts', '{}'::jsonb)), array['attempts', $1], $2::jsonb, true)`
+    );
+    expect(params).toEqual(["a@example.com", JSON.stringify({ deliveryId: "dlv_1" }), "doc_1"]);
+  });
+
+  it("writes nothing once the request is closed", () => {
+    expect(sql).toContain(
+      `where ("peppol_transmitted_documents"."id" = $3 and "peppol_transmitted_documents"."email_fallback" is not null)`
+    );
+  });
+});
+
+describe("the statement that hands a request back after a failed run", () => {
+  const { sql, params } = compact(releaseEmailFallbackStatement(drizzle.mock(), "doc_1"));
+
+  it("drops only the start time, so what the run noted survives", () => {
+    expect(sql).toContain(
+      `set "email_fallback" = "peppol_transmitted_documents"."email_fallback" - 'startedAt'`
+    );
+    expect(sql).toContain(
+      `where ("peppol_transmitted_documents"."id" = $1 and "peppol_transmitted_documents"."email_fallback" is not null)`
+    );
+    expect(params).toEqual(["doc_1"]);
+  });
+});
+
+describe("the statement that finds the fallbacks a stopped run left half done", () => {
+  const { sql, params } = compact(stalledEmailFallbacksStatement(drizzle.mock(), staleBefore, 20));
+
+  it("takes the requests with attempts noted that no live run holds, oldest first and bounded", () => {
+    expect(sql).toContain(`"peppol_transmitted_documents"."email_fallback" ? 'attempts'`);
+    expect(sql).toContain(
+      `(("peppol_transmitted_documents"."email_fallback"->>'startedAt')::timestamptz is null or ("peppol_transmitted_documents"."email_fallback"->>'startedAt')::timestamptz < $1)`
+    );
+    expect(sql).toContain('order by "peppol_transmitted_documents"."id" limit $2');
+    expect(params).toEqual([staleBefore, 20]);
+  });
+});

--- a/test/email-fallback.test.ts
+++ b/test/email-fallback.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "bun:test";
+import {
+  emailFallbackRequest,
+  runEmailFallback,
+  EMAIL_FALLBACK_CLAIM_STALE_MS,
+  OUTCOME_NOT_RECORDED_MESSAGE,
+  type EmailFallbackDelivery,
+  type EmailFallbackDependencies,
+  type EmailFallbackDeliveryRow,
+  type EmailFallbackDocument,
+  type EmailFallbackRequest,
+} from "../data/deliveries/email-fallback";
+
+describe("keeping the email fallback with the document", () => {
+  const email = { when: "on_peppol_failure" as const, to: ["a@example.com"], subject: "Invoice 1" };
+
+  it("keeps the request when the email is for a failure and the transmission was accepted", () => {
+    expect(emailFallbackRequest(email, true)).toEqual({ to: ["a@example.com"], subject: "Invoice 1" });
+    expect(emailFallbackRequest({ ...email, htmlBody: "<p>Hi</p>" }, true)).toEqual({
+      to: ["a@example.com"],
+      subject: "Invoice 1",
+      htmlBody: "<p>Hi</p>",
+    });
+  });
+
+  it("keeps an address named twice only once, so it is only ever mailed once", () => {
+    expect(emailFallbackRequest({ ...email, to: ["a@example.com", "a@example.com"] }, true)).toEqual({
+      to: ["a@example.com"],
+      subject: "Invoice 1",
+    });
+  });
+
+  it("keeps nothing when the email already went out or was never asked for", () => {
+    // Sent with the transmission, whatever becomes of it.
+    expect(emailFallbackRequest({ ...email, when: "always" }, true)).toBeNull();
+    // Refused in the send: the pipeline mailed it right there.
+    expect(emailFallbackRequest(email, false)).toBeNull();
+    expect(emailFallbackRequest({ ...email, to: [] }, true)).toBeNull();
+    expect(emailFallbackRequest(null, true)).toBeNull();
+    expect(emailFallbackRequest(undefined, true)).toBeNull();
+  });
+});
+
+const document: EmailFallbackDocument = {
+  id: "doc_1",
+  teamId: "team_1",
+  companyId: "cmp_1",
+  type: "invoice",
+  senderId: "0225:123456789",
+  receiverId: "0208:987654321",
+  envelopeId: "env-1",
+  emailRecipients: [],
+  isPlayground: false,
+  useTestNetwork: false,
+  request: { to: ["a@example.com", "b@example.com"], subject: "Invoice 1" },
+};
+
+/**
+ * The document row as the database keeps it: the fallback request is a value on the
+ * row that a run marks started, notes addresses in, and finally clears. The fake
+ * follows the same rules the statements do, so a run that stops halfway leaves the
+ * row in the state a later run would really find.
+ */
+function fakeDependencies(options: {
+  document: EmailFallbackDocument | null;
+  failing?: string[];
+  /** Ids of deliveries a stopped run wrote before this one starts. */
+  existingDeliveries?: EmailFallbackDelivery[];
+  finishFails?: () => boolean;
+}) {
+  let request: EmailFallbackRequest | null = options.document?.request ?? null;
+  const sent: string[] = [];
+  const deliveries = new Map<string, EmailFallbackDelivery>(
+    (options.existingDeliveries ?? []).map((delivery) => [delivery.id, delivery])
+  );
+  const finished: Parameters<EmailFallbackDependencies["finish"]>[0][] = [];
+  const audited: Parameters<EmailFallbackDependencies["audit"]>[0][] = [];
+  const deps: EmailFallbackDependencies = {
+    async claim(_documentId, { now, staleBefore }) {
+      if (!options.document || !request) {
+        return null;
+      }
+      const startedAt = request.startedAt ? new Date(request.startedAt) : null;
+      if (startedAt && startedAt >= staleBefore) {
+        return null;
+      }
+      const taken = request;
+      request = { ...taken, startedAt: now.toISOString() };
+      return { ...options.document, request: taken };
+    },
+    async noteAttempt(_documentId, address, deliveryId) {
+      if (!request) {
+        return;
+      }
+      request = { ...request, attempts: { ...request.attempts, [address]: { deliveryId } } };
+    },
+    async recordedDelivery(deliveryId) {
+      return deliveries.get(deliveryId) ?? null;
+    },
+    async loadPayload() {
+      return { xml: "<Invoice/>", parsed: null };
+    },
+    async sendEmail(email) {
+      if (options.failing?.includes(email.to)) {
+        throw new Error(`Mailbox ${email.to} rejected the message`);
+      }
+      sent.push(email.to);
+    },
+    async recordDelivery(row: EmailFallbackDeliveryRow) {
+      const existing = deliveries.get(row.id!);
+      if (existing) {
+        return existing;
+      }
+      const written: EmailFallbackDelivery = {
+        id: row.id!,
+        address: row.address,
+        status: row.status,
+        failureCategory: row.failureCategory ?? null,
+        failureMessage: row.failureMessage ?? null,
+        provider: row.provider ?? null,
+        providerTransactionId: row.providerTransactionId ?? null,
+      };
+      deliveries.set(written.id, written);
+      return written;
+    },
+    async finish(outcome) {
+      if (options.finishFails?.()) {
+        throw new Error("event storage unavailable");
+      }
+      if (!request) {
+        return false;
+      }
+      request = null;
+      finished.push(outcome);
+      return true;
+    },
+    async release() {
+      if (request) {
+        const { startedAt: _startedAt, ...kept } = request;
+        request = kept;
+      }
+    },
+    async audit(event) {
+      audited.push(event);
+    },
+  };
+  return { deps, sent, deliveries, finished, audited, request: () => request };
+}
+
+describe("sending the email fallback after a later failure", () => {
+  it("sends each requested address once, as the sending pipeline would, and bills what went out", async () => {
+    const { deps, sent, finished, audited, request } = fakeDependencies({ document });
+    const now = new Date("2026-09-09T12:00:00Z");
+
+    const outcome = await runEmailFallback("doc_1", deps, now);
+
+    expect(outcome).toMatchObject({
+      kind: "sent",
+      sent: ["a@example.com", "b@example.com"],
+      failed: [],
+    });
+    expect(sent).toEqual(["a@example.com", "b@example.com"]);
+    expect(finished).toHaveLength(1);
+    expect(finished[0]!.deliveries).toEqual([
+      expect.objectContaining({ address: "a@example.com", status: "pending" }),
+      expect.objectContaining({ address: "b@example.com", status: "pending" }),
+    ]);
+    expect(finished[0]!.transferEvents.map((event) => event.type)).toEqual(["email", "email"]);
+    expect(finished[0]!.sent).toEqual(["a@example.com", "b@example.com"]);
+    expect(audited).toEqual([
+      { documentId: "doc_1", teamId: "team_1", sent: ["a@example.com", "b@example.com"], failed: [] },
+    ]);
+    // The request is gone: a later report finds nothing left to do.
+    expect(request()).toBeNull();
+  });
+
+  it("sends once when two failure reports arrive at the same time", async () => {
+    const { deps, sent, finished } = fakeDependencies({ document });
+
+    const outcomes = await Promise.all([runEmailFallback("doc_1", deps), runEmailFallback("doc_1", deps)]);
+
+    expect(outcomes.map((outcome) => outcome.kind).sort()).toEqual(["none", "sent"]);
+    expect(sent).toEqual(["a@example.com", "b@example.com"]);
+    expect(finished).toHaveLength(1);
+  });
+
+  it("does nothing for a document without a waiting request", async () => {
+    // No request was kept: the email was never asked for, or went out with the send.
+    const { deps, sent, finished, audited } = fakeDependencies({ document: null });
+
+    expect(await runEmailFallback("doc_1", deps)).toEqual({ kind: "none" });
+    expect(sent).toEqual([]);
+    expect(finished).toEqual([]);
+    expect(audited).toEqual([]);
+  });
+
+  it("leaves a request another run is holding alone until that run is long overdue", async () => {
+    const { deps, sent } = fakeDependencies({
+      document: {
+        ...document,
+        request: { ...document.request, startedAt: new Date("2026-09-09T12:00:00Z").toISOString() },
+      },
+    });
+
+    const held = new Date("2026-09-09T12:05:00Z");
+    expect(await runEmailFallback("doc_1", deps, held)).toEqual({ kind: "none" });
+    expect(sent).toEqual([]);
+
+    const overdue = new Date(new Date("2026-09-09T12:00:00Z").getTime() + EMAIL_FALLBACK_CLAIM_STALE_MS + 1);
+    expect((await runEmailFallback("doc_1", deps, overdue)).kind).toBe("sent");
+    expect(sent).toEqual(["a@example.com", "b@example.com"]);
+  });
+
+  it("records an address the mail service refused as a failed delivery and carries on with the others", async () => {
+    const { deps, sent, finished } = fakeDependencies({ document, failing: ["a@example.com"] });
+
+    const outcome = await runEmailFallback("doc_1", deps);
+
+    expect(outcome).toMatchObject({
+      kind: "sent",
+      sent: ["b@example.com"],
+      failed: [{ address: "a@example.com", message: "Mailbox a@example.com rejected the message" }],
+    });
+    expect(sent).toEqual(["b@example.com"]);
+    expect(finished[0]!.deliveries).toEqual([
+      expect.objectContaining({
+        address: "a@example.com",
+        status: "failed",
+        failureCategory: "transport",
+        failureMessage: "Mailbox a@example.com rejected the message",
+      }),
+      expect.objectContaining({ address: "b@example.com", status: "pending" }),
+    ]);
+    // Only the email that went out is billed.
+    expect(finished[0]!.transferEvents).toHaveLength(1);
+    expect(finished[0]!.sent).toEqual(["b@example.com"]);
+  });
+
+  it("bills nothing in a playground", async () => {
+    const { deps, finished } = fakeDependencies({ document: { ...document, isPlayground: true } });
+
+    await runEmailFallback("doc_1", deps);
+
+    expect(finished[0]!.deliveries).toHaveLength(2);
+    expect(finished[0]!.transferEvents).toEqual([]);
+  });
+});
+
+describe("resuming a fallback run that stopped after the mail service accepted a message", () => {
+  it("records and bills the accepted messages once, without mailing anything again", async () => {
+    let broken = true;
+    const { deps, sent, finished, deliveries } = fakeDependencies({
+      document,
+      finishFails: () => broken,
+    });
+
+    // The messages went out; closing the request found the event store down.
+    await expect(runEmailFallback("doc_1", deps)).rejects.toThrow("event storage unavailable");
+    expect(sent).toEqual(["a@example.com", "b@example.com"]);
+    expect(finished).toEqual([]);
+    // The delivery rows of the accepted messages were written as they were accepted.
+    expect([...deliveries.values()].map((delivery) => delivery.address)).toEqual([
+      "a@example.com",
+      "b@example.com",
+    ]);
+
+    broken = false;
+    const outcome = await runEmailFallback("doc_1", deps);
+
+    expect(outcome).toMatchObject({ kind: "sent", sent: ["a@example.com", "b@example.com"], failed: [] });
+    // Nothing was mailed a second time, and the accepted messages are billed once.
+    expect(sent).toEqual(["a@example.com", "b@example.com"]);
+    expect(deliveries.size).toBe(2);
+    expect(finished).toHaveLength(1);
+    expect(finished[0]!.transferEvents).toHaveLength(2);
+    expect(finished[0]!.sent).toEqual(["a@example.com", "b@example.com"]);
+    expect(finished[0]!.deliveries.map((delivery) => delivery.id)).toEqual(
+      [...deliveries.values()].map((delivery) => delivery.id)
+    );
+  });
+
+  it("closes an address whose answer was never recorded as failed rather than mailing it again", async () => {
+    // The run noted the address, then stopped before the service's answer was written.
+    const { deps, sent, finished } = fakeDependencies({
+      document: {
+        ...document,
+        request: {
+          ...document.request,
+          to: ["a@example.com"],
+          attempts: { "a@example.com": { deliveryId: "dlv_lost" } },
+        },
+      },
+    });
+
+    const outcome = await runEmailFallback("doc_1", deps);
+
+    expect(sent).toEqual([]);
+    expect(outcome).toMatchObject({
+      kind: "sent",
+      sent: [],
+      failed: [{ address: "a@example.com", message: OUTCOME_NOT_RECORDED_MESSAGE }],
+    });
+    expect(finished[0]!.deliveries).toEqual([
+      expect.objectContaining({
+        id: "dlv_lost",
+        address: "a@example.com",
+        status: "failed",
+        failureCategory: "other",
+        failureMessage: OUTCOME_NOT_RECORDED_MESSAGE,
+      }),
+    ]);
+    // Nothing went out, so nothing is billed.
+    expect(finished[0]!.transferEvents).toEqual([]);
+  });
+
+  it("writes nothing when another run closed the request while this one was working", async () => {
+    const { deps, finished } = fakeDependencies({ document });
+    // The claim happens first; the request is closed by the other run before finish.
+    const running = runEmailFallback("doc_1", deps);
+    const other = runEmailFallback("doc_1", deps);
+
+    expect((await running).kind).toBe("sent");
+    expect((await other).kind).toBe("none");
+    expect(finished).toHaveLength(1);
+  });
+});

--- a/test/persistence/failed-delivery-email-fallback.test.ts
+++ b/test/persistence/failed-delivery-email-fallback.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// A provider report is applied against a fake of the database so the failure path
+// can be followed end to end: the conditional update, the event, and the email
+// fallback that a failed Peppol delivery triggers. The webhook and the
+// reconciliation poll both apply reports through this one function.
+
+type Row = Record<string, unknown>;
+
+/** A query builder that accepts any chain of calls and resolves to `result`. */
+function chain(result: unknown): any {
+  const proxy: any = new Proxy(() => proxy, {
+    get(_target, property) {
+      if (property === "then") {
+        return (resolve: (value: unknown) => void) => resolve(result);
+      }
+      return () => proxy;
+    },
+  });
+  return proxy;
+}
+
+let found: Row | undefined;
+let updated: Row | undefined;
+const published: Row[] = [];
+const fallbacks: string[] = [];
+
+mock.module("@recommand/db", () => ({
+  db: {
+    select: () => chain(found ? [found] : []),
+    insert: () => chain([]),
+    delete: () => chain([]),
+    transaction: async (run: (tx: unknown) => Promise<unknown>) =>
+      run({ update: () => chain(updated ? [updated] : []) }),
+  },
+}));
+mock.module("@core/data/rules/events", () => ({
+  publishEvent: async (type: string, args: Row) => {
+    published.push({ type, ...args });
+  },
+}));
+mock.module("@core/lib/audit", () => ({ writeAuditEvent: async () => {} }));
+mock.module("@peppol/utils/system-notifications/telegram", () => ({ sendSystemAlert: async () => {} }));
+mock.module("@peppol/data/deliveries/email-fallback-db", () => ({
+  runEmailFallbackForDocument: async (documentId: string) => {
+    fallbacks.push(documentId);
+    return { kind: "none" };
+  },
+}));
+
+const { applyProviderDeliveryReport } = await import("../../data/deliveries");
+
+const delivery = {
+  id: "dlv_1",
+  transmittedDocumentId: "doc_1",
+  teamId: "team_1",
+  companyId: "cmp_1",
+  channel: "peppol",
+  address: "0208:987654321",
+  status: "pending",
+  provider: "at-shared-ap-fr",
+  providerTransactionId: "tx-1",
+};
+const document = { id: "doc_1", type: "invoice", senderId: "0225:1", receiverId: "0208:987654321", envelopeId: "env-1" };
+
+function report(status: "failed" | "delivered") {
+  return {
+    channel: "peppol" as const,
+    provider: "at-shared-ap-fr",
+    providerTransactionId: "tx-1",
+    useTestNetwork: false,
+    status,
+    failure: status === "failed" ? { category: "validation" as const, message: "Schematron failed", providerCode: "TXE-1005" } : null,
+    eventId: "evt-1",
+    eventType: "transaction.send_failed",
+    payload: {},
+  };
+}
+
+beforeEach(() => {
+  found = { delivery, document };
+  updated = { ...delivery, status: "failed" };
+  published.length = 0;
+  fallbacks.length = 0;
+});
+
+describe("a failure report on a pending Peppol delivery", () => {
+  it("fails the delivery, tells the owner once, and then sends the email fallback", async () => {
+    expect(await applyProviderDeliveryReport(report("failed"))).toBe("applied");
+
+    expect(published.map((event) => event.type)).toEqual(["peppol.document.delivery_status.v1"]);
+    expect(published[0]!.payload).toMatchObject({ deliveryId: "dlv_1", status: "failed", previousStatus: "pending" });
+    expect(fallbacks).toEqual(["doc_1"]);
+  });
+
+  it("sends no fallback when another caller moved the delivery first", async () => {
+    // The conditional update found the delivery no longer pending.
+    updated = undefined;
+
+    expect(await applyProviderDeliveryReport(report("failed"))).toBe("unchanged");
+    expect(published).toEqual([]);
+    expect(fallbacks).toEqual([]);
+  });
+
+  it("sends no fallback when the delivery is already final", async () => {
+    found = { delivery: { ...delivery, status: "delivered" }, document };
+
+    expect(await applyProviderDeliveryReport(report("failed"))).toBe("unchanged");
+    expect(fallbacks).toEqual([]);
+  });
+
+  it("sends no fallback on a confirmation", async () => {
+    updated = { ...delivery, status: "delivered" };
+
+    expect(await applyProviderDeliveryReport(report("delivered"))).toBe("applied");
+    expect(published[0]!.payload).toMatchObject({ status: "delivered" });
+    expect(fallbacks).toEqual([]);
+  });
+});

--- a/test/persistence/reconciliation-applies-reports.test.ts
+++ b/test/persistence/reconciliation-applies-reports.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, mock } from "bun:test";
+
+// The reconciliation poll asks the access point about a pending delivery and hands
+// the answer to the same report application the webhook uses, so everything that
+// follows a failure, the event and the email fallback included, happens for a
+// failure the poll discovered just as for one the webhook reported.
+
+function chain(result: unknown): any {
+  const proxy: any = new Proxy(() => proxy, {
+    get(_target, property) {
+      if (property === "then") {
+        return (resolve: (value: unknown) => void) => resolve(result);
+      }
+      return () => proxy;
+    },
+  });
+  return proxy;
+}
+
+const applied: unknown[] = [];
+const checked: string[] = [];
+
+mock.module("@recommand/db", () => ({
+  db: {
+    select: () =>
+      chain([
+        { id: "dlv_1", providerTransactionId: "tx-1", useTestNetwork: false },
+        { id: "dlv_2", providerTransactionId: "tx-2", useTestNetwork: true },
+      ]),
+    update: () => ({ set: () => ({ where: async () => { checked.push("checked"); } }) }),
+  },
+}));
+mock.module("@peppol/data/at/client", () => ({
+  getArratechConfig: (useTestNetwork: boolean) => ({ orgId: useTestNetwork ? "org-test" : "org-prod" }),
+  fetchArratechJson: async (path: string) =>
+    path.includes("tx-1")
+      ? { transactionStatus: "FAILED", serviceError: { code: "TXE-1005", message: "Schematron failed", category: "VALIDATION_ERROR" } }
+      : { transactionStatus: "COMPLETED_NO_DELIVERY" },
+}));
+const model = await import("../../data/deliveries/model");
+mock.module("@peppol/data/deliveries", () => ({
+  ...model,
+  applyProviderDeliveryReport: async (report: unknown) => {
+    applied.push(report);
+    return "applied";
+  },
+  pruneStagedDeliveryReports: async () => 0,
+}));
+
+const { reconcilePendingArratechDeliveries } = await import("../../data/deliveries/reconcile");
+
+describe("the reconciliation poll", () => {
+  it("applies what the access point answers through the same path as the webhook", async () => {
+    const logger = { info: () => {}, warn: () => {}, error: () => {} } as never;
+
+    const progress = await reconcilePendingArratechDeliveries(logger);
+
+    expect(progress).toEqual({ checked: 2, applied: 1 });
+    expect(applied).toEqual([
+      {
+        channel: "peppol",
+        provider: "at-shared-ap-fr",
+        providerTransactionId: "tx-1",
+        useTestNetwork: false,
+        status: "failed",
+        failure: { category: "validation", message: "Schematron failed", providerCode: "TXE-1005" },
+        eventId: null,
+        eventType: null,
+        payload: expect.objectContaining({ transactionStatus: "FAILED" }),
+      },
+    ]);
+    // Both deliveries were asked about; the unsettled one stays pending untouched.
+    expect(checked).toHaveLength(2);
+  });
+});

--- a/test/persistence/send-response-deliveries.test.ts
+++ b/test/persistence/send-response-deliveries.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { DocumentDelivery } from "../../data/deliveries/model";
+import type { documentDeliveries } from "../../db/schema";
+
+// Recording a document is exercised against fakes of everything it writes to, so
+// the shape of what it returns can be asserted without a database. The point under
+// test is the read-back of the deliveries after the staging step.
+
+let deliveries: DocumentDelivery[] = [];
+let stagedOutcome: () => Promise<string> = async () => "unchanged";
+const events: string[] = [];
+
+mock.module("@recommand/db", () => ({
+  db: {
+    transaction: async (run: (tx: unknown) => Promise<unknown>) =>
+      run({
+        insert: () => ({
+          values: (row: { id: string }) => ({ returning: async () => [{ id: row.id }] }),
+        }),
+      }),
+    insert: () => ({ values: async () => {} }),
+  },
+}));
+mock.module("@core/lib/audit", () => ({
+  audit: async () => {},
+  writeAuditEvent: async () => {},
+}));
+mock.module("@core/data/rules/events", () => ({
+  publishEvent: async (type: string) => {
+    events.push(type);
+  },
+}));
+mock.module("@peppol/data/offload/storage", () => ({
+  uploadDocumentOriginalPayload: async () => "prefix",
+  parsedHasAttachments: () => false,
+}));
+mock.module("@peppol/data/send-document-notifications", () => ({
+  sendOutgoingDocumentNotifications: async () => {},
+}));
+mock.module("@peppol/utils/system-notifications/telegram", () => ({
+  sendSystemAlert: async () => {},
+}));
+const model = await import("../../data/deliveries/model");
+mock.module("@peppol/data/deliveries", () => ({
+  ...model,
+  insertDocumentDeliveries: async (_tx: unknown, rows: (typeof documentDeliveries.$inferInsert)[]) => {
+    deliveries = rows.map((row, index) => ({
+      providerEventId: null,
+      providerEventType: null,
+      providerPayload: null,
+      lastCheckedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...row,
+      id: `dlv_${index + 1}`,
+    })) as DocumentDelivery[];
+    return deliveries.map((delivery) => ({ ...delivery }));
+  },
+  applyStagedDeliveryReport: async () => await stagedOutcome(),
+  listDocumentDeliveries: async () => deliveries.map((delivery) => ({ ...delivery })),
+}));
+
+const { recordOutgoingDocument } = await import("../../data/record-outgoing-document");
+
+const company = {
+  id: "cmp_1",
+  name: "Example SARL",
+  country: "FR",
+  accessPointProvider: "at-shared-ap-fr",
+  smpProvider: "at-shared-smp-fr",
+} as never;
+
+async function record(apTransactionId: string | null) {
+  return await recordOutgoingDocument({
+    c: null,
+    id: "doc_1",
+    teamId: "team_1",
+    company,
+    isPlayground: true,
+    useTestNetwork: false,
+    inputFormat: "json_api",
+    document: {
+      senderId: "0225:123456789",
+      receiverId: "0208:987654321",
+      docTypeId: "doc-type",
+      processId: "process",
+      countryC1: "FR",
+      type: "invoice",
+      parsed: null,
+      xml: "<Invoice/>",
+    },
+    delivery: {
+      kind: "peppol",
+      sentPeppol: true,
+      emailRecipients: [],
+      as4Response: {
+        ok: true,
+        peppolMessageId: null,
+        peppolConversationId: null,
+        receivedPeppolSignalMessage: null,
+        sbdhInstanceIdentifier: "env-1",
+        apTransactionId,
+      },
+    },
+  });
+}
+
+describe("the deliveries a recorded document returns", () => {
+  it("reflect a report the webhook applied between the insert and the staging check", async () => {
+    // The webhook got to the delivery first: by the time this call looks for a staged
+    // report, the delivery is already final and there is nothing staged.
+    stagedOutcome = async () => {
+      deliveries[0]!.status = "failed";
+      deliveries[0]!.failureCategory = "validation";
+      deliveries[0]!.failureProviderCode = "TXE-1005";
+      return "unchanged";
+    };
+
+    const recorded = await record("tx-1");
+
+    expect(recorded.id).toBe("doc_1");
+    expect(recorded.deliveries).toHaveLength(1);
+    expect(recorded.deliveries[0]).toMatchObject({
+      channel: "peppol",
+      status: "failed",
+      failureCategory: "validation",
+      failureProviderCode: "TXE-1005",
+    });
+    expect(events).toContain("peppol.document.sent.v1");
+  });
+
+  it("reflect a staged report this call applied itself", async () => {
+    stagedOutcome = async () => {
+      deliveries[0]!.status = "delivered";
+      return "applied";
+    };
+
+    const recorded = await record("tx-2");
+
+    expect(recorded.deliveries[0]).toMatchObject({ status: "delivered" });
+  });
+
+  it("are the pending rows as inserted when no report has arrived", async () => {
+    stagedOutcome = async () => "unchanged";
+
+    const recorded = await record("tx-3");
+
+    expect(recorded.deliveries[0]).toMatchObject({ status: "pending", providerTransactionId: "tx-3" });
+  });
+});

--- a/test/record-outgoing-document.test.ts
+++ b/test/record-outgoing-document.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  buildOutgoingDocumentDeliveries,
   buildOutgoingDocumentRow,
   buildOutgoingTransferEvents,
   type OutgoingDocumentDelivery,
@@ -139,6 +140,20 @@ describe("outgoing document recording", () => {
     });
   });
 
+  it("keeps the email asked for on failure with the document until the outcome is known", () => {
+    const row = buildOutgoingDocumentRow({
+      id: "doc_invoice",
+      teamId: "team_1",
+      company,
+      document: peppolDocument,
+      delivery: { ...peppolDelivery, emailFallback: { to: ["a@example.com"], subject: "Invoice 1" } },
+      storage,
+    });
+    expect(row.emailFallback).toEqual({ to: ["a@example.com"], subject: "Invoice 1" });
+    expect(row.sentOverEmail).toBe(false);
+    expect(row.emailRecipients).toEqual([]);
+  });
+
   it("bills a report exactly once, like a transmission", () => {
     const base = {
       teamId: "team_1",
@@ -193,5 +208,86 @@ describe("outgoing document recording", () => {
         },
       })
     ).toEqual([]);
+  });
+});
+
+describe("outgoing document deliveries", () => {
+  const now = new Date("2026-09-09T10:00:00Z");
+  const build = (
+    delivery: OutgoingDocumentDelivery,
+    overrides: { accessPointProvider?: Company["accessPointProvider"]; receiverId?: string | null } = {}
+  ) =>
+    buildOutgoingDocumentDeliveries({
+      transmittedDocumentId: "doc_1",
+      teamId: "team_1",
+      company: { id: company.id, accessPointProvider: overrides.accessPointProvider ?? "recommand-ap1" },
+      document: { receiverId: overrides.receiverId === undefined ? "0208:987654321" : overrides.receiverId },
+      delivery,
+      useTestNetwork: false,
+      now,
+    });
+
+  it("records a transmission through our own access point as delivered: the receipt came with the send", () => {
+    const rows = build(peppolDelivery);
+    expect(rows).toEqual([
+      {
+        transmittedDocumentId: "doc_1",
+        teamId: "team_1",
+        companyId: company.id,
+        statusChangedAt: now,
+        useTestNetwork: false,
+        channel: "peppol",
+        address: "0208:987654321",
+        status: "delivered",
+        failureCategory: null,
+        failureMessage: null,
+        failureProviderCode: null,
+        provider: "recommand-ap1",
+        providerTransactionId: "tx-1",
+      },
+    ]);
+  });
+
+  it("leaves a transmission through a shared access point pending until it reports the outcome", () => {
+    const [row] = build(peppolDelivery, { accessPointProvider: "at-shared-ap-fr" });
+    expect(row).toMatchObject({ status: "pending", provider: "at-shared-ap-fr", providerTransactionId: "tx-1" });
+  });
+
+  it("records a simulated transmission as delivered without a provider, whatever the company's access point", () => {
+    const simulated: OutgoingDocumentDelivery = { kind: "peppol", sentPeppol: true, emailRecipients: [], as4Response: null };
+    const [row] = build(simulated, { accessPointProvider: "at-shared-ap-fr" });
+    expect(row).toMatchObject({ status: "delivered", provider: null, providerTransactionId: null });
+  });
+
+  it("records a refused transmission that fell back to email as failed, with the refusal's reason", () => {
+    const rows = build({
+      kind: "peppol",
+      sentPeppol: false,
+      emailRecipients: ["a@example.com", "b@example.com"],
+      as4Response: null,
+      peppolFailure: { category: "document_not_supported", message: "Not registered for invoices", providerCode: null },
+    });
+    expect(rows.map((row) => [row.channel, row.address, row.status])).toEqual([
+      ["peppol", "0208:987654321", "failed"],
+      ["email", "a@example.com", "pending"],
+      ["email", "b@example.com", "pending"],
+    ]);
+    expect(rows[0]).toMatchObject({
+      failureCategory: "document_not_supported",
+      failureMessage: "Not registered for invoices",
+      provider: null,
+    });
+  });
+
+  it("creates no Peppol delivery for an email-only document", () => {
+    const rows = build(
+      { kind: "peppol", sentPeppol: false, emailRecipients: ["a@example.com"], as4Response: null },
+      { receiverId: null }
+    );
+    expect(rows.map((row) => row.channel)).toEqual(["email"]);
+  });
+
+  it("creates no deliveries for a filed report", () => {
+    expect(build(reportingDelivery, { receiverId: null })).toEqual([]);
   });
 });

--- a/test/send-document-response.test.ts
+++ b/test/send-document-response.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "bun:test";
+import { sendDocumentResponseBody } from "../utils/pipelines/sending/response";
+import type { DocumentDelivery } from "../data/deliveries/model";
+
+// What the send returns is two things at once: what this request did, and where the
+// document stands. They can differ, because the access point can report the
+// transmission failed before the send has answered, and the email fallback the
+// sender asked for then goes out inside the same call. `sentOverPeppol`,
+// `sentOverEmail` and `emailRecipients` describe the request; `deliveries` and
+// `deliveryStatus` are read back from the document afterwards and are the truth.
+
+const statusChangedAt = new Date("2026-09-09T12:00:00Z");
+
+function delivery(overrides: Partial<DocumentDelivery> & { id: string }): DocumentDelivery {
+  return {
+    transmittedDocumentId: "doc_1",
+    teamId: "team_1",
+    companyId: "cmp_1",
+    channel: "peppol",
+    address: "0208:987654321",
+    status: "pending",
+    statusChangedAt,
+    failureCategory: null,
+    failureMessage: null,
+    failureProviderCode: null,
+    provider: null,
+    useTestNetwork: false,
+    providerTransactionId: null,
+    providerEventId: null,
+    providerEventType: null,
+    providerPayload: null,
+    lastCheckedAt: null,
+    createdAt: statusChangedAt,
+    updatedAt: statusChangedAt,
+    ...overrides,
+  } as DocumentDelivery;
+}
+
+const as4Response = {
+  ok: true,
+  peppolMessageId: "msg-1",
+  peppolConversationId: "conv-1",
+  receivedPeppolSignalMessage: null,
+  sbdhInstanceIdentifier: "env-1",
+  apTransactionId: "tx-1",
+};
+
+describe("the body of a successful send", () => {
+  it("describes the request in the legacy fields and the document in the deliveries", () => {
+    // The access point reported the transmission failed while this call was still
+    // recording it, so the fallback the sender asked for has already gone out.
+    const body = sendDocumentResponseBody({
+      teamId: "team_1",
+      companyId: "cmp_1",
+      documentId: "doc_1",
+      as4Response,
+      sentPeppol: true,
+      emailRecipients: [],
+      deliveries: [
+        delivery({
+          id: "dlv_1",
+          status: "failed",
+          failureCategory: "validation",
+          failureMessage: "Schematron failed",
+          failureProviderCode: "TXE-1005",
+        }),
+        delivery({ id: "dlv_2", channel: "email", address: "a@example.com", status: "pending" }),
+      ],
+      peppolFailure: "",
+      emailFailure: "",
+    });
+
+    // The request handed the document to the access point and mailed nothing itself.
+    expect(body.sentOverPeppol).toBe(true);
+    expect(body.sentOverEmail).toBe(false);
+    expect(body.emailRecipients).toEqual([]);
+    // Where the document stands, fallback included.
+    expect(body.deliveries.map((entry) => [entry.channel, entry.address, entry.status])).toEqual([
+      ["peppol", "0208:987654321", "failed"],
+      ["email", "a@example.com", "pending"],
+    ]);
+    expect(body.deliveryStatus).toBe("pending");
+    expect(body.deliveries[0]!.failure).toEqual({
+      category: "validation",
+      message: "Schematron failed",
+      providerCode: "TXE-1005",
+    });
+  });
+
+  it("names the addresses this request mailed, and carries the transmission's references", () => {
+    const body = sendDocumentResponseBody({
+      teamId: "team_1",
+      companyId: "cmp_1",
+      documentId: "doc_1",
+      as4Response,
+      sentPeppol: true,
+      emailRecipients: ["a@example.com"],
+      deliveries: [delivery({ id: "dlv_1" })],
+      peppolFailure: "",
+      emailFailure: "",
+    });
+
+    expect(body.sentOverEmail).toBe(true);
+    expect(body.emailRecipients).toEqual(["a@example.com"]);
+    expect(body.peppolMessageId).toBe("msg-1");
+    expect(body.envelopeId).toBe("env-1");
+    expect(body.deliveries[0]!.references).toEqual({
+      peppolMessageId: "msg-1",
+      peppolConversationId: "conv-1",
+      envelopeId: "env-1",
+    });
+  });
+
+  it("adds the failure contexts only when there is something to say", () => {
+    const input = {
+      teamId: "team_1",
+      companyId: "cmp_1",
+      documentId: "doc_1",
+      as4Response: null,
+      sentPeppol: false,
+      emailRecipients: [],
+      deliveries: [],
+      peppolFailure: "",
+      emailFailure: "",
+    };
+
+    expect(sendDocumentResponseBody(input)).not.toHaveProperty("additionalPeppolFailureContext");
+    expect(sendDocumentResponseBody(input).deliveryStatus).toBeNull();
+    expect(
+      sendDocumentResponseBody({ ...input, peppolFailure: "No receiver", emailFailure: "No mailbox" })
+    ).toMatchObject({
+      additionalPeppolFailureContext: "No receiver",
+      additionalEmailFailureContext: "No mailbox",
+    });
+  });
+});

--- a/test/webhooks/arratech-delivery-reports.test.ts
+++ b/test/webhooks/arratech-delivery-reports.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { createHmac } from "node:crypto";
+import { Hono } from "hono";
+
+const productionSecret = "production-" + crypto.randomUUID();
+const testSecret = "test-" + crypto.randomUUID();
+const productionAp = "ap-production";
+const testAp = "ap-test";
+
+const reports: unknown[] = [];
+const sent: unknown[] = [];
+let sentOutcome = "sent-by-us";
+
+mock.module("@recommand/lib/api", () => ({ Server: Hono }));
+mock.module("@recommand/lib/utils", () => ({
+  actionSuccess: (value: unknown) => ({ success: true, ...(value as object) }),
+  actionFailure: (value: unknown) => ({ success: false, error: String(value) }),
+}));
+mock.module("@directory/utils/util", () => ({ UserFacingError: class extends Error {} }));
+mock.module("@peppol/db/schema", () => ({ transmittedDocuments: { id: "id", apTransactionId: "ap", direction: "direction" } }));
+mock.module("@recommand/db", () => ({ db: {} }));
+mock.module("@peppol/data/at/ap", () => ({ downloadBusinessDocument: async () => null }));
+mock.module("@peppol/data/at/client", () => ({
+  getArratechConfig: (useTestNetwork: boolean) => ({ apRef: useTestNetwork ? testAp : productionAp }),
+}));
+mock.module("@peppol/data/provider-sent", () => ({
+  recordProviderSentTransaction: async (transaction: unknown) => {
+    sent.push(transaction);
+    return sentOutcome;
+  },
+}));
+// The webhook only interprets the report; what it does to a delivery is the model's
+// business and is tested there. The interpretation itself is the real one.
+const model = await import("../../data/deliveries/model");
+mock.module("@peppol/data/deliveries", () => ({
+  ...model,
+  applyProviderDeliveryReport: async (report: unknown) => {
+    reports.push(report);
+    return "applied";
+  },
+}));
+mock.module("@peppol/utils/pipelines/receiving", () => ({ receivingPipeline: async () => {} }));
+
+const { default: server } = await import("../../api/internal/arratech-webhook");
+
+const failedPayload = {
+  id: "tx-1",
+  transactionStatus: "FAILED",
+  createdAt: "2026-09-09T10:00:00Z",
+  apId: productionAp,
+  docInstanceId: "env-1",
+  serviceError: {
+    code: "TXE-1005",
+    message: "The document could not be delivered to the recipient.",
+    category: "TRANSPORT_ERROR",
+  },
+};
+
+async function post(body: object, secret: string | null) {
+  const raw = JSON.stringify(body);
+  const headers: Record<string, string> = {};
+  if (secret !== null) {
+    headers["x-arratech-webhook-sign"] = createHmac("sha256", secret).update(raw).digest("hex");
+  }
+  const response = await server.request("/arratech", { method: "POST", body: raw, headers });
+  return { status: response.status, body: (await response.json()) as Record<string, unknown> };
+}
+
+function event(payload: object, eventType = "transaction.send_failed") {
+  return { id: "evt-1", eventType, payload };
+}
+
+beforeEach(() => {
+  reports.length = 0;
+  sent.length = 0;
+  sentOutcome = "sent-by-us";
+  process.env.ARRATECH_WEBHOOK_SECRET = productionSecret;
+  process.env.ARRATECH_TEST_WEBHOOK_SECRET = testSecret;
+});
+
+describe("transaction.send_failed", () => {
+  it("fails the transaction's delivery with the provider's error mapped to a category", async () => {
+    const result = await post(event(failedPayload), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(result.body.outcome).toBe("applied");
+    expect(reports).toEqual([
+      {
+        channel: "peppol",
+        provider: "at-shared-ap-fr",
+        providerTransactionId: "tx-1",
+        useTestNetwork: false,
+        status: "failed",
+        failure: {
+          category: "transport",
+          message: "The document could not be delivered to the recipient.",
+          providerCode: "TXE-1005",
+        },
+        eventId: "evt-1",
+        eventType: "transaction.send_failed",
+        payload: failedPayload,
+      },
+    ]);
+    expect(sent).toEqual([]);
+  });
+
+  it("accepts a failure without error details or addressing, which the provider omits rather than nulls", async () => {
+    const result = await post(event({ id: "tx-2", transactionStatus: "REJECTED", createdAt: "2026-09-09T10:00:00Z", apId: productionAp }), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      providerTransactionId: "tx-2",
+      status: "failed",
+      failure: { category: "other", message: null, providerCode: null },
+    });
+  });
+
+  it("takes the network from the signature when the access point is omitted", async () => {
+    const { apId: _omitted, ...withoutAp } = failedPayload;
+
+    const production = await post(event(withoutAp), productionSecret);
+    const test = await post(event(withoutAp), testSecret);
+
+    expect(production.status).toBe(200);
+    expect(test.status).toBe(200);
+    expect(reports.map((report) => (report as { useTestNetwork: boolean }).useTestNetwork)).toEqual([false, true]);
+  });
+
+  it("refuses to guess the network when both secrets match and no access point is reported", async () => {
+    process.env.ARRATECH_TEST_WEBHOOK_SECRET = productionSecret;
+    const { apId: _omitted, ...withoutAp } = failedPayload;
+
+    const result = await post(event(withoutAp), productionSecret);
+
+    expect(result.status).toBe(400);
+    expect(reports).toEqual([]);
+  });
+
+  it("requires the signature to belong to the reported access point's network", async () => {
+    const result = await post(event({ ...failedPayload, apId: testAp }), productionSecret);
+
+    expect(result.status).toBe(401);
+    expect(reports).toEqual([]);
+  });
+
+  it("ignores a failure for an access point that is not ours", async () => {
+    const result = await post(event({ ...failedPayload, apId: "someone-elses-ap" }), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(reports).toEqual([]);
+  });
+
+  it("rejects a failure without a transaction id", async () => {
+    const { id: _omitted, ...withoutId } = failedPayload;
+
+    const result = await post(event(withoutId), productionSecret);
+
+    expect(result.status).toBe(400);
+    expect(reports).toEqual([]);
+  });
+
+  it("rejects an unsigned or wrongly signed report", async () => {
+    expect((await post(event(failedPayload), null)).status).toBe(401);
+    expect((await post(event(failedPayload), "not-a-secret")).status).toBe(401);
+    expect(reports).toEqual([]);
+  });
+});
+
+describe("other transaction events", () => {
+  it("still ignores event types it does not handle, including inbound failures", async () => {
+    for (const eventType of ["transaction.receive_failed", "mls.received", "webhooks.test"]) {
+      const result = await post(event(failedPayload, eventType), productionSecret);
+      expect(result.status).toBe(200);
+      expect(result.body.message).toBe("Event type not processed");
+    }
+    expect(reports).toEqual([]);
+    expect(sent).toEqual([]);
+  });
+
+  const completedPayload = {
+    id: "tx-3",
+    apId: productionAp,
+    senderId: "0225:123456789",
+    receiverId: "0208:0123456789",
+    docTypeId: "doc-type",
+    processId: "process",
+    transactionStatus: "COMPLETED",
+    docInstanceId: "env-3",
+  };
+
+  it("confirms the delivery of our own send when its transaction completes", async () => {
+    const result = await post(event({ ...completedPayload }, "transaction.sent"), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(result.body.outcome).toBe("sent-by-us");
+    expect(result.body.delivery).toBe("applied");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ apTransactionId: "tx-3", useTestNetwork: false, docInstanceId: "env-3" });
+    expect(reports).toEqual([
+      {
+        channel: "peppol",
+        provider: "at-shared-ap-fr",
+        providerTransactionId: "tx-3",
+        useTestNetwork: false,
+        status: "delivered",
+        failure: null,
+        eventId: "evt-1",
+        eventType: "transaction.sent",
+        payload: completedPayload,
+      },
+    ]);
+  });
+
+  it("confirms the delivery of a document the provider sent on our behalf just the same", async () => {
+    sentOutcome = "recorded";
+    const result = await post(event({ ...completedPayload, id: "tx-5" }, "transaction.sent"), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(result.body.outcome).toBe("recorded");
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({ providerTransactionId: "tx-5", status: "delivered" });
+  });
+
+  it("does not turn a transaction.sent that is not completed into a failure", async () => {
+    const payload = {
+      id: "tx-4",
+      apId: productionAp,
+      senderId: "0225:123456789",
+      receiverId: "0208:0123456789",
+      docTypeId: "doc-type",
+      processId: "process",
+      transactionStatus: "FAILED",
+    };
+
+    const result = await post(event(payload, "transaction.sent"), productionSecret);
+
+    expect(result.status).toBe(200);
+    expect(result.body.message).toBe("Transaction not completed");
+    expect(sent).toEqual([]);
+    expect(reports).toEqual([]);
+  });
+});

--- a/translations/de.csv
+++ b/translations/de.csv
@@ -967,6 +967,11 @@ Change VAT settings,MwSt.-Einstellungen ändern
 Changing the regime during a reporting period can leave that period unfiled. Coordinate such a change with support.,Eine Änderung des Regimes während eines Meldezeitraums kann dazu führen\, dass dieser Zeitraum nicht eingereicht wird. Stimmen Sie eine solche Änderung mit dem Support ab.
 Choose the VAT regime and when VAT becomes due first,Wählen Sie zuerst das MwSt.-Regime und den Zeitpunkt der Steuerentstehung
 Daily B2C totals and cross-border invoices are reported to the French tax administration on the company's behalf. Register the company once\, then submit reports through the API.,Tägliche B2C-Summen und grenzüberschreitende Rechnungen werden im Namen des Unternehmens an die französische Steuerverwaltung gemeldet. Registrieren Sie das Unternehmen einmalig und reichen Sie die Meldungen anschließend über die API ein.
+Delivered,Zugestellt
+Deliveries,Zustellungen
+Delivery failed,Zustellung fehlgeschlagen
+Email delivery to {0} failed.,Die E-Mail-Zustellung an {0} ist fehlgeschlagen.
+Error code {0}.,Fehlercode {0}.
 Failed to load the e-reporting registration,Die E-Reporting-Registrierung konnte nicht geladen werden
 Failed to register the company for e-reporting,Das Unternehmen konnte nicht für E-Reporting registriert werden
 Filed by corrective filing,Eingereicht per Korrekturmeldung
@@ -976,11 +981,14 @@ French e-reporting,Französisches E-Reporting
 Last checked {0}.,Zuletzt geprüft am {0}.
 Late\, awaiting corrective filing,Verspätet\, wartet auf Korrekturmeldung
 Needs support,Support erforderlich
+No deliveries recorded for this document.,Für dieses Dokument sind keine Zustellungen erfasst.
 On invoicing (TVA sur les débits),Bei Rechnungsstellung (TVA sur les débits)
 On payment (TVA sur les encaissements),Bei Zahlung (TVA sur les encaissements)
 Our support team has been notified and will contact you. You can also reach us at support@recommand.eu.,Unser Support-Team wurde benachrichtigt und wird sich bei Ihnen melden. Sie erreichen uns auch unter support@recommand.eu.
 Outcome code {0}.,Ergebniscode {0}.
 Payment reports are only filed when VAT becomes due on payment.,Zahlungsmeldungen werden nur eingereicht\, wenn die MwSt. bei Zahlung entsteht.
+Peppol,Peppol
+Peppol delivery to {0} failed.,Die Peppol-Zustellung an {0} ist fehlgeschlagen.
 Playground and test-network teams do not file with the tax administration. Reports are accepted and recorded\, but simulated.,Playground- und Testnetzwerk-Teams reichen nichts bei der Steuerverwaltung ein. Meldungen werden angenommen und gespeichert\, aber simuliert.
 Register for e-reporting,Für E-Reporting registrieren
 Registered,Registriert
@@ -992,6 +1000,7 @@ Select the VAT regime,MwSt.-Regime auswählen
 Select when VAT becomes due,Zeitpunkt der Steuerentstehung auswählen
 Simulated,Simuliert
 Simulated: this report is recorded but not filed.,Simuliert: Diese Meldung wurde gespeichert\, aber nicht eingereicht.
+Status since {0},Status seit {0}
 Superseded,Ersetzt
 Suspended,Ausgesetzt
 The company is registered for French e-reporting,Das Unternehmen ist für französisches E-Reporting registriert
@@ -1004,3 +1013,4 @@ Update registration,Registrierung aktualisieren
 VAT becomes due,Steuerentstehung
 VAT regime,MwSt.-Regime
 Verify the company first. The signed French mandate is what allows us to report on its behalf.,Verifizieren Sie zuerst das Unternehmen. Das unterzeichnete französische Mandat berechtigt uns\, in seinem Namen zu melden.
+Where this document stands with each recipient it was sent to.,Wo dieses Dokument bei jedem Empfänger steht\, an den es gesendet wurde.

--- a/translations/fr.csv
+++ b/translations/fr.csv
@@ -967,6 +967,11 @@ Change VAT settings,Modifier les paramètres de TVA
 Changing the regime during a reporting period can leave that period unfiled. Coordinate such a change with support.,Modifier le régime pendant une période de déclaration peut laisser cette période sans dépôt. Coordonnez ce changement avec le support.
 Choose the VAT regime and when VAT becomes due first,Choisissez d'abord le régime de TVA et le moment d'exigibilité de la TVA
 Daily B2C totals and cross-border invoices are reported to the French tax administration on the company's behalf. Register the company once\, then submit reports through the API.,Les totaux B2C journaliers et les factures transfrontalières sont transmis à l'administration fiscale française au nom de l'entreprise. Enregistrez l'entreprise une fois\, puis soumettez les déclarations via l'API.
+Delivered,Livré
+Deliveries,Livraisons
+Delivery failed,Livraison échouée
+Email delivery to {0} failed.,La livraison par e-mail à {0} a échoué.
+Error code {0}.,Code d'erreur {0}.
 Failed to load the e-reporting registration,Impossible de charger l'enregistrement e-reporting
 Failed to register the company for e-reporting,Impossible d'enregistrer l'entreprise pour l'e-reporting
 Filed by corrective filing,Déposée par dépôt rectificatif
@@ -976,11 +981,14 @@ French e-reporting,E-reporting France
 Last checked {0}.,Dernière vérification le {0}.
 Late\, awaiting corrective filing,En retard\, en attente de dépôt rectificatif
 Needs support,Support requis
+No deliveries recorded for this document.,Aucune livraison enregistrée pour ce document.
 On invoicing (TVA sur les débits),À la facturation (TVA sur les débits)
 On payment (TVA sur les encaissements),À l'encaissement (TVA sur les encaissements)
 Our support team has been notified and will contact you. You can also reach us at support@recommand.eu.,Notre équipe support a été informée et vous contactera. Vous pouvez aussi nous joindre à support@recommand.eu.
 Outcome code {0}.,Code de résultat {0}.
 Payment reports are only filed when VAT becomes due on payment.,Les déclarations de paiement ne sont déposées que lorsque la TVA est exigible à l'encaissement.
+Peppol,Peppol
+Peppol delivery to {0} failed.,La livraison Peppol à {0} a échoué.
 Playground and test-network teams do not file with the tax administration. Reports are accepted and recorded\, but simulated.,Les équipes playground et réseau de test ne déposent rien auprès de l'administration fiscale. Les déclarations sont acceptées et enregistrées\, mais simulées.
 Register for e-reporting,S'enregistrer pour l'e-reporting
 Registered,Enregistrée
@@ -992,6 +1000,7 @@ Select the VAT regime,Sélectionnez le régime de TVA
 Select when VAT becomes due,Sélectionnez le moment d'exigibilité de la TVA
 Simulated,Simulée
 Simulated: this report is recorded but not filed.,Simulée : cette déclaration est enregistrée mais non déposée.
+Status since {0},Statut depuis le {0}
 Superseded,Remplacée
 Suspended,Suspendue
 The company is registered for French e-reporting,L'entreprise est enregistrée pour l'e-reporting France
@@ -1004,3 +1013,4 @@ Update registration,Mettre à jour l'enregistrement
 VAT becomes due,Exigibilité de la TVA
 VAT regime,Régime de TVA
 Verify the company first. The signed French mandate is what allows us to report on its behalf.,Vérifiez d'abord l'entreprise. Le mandat français signé est ce qui nous autorise à déclarer en son nom.
+Where this document stands with each recipient it was sent to.,Où en est ce document auprès de chaque destinataire auquel il a été envoyé.

--- a/translations/nl.csv
+++ b/translations/nl.csv
@@ -967,6 +967,11 @@ Change VAT settings,Btw-instellingen wijzigen
 Changing the regime during a reporting period can leave that period unfiled. Coordinate such a change with support.,Het regime wijzigen tijdens een aangifteperiode kan ervoor zorgen dat die periode niet wordt aangegeven. Stem zo'n wijziging af met support.
 Choose the VAT regime and when VAT becomes due first,Kies eerst het btw-regime en wanneer de btw verschuldigd wordt
 Daily B2C totals and cross-border invoices are reported to the French tax administration on the company's behalf. Register the company once\, then submit reports through the API.,Dagelijkse B2C-totalen en grensoverschrijdende facturen worden namens het bedrijf aan de Franse belastingdienst gerapporteerd. Registreer het bedrijf eenmalig en dien daarna rapporten in via de API.
+Delivered,Afgeleverd
+Deliveries,Afleveringen
+Delivery failed,Aflevering mislukt
+Email delivery to {0} failed.,E-mailaflevering aan {0} mislukt.
+Error code {0}.,Foutcode {0}.
 Failed to load the e-reporting registration,Laden van de e-reporting-registratie mislukt
 Failed to register the company for e-reporting,Registreren van het bedrijf voor e-reporting mislukt
 Filed by corrective filing,Aangegeven via corrigerende aangifte
@@ -976,11 +981,14 @@ French e-reporting,Franse e-reporting
 Last checked {0}.,Laatst gecontroleerd op {0}.
 Late\, awaiting corrective filing,Laattijdig\, wacht op corrigerende aangifte
 Needs support,Support nodig
+No deliveries recorded for this document.,Geen afleveringen geregistreerd voor dit document.
 On invoicing (TVA sur les débits),Bij facturatie (TVA sur les débits)
 On payment (TVA sur les encaissements),Bij betaling (TVA sur les encaissements)
 Our support team has been notified and will contact you. You can also reach us at support@recommand.eu.,Ons supportteam is op de hoogte gebracht en neemt contact met je op. Je kunt ons ook bereiken via support@recommand.eu.
 Outcome code {0}.,Resultaatcode {0}.
 Payment reports are only filed when VAT becomes due on payment.,Betalingsrapporten worden alleen ingediend wanneer de btw verschuldigd wordt bij betaling.
+Peppol,Peppol
+Peppol delivery to {0} failed.,Peppol-aflevering aan {0} mislukt.
 Playground and test-network teams do not file with the tax administration. Reports are accepted and recorded\, but simulated.,Playground- en testnetwerkteams dienen niets in bij de belastingdienst. Rapporten worden aanvaard en opgeslagen\, maar gesimuleerd.
 Register for e-reporting,Registreren voor e-reporting
 Registered,Geregistreerd
@@ -992,6 +1000,7 @@ Select the VAT regime,Selecteer het btw-regime
 Select when VAT becomes due,Selecteer wanneer de btw verschuldigd wordt
 Simulated,Gesimuleerd
 Simulated: this report is recorded but not filed.,Gesimuleerd: dit rapport is opgeslagen maar niet ingediend.
+Status since {0},Status sinds {0}
 Superseded,Vervangen
 Suspended,Opgeschort
 The company is registered for French e-reporting,Het bedrijf is geregistreerd voor Franse e-reporting
@@ -1004,3 +1013,4 @@ Update registration,Registratie bijwerken
 VAT becomes due,Btw verschuldigd
 VAT regime,Btw-regime
 Verify the company first. The signed French mandate is what allows us to report on its behalf.,Verifieer eerst het bedrijf. Het ondertekende Franse mandaat geeft ons de bevoegdheid om namens het bedrijf te rapporteren.
+Where this document stands with each recipient it was sent to.,Waar dit document staat bij elke ontvanger waarnaar het is verzonden.

--- a/utils/parsing/send-document.ts
+++ b/utils/parsing/send-document.ts
@@ -121,7 +121,7 @@ export const sendDocumentBaseShape = {
         .enum(["always", "on_peppol_failure"])
         .default("on_peppol_failure")
         .openapi({
-          description: "When to send the email. If the provided Peppol recipient is null, email becomes the primary delivery method and emails are always sent.",
+          description: "When to send the email. `always` sends it with the Peppol transmission. `on_peppol_failure` sends it when the Peppol transmission is refused at send time, or when the access point reports afterwards that it failed; in that second case the email goes out at that moment and appears as email deliveries on the document, announced by a `document.delivery_status_changed` event. If the Peppol recipient is null, email is the only channel and is always sent.",
         }),
       to: z.array(z.string()).openapi({
         description: "The email addresses to send the document to.",
@@ -142,7 +142,7 @@ export const sendDocumentBaseShape = {
     .openapi({
       ref: "Email",
       description:
-        "Email delivery options. When Peppol recipient is provided, email is optional and you can choose to always send the email, or only when Peppol delivery fails. When Peppol recipient is null, email becomes the primary delivery method and `email.to` is required. Each sent email is counted towards your document quota.",
+        "Email delivery options. When a Peppol recipient is provided, email is optional and you can choose to always send the email, or only when Peppol delivery fails, whether that is refused at send time or reported later by the access point. When the Peppol recipient is null, email becomes the primary delivery method and `email.to` is required. Each email counts towards your document quota at the moment it is sent.",
     }),
   pdfGeneration: z
     .object({

--- a/utils/pipelines/provider-sent/index.ts
+++ b/utils/pipelines/provider-sent/index.ts
@@ -52,6 +52,7 @@ export async function providerSentPipeline(
     // Only playground teams are on the test network, and their documents are not
     // billed there either when they send through our own API.
     isPlayground: options.useTestNetwork ?? false,
+    useTestNetwork: options.useTestNetwork ?? false,
     inputFormat: "access_point",
     document: {
       senderId,

--- a/utils/pipelines/sending/errors.ts
+++ b/utils/pipelines/sending/errors.ts
@@ -2,6 +2,8 @@ export class SendingFailure extends Error {
   constructor(
     message: string | Record<string, string[]>,
     readonly status: 400 | 422,
+    /** Extra fields returned next to the errors, such as why a delivery failed. */
+    readonly details: Record<string, unknown> = {},
   ) {
     super(typeof message === "string" ? message : JSON.stringify(message));
     this.payload = message;

--- a/utils/pipelines/sending/index.ts
+++ b/utils/pipelines/sending/index.ts
@@ -5,7 +5,13 @@ import {
 } from "@peppol/data/access-point-providers";
 import { getSendingCompanyIdentifier } from "@peppol/data/company-identifiers";
 import { sendDocumentEmail } from "@peppol/data/email/send-email";
-import { simulateSendAs4 } from "@peppol/data/playground/simulate-ap";
+import {
+  PlaygroundRecipientNotFoundError,
+  simulateSendAs4,
+} from "@peppol/data/playground/simulate-ap";
+import type { DeliveryFailureCategory } from "@peppol/data/deliveries/model";
+import { sendDocumentResponseBody } from "./response";
+import { emailFallbackRequest } from "@peppol/data/deliveries/email-fallback";
 import { recordOutgoingDocument } from "@peppol/data/record-outgoing-document";
 import { getRecipientCapabilities } from "@peppol/data/recipient-capabilities";
 import { normalizePeppolAddress } from "@peppol/utils/parsing/peppol-address";
@@ -116,12 +122,17 @@ export async function sendingPipeline(c: SendingContext) {
     let sentPeppol = false;
     let as4Response: SendAs4Response | null = null;
     let peppolFailure = "";
+    // Why the transmission was refused, in the words the deliveries use, so a refusal
+    // in the send itself is reported the same way as one the access point reports
+    // afterwards.
+    let peppolFailureCategory: DeliveryFailureCategory | null = null;
     if (recipientAddress !== null) {
       if (prepared.peppolRoutingFailure) {
         // The recipient receives nothing this document can be written as, so the
         // transmission is skipped rather than handed to an access point that can only
         // return the same answer. Email delivery, if configured, still applies.
         peppolFailure = prepared.peppolRoutingFailure;
+        peppolFailureCategory = "document_not_supported";
       } else if (isPlayground && !useTestNetwork) {
         try {
           await simulateSendAs4({
@@ -141,6 +152,10 @@ export async function sendingPipeline(c: SendingContext) {
             error instanceof Error
               ? error.message
               : "No additional context available, please contact support@recommand.eu if you could use our help.";
+          peppolFailureCategory =
+            error instanceof PlaygroundRecipientNotFoundError
+              ? "recipient_not_found"
+              : "transport";
         }
       } else {
         as4Response = await getAccessPointProvider(
@@ -160,6 +175,8 @@ export async function sendingPipeline(c: SendingContext) {
           peppolFailure =
             as4Response.sendingException?.message ??
             "No additional context available, please contact support@recommand.eu if you could use our help.";
+          peppolFailureCategory =
+            as4Response.sendingException?.category ?? "transport";
         }
       }
 
@@ -167,6 +184,7 @@ export async function sendingPipeline(c: SendingContext) {
         throw new SendingFailure(
           `Failed to send document over Peppol network. ${peppolFailure}`,
           422,
+          { deliveryFailure: { channel: "peppol", category: peppolFailureCategory ?? "other" } },
         );
       }
     }
@@ -200,6 +218,9 @@ export async function sendingPipeline(c: SendingContext) {
       throw new SendingFailure(
         `Failed to send document over Peppol network and email. ${peppolFailure} ${emailFailure}`,
         422,
+        peppolFailureCategory
+          ? { deliveryFailure: { channel: "peppol", category: peppolFailureCategory } }
+          : {},
       );
     }
 
@@ -209,6 +230,7 @@ export async function sendingPipeline(c: SendingContext) {
       teamId: team.id,
       company,
       isPlayground,
+      useTestNetwork,
       inputFormat,
       document: {
         senderId: senderAddress,
@@ -226,6 +248,18 @@ export async function sendingPipeline(c: SendingContext) {
         sentPeppol,
         emailRecipients,
         as4Response,
+        peppolFailure:
+          recipientAddress !== null && !sentPeppol
+            ? {
+                category: peppolFailureCategory ?? "other",
+                message: peppolFailure || null,
+                providerCode: null,
+              }
+            : null,
+        // An email asked for only on failure has not gone out when the transmission
+        // was accepted; it is kept with the document in case the access point
+        // reports the transmission failed later.
+        emailFallback: emailFallbackRequest(input.email, sentPeppol),
       },
       originalPayload: prepared.originalPayload,
     });
@@ -239,22 +273,19 @@ export async function sendingPipeline(c: SendingContext) {
     });
 
     return c.json(
-      actionSuccess({
-        teamId: team.id,
-        companyId: company.id,
-        id: transmittedDocument.id,
-        peppolMessageId: as4Response?.peppolMessageId ?? null,
-        envelopeId: as4Response?.sbdhInstanceIdentifier ?? null,
-        sentOverPeppol: sentPeppol,
-        sentOverEmail: emailRecipients.length > 0,
-        emailRecipients,
-        ...(peppolFailure
-          ? { additionalPeppolFailureContext: peppolFailure }
-          : {}),
-        ...(emailFailure
-          ? { additionalEmailFailureContext: emailFailure }
-          : {}),
-      }),
+      actionSuccess(
+        sendDocumentResponseBody({
+          teamId: team.id,
+          companyId: company.id,
+          documentId: transmittedDocument.id,
+          as4Response,
+          sentPeppol,
+          emailRecipients,
+          deliveries: transmittedDocument.deliveries,
+          peppolFailure,
+          emailFailure,
+        }),
+      ),
     );
   } catch (error) {
     if (error instanceof SendingFailure) {
@@ -262,7 +293,7 @@ export async function sendingPipeline(c: SendingContext) {
         typeof error.payload === "string"
           ? actionFailure(error.payload)
           : actionFailure(error.payload);
-      return c.json(failure, error.status);
+      return c.json({ ...failure, ...error.details }, error.status);
     }
 
     console.error(error);

--- a/utils/pipelines/sending/response.ts
+++ b/utils/pipelines/sending/response.ts
@@ -1,0 +1,48 @@
+import type { SendAs4Response } from "@peppol/data/access-point-providers";
+import {
+  summarizeDeliveryStatus,
+  toDeliverySummary,
+  type DocumentDelivery,
+} from "@peppol/data/deliveries/model";
+
+/**
+ * The body of a successful send. `sentOverPeppol`, `sentOverEmail` and
+ * `emailRecipients` describe what this request did: they are what the send knew as
+ * it handed the document over. `deliveries` and `deliveryStatus` are read back after
+ * recording and are where the document stands, which can already be further along:
+ * an access point's report that overtook the send may have failed the transmission
+ * and sent the email fallback, and those email deliveries then appear here while
+ * the request's own fields still say no email was sent by it.
+ */
+export function sendDocumentResponseBody(input: {
+  teamId: string;
+  companyId: string;
+  documentId: string;
+  as4Response: SendAs4Response | null;
+  sentPeppol: boolean;
+  emailRecipients: string[];
+  deliveries: DocumentDelivery[];
+  peppolFailure: string;
+  emailFailure: string;
+}) {
+  const references = {
+    peppolMessageId: input.as4Response?.peppolMessageId ?? null,
+    peppolConversationId: input.as4Response?.peppolConversationId ?? null,
+    envelopeId: input.as4Response?.sbdhInstanceIdentifier ?? null,
+  };
+  const deliveries = input.deliveries.map((delivery) => toDeliverySummary(delivery, references));
+  return {
+    teamId: input.teamId,
+    companyId: input.companyId,
+    id: input.documentId,
+    peppolMessageId: references.peppolMessageId,
+    envelopeId: references.envelopeId,
+    sentOverPeppol: input.sentPeppol,
+    sentOverEmail: input.emailRecipients.length > 0,
+    emailRecipients: input.emailRecipients,
+    deliveryStatus: summarizeDeliveryStatus(deliveries.map((delivery) => delivery.status)),
+    deliveries,
+    ...(input.peppolFailure ? { additionalPeppolFailureContext: input.peppolFailure } : {}),
+    ...(input.emailFailure ? { additionalEmailFailureContext: input.emailFailure } : {}),
+  };
+}


### PR DESCRIPTION
Track each outgoing document delivery independently, with pending, delivered and failed statuses per recipient and channel. Expose attempts and an aggregate status through the API and dashboard, and publish status-change events when an outcome becomes known.

Handle asynchronous delivery failures and requested email fallback after the initial send returns. Preserve existing send-response fields. Create schema separately from the resumable historical backfill, and reconcile pending attempts with bounded provider requests.

Validation covers status transitions, duplicate reports, fallback recovery, database transactions, backfill and API compatibility. Package typechecks and the production build pass.
