### PR TITLE
Require the invoicing framework on French cross-border reports

### DIFF
--- a/api/documents/shared.ts
+++ b/api/documents/shared.ts
@@ -7,7 +7,7 @@ import { creditNoteSchema } from "@peppol/utils/parsing/creditnote/schemas";
 import { messageLevelResponseSchema } from "@peppol/utils/parsing/message-level-response/schemas";
 import { franceCdarSchema } from "@peppol/utils/parsing/france-cdar/schemas";
 import { frenchB2CReportSchema } from "@peppol/utils/parsing/b2c-reporting/france";
-import { frenchB2BiReportSchema } from "@peppol/utils/parsing/b2bi-reporting/france";
+import { storedFrenchB2BiReportSchema } from "@peppol/utils/parsing/b2bi-reporting/france";
 import { labelResponse } from "@directory/api/labels/shared";
 import { validationResponse } from "@peppol/types/validation";
 import { STORED_DOCUMENT_TYPE_KEYS } from "@peppol/utils/type-repository/document-types/keys";
@@ -90,7 +90,9 @@ export const transmittedDocumentResponse = z.object({
         messageLevelResponseSchema,
         franceCdarSchema,
         frenchB2CReportSchema,
-        frenchB2BiReportSchema,
+        // The stored shape, which reads back reports filed before the invoicing
+        // framework was part of a cross-border report.
+        storedFrenchB2BiReportSchema,
         z.null(),
     ]).openapi({
         description: "The document read into the JSON shape of its type, so you do not have to parse the XML yourself. Null when the type is `unknown` or the payload was not kept.",

--- a/api/reporting/submit.ts
+++ b/api/reporting/submit.ts
@@ -24,7 +24,10 @@ import {
   resolveFrenchReportingEnvironment,
   type FrenchReportingDeclarant,
 } from "@peppol/data/fr-reporting-declarants";
-import { recordFrenchReportingSubmission } from "@peppol/data/fr-reporting-submissions";
+import {
+  ensureFrenchReportingSubmissionRecord,
+  recordFrenchReportingSubmission,
+} from "@peppol/data/fr-reporting-submissions";
 import { recordOutgoingDocument } from "@peppol/data/record-outgoing-document";
 import { findOutgoingDocumentByExternalReference } from "@peppol/data/transmitted-documents";
 import {
@@ -43,6 +46,8 @@ import {
   getFrenchB2CReportDocumentProfile,
   type FrenchB2CReport,
 } from "@peppol/utils/parsing/b2c-reporting/france";
+import { assessFrenchReportDuplicate } from "@peppol/utils/parsing/fr-reporting/duplicates";
+import { sendSystemAlert } from "@peppol/utils/system-notifications/telegram";
 import type { ReportingDocumentTypeKey } from "@peppol/utils/type-repository/document-types/types";
 import { Server, type Context } from "@recommand/lib/api";
 import { actionFailure, actionSuccess } from "@recommand/lib/utils";
@@ -63,9 +68,17 @@ const frenchReportResponseSchema = z.object({
     description:
       "True when this reference was already filed, in which case the identifier of the existing report is returned and nothing was filed again.",
   }),
+  warning: z.string().optional().openapi({
+    description:
+      "Present only on a duplicate that is not a plain retry: the reference was already used for a report that differs from this request, so nothing was filed for this request. The text says what was found. A correction or a cancellation sent under the reference of the report it means to act on is the usual cause.",
+  }),
 });
 
-const referenceGuidance = `Choose a new, unique \`reference\` for every report, including corrections and cancellations. Retrying the exact same request with the same reference is safe: it returns the report filed the first time instead of filing a second one. A correction or cancellation acts on the report identified by the data in the request (the day and category of a daily total, or the document number of an invoice) and carries the optional \`action\` field.`;
+const referenceGuidance = `Choose a new, unique \`reference\` for every report, including corrections and cancellations. Retrying the exact same request with the same reference is safe: it returns the report filed the first time instead of filing a second one. A correction or cancellation acts on the report identified by the data in the request, and carries the optional \`action\` field.
+
+A report is matched on the declarant and on the data that identifies the operation, and never on the reference: an invoice report and its payments on the invoice number, a daily sales total on the day, category and currency, and a daily payment total on the day and currency. Neither the issue date nor the payment date is part of how an invoice or its payment is matched. A correction replaces the report it matches in full, so send the complete report rather than the fields that changed, and a cancellation carries the complete report as well. Both are refused once the filing for that period has been assembled, which happens after the period ends rather than on the last day itself.
+
+When the reference of an earlier report is reused, the earlier report is returned with \`duplicate: true\` and a \`warning\`, and nothing is filed: the correction or cancellation still has to be sent under a new reference.`;
 
 const registrationGuidance = `The company must be registered for French e-reporting first, through \`PUT /:companyId/reporting/fr/declarant\`. Reports for playground and test-network teams are recorded but not filed.`;
 
@@ -279,12 +292,53 @@ async function fileFrenchReport({
     }
   }
 
+  if (submission?.unknownReportingStatus) {
+    console.warn(
+      `French report ${externalReferenceId} was accepted with reporting status "${submission.unknownReportingStatus}", which this integration does not know`,
+    );
+  }
+
   const existing = await findOutgoingDocumentByExternalReference(
     company.id,
     externalReferenceId,
   );
   if (existing) {
-    return c.json(actionSuccess({ id: existing.id, duplicate: true }));
+    // The reference was used before. Two things can be true of the report on file: it
+    // may be the one this request is retrying, or it may be a different report whose
+    // reference was reused, in which case nothing was filed for this request. The
+    // stored report says which.
+    const assessment = assessFrenchReportDuplicate({
+      stored: existing.parsed,
+      submitted: report,
+    });
+    if (assessment.kind !== "retry") {
+      console.warn(
+        `French report reference ${report.reference} for company ${company.id} resolved to an earlier report (${assessment.kind})`,
+      );
+    }
+
+    // A report filed without its record here is never polled, so the retry that lands
+    // on the existing document is where the missing record is rebuilt.
+    await ensureFrenchReportingSubmissionRecord({
+      transmittedDocumentId: existing.id,
+      storedReport: existing.parsed,
+      declarantId: declarant.id,
+      teamId: team.id,
+      companyId: company.id,
+      environment,
+      flowId: externalReferenceId,
+      simulated,
+      ledgerStatus: submission?.status ?? null,
+      reportingStatus: submission?.reportingStatus ?? null,
+    });
+
+    return c.json(
+      actionSuccess({
+        id: existing.id,
+        duplicate: true,
+        ...(assessment.warning ? { warning: assessment.warning } : {}),
+      }),
+    );
   }
 
   // The report is filed rather than transmitted, so it has no XML, no recipient and
@@ -330,6 +384,13 @@ async function fileFrenchReport({
     });
   } catch (error) {
     console.error("Failed to record French reporting submission:", error);
+    // The report is filed and its document exists, but nothing follows it yet. A retry
+    // of the same reference repairs this; support is told in case none comes.
+    sendSystemAlert(
+      "French Reporting Record Not Written",
+      `E-reporting event ${externalReferenceId} (company ${company.id}) was filed and recorded as document ${transmittedDocument.id}, but its follow-up record could not be written, so its status is not being polled. A retry under the same reference restores it.`,
+      "error",
+    );
   }
 
   return c.json(actionSuccess({ id: transmittedDocument.id, duplicate }));

--- a/data/at/fr-reporting.ts
+++ b/data/at/fr-reporting.ts
@@ -20,9 +20,6 @@ const FRENCH_REPORTING_PROFILE = "FR-F10";
 /** The declarant files as the seller of the reported operations. */
 const FRENCH_DECLARANT_ROLE = "SE";
 
-/** The only "cadre de facturation" Arratech documents for a 10.1 event. */
-const FRENCH_INVOICE_CADRE = "S1";
-
 /**
  * The tax administration's own party codes. They are not ICD codes: an Italian
  * buyer is 0223, never 0211. The code decides what the company id must contain.
@@ -151,7 +148,10 @@ type FrenchReportAction = keyof typeof arratechActionByPublicAction;
  * The sub-flux and operation a report is filed as, for the record we keep of the
  * filing.
  */
-export function describeFrenchReportEvent(report: FrenchB2CReport | FrenchB2BiReport): {
+export function describeFrenchReportEvent(report: {
+  type: FrenchB2CReport["type"] | FrenchB2BiReport["type"];
+  action: FrenchReportAction;
+}): {
   subFlux: "10.1" | "10.2" | "10.3" | "10.4";
   operation: "SUBMIT" | "CANCEL";
   transmissionType: "IN" | "RE";
@@ -243,7 +243,10 @@ export function toArratechB2BiFlow(
         typeCode: input.documentType === "creditNote" ? "381" : "380",
         currencyCode: input.currency,
         ...(input.dueDate ? { dueDate: input.dueDate } : {}),
-        cadre: FRENCH_INVOICE_CADRE,
+        // The "cadre de facturation" is the invoicing framework of the reported
+        // document, in the codes an invoice carries. It is checked against the invoice
+        // when the period is assembled, so it comes from the report and is not assumed.
+        cadre: input.billingMode,
         seller,
         buyer: toFrenchReportingBuyer(input.buyer),
         taxExclusiveAmount: input.taxExclusiveAmount,
@@ -304,12 +307,14 @@ export const frenchReportingLedgerStatuses = [
   "REJECTED",
 ] as const;
 
+// The statuses are read as plain strings for the same reason as on the status
+// endpoint: an unknown value must not fail a report that was accepted.
 const arratechSubmissionResponseSchema = z
   .object({
     flowId: z.string().min(1),
     duplicate: z.boolean().default(false),
-    status: z.enum(frenchReportingLedgerStatuses).nullish(),
-    reportingStatus: z.enum(frenchReportingStatuses).nullish(),
+    status: z.string().nullish(),
+    reportingStatus: z.string().nullish(),
   })
   .passthrough();
 
@@ -317,10 +322,20 @@ export type FrenchReportingSubmissionResult = {
   flowId: string;
   /** True when this reference was already on file and nothing new was filed. */
   duplicate: boolean;
-  status: (typeof frenchReportingLedgerStatuses)[number] | null;
+  /** The service's own ledger value, kept as it was answered. */
+  status: string | null;
+  /** Null when the service answered a status this integration does not know. */
   reportingStatus: FrenchReportingStatus | null;
+  /** The reporting status as answered, when it is not one this integration knows. */
+  unknownReportingStatus: string | null;
 };
 
+/**
+ * The status of an event as the service answers it. The two status vocabularies are
+ * read as plain strings rather than as closed lists: a value we do not know yet must
+ * be visible and recoverable, not a parse failure that stops the event from ever
+ * being followed again. `toKnownReportingStatus` decides what a value means.
+ */
 const arratechSubmissionStatusSchema = z
   .object({
     flowId: z.string(),
@@ -329,8 +344,8 @@ const arratechSubmissionStatusSchema = z
     subFlux: z.string(),
     operation: z.string(),
     transmissionType: z.string(),
-    status: z.enum(frenchReportingLedgerStatuses),
-    reportingStatus: z.enum(frenchReportingStatuses),
+    status: z.string().nullable(),
+    reportingStatus: z.string(),
     receivedAt: z.string(),
     operationDate: z.string().nullable(),
     periodStart: z.string().nullable(),
@@ -342,6 +357,17 @@ const arratechSubmissionStatusSchema = z
   .passthrough();
 
 export type FrenchReportingSubmissionStatus = z.infer<typeof arratechSubmissionStatusSchema>;
+
+/**
+ * The status a reported value stands for, or null when the value is not one this
+ * integration knows. A null is never treated as progress: the caller keeps the status
+ * it already had and makes the unknown value visible.
+ */
+export function toKnownReportingStatus(value: string | null): FrenchReportingStatus | null {
+  return (frenchReportingStatuses as readonly string[]).includes(value ?? "")
+    ? (value as FrenchReportingStatus)
+    : null;
+}
 
 /**
  * Why a submission did not go through, in the terms the API answers with:
@@ -435,12 +461,15 @@ async function submitArratechFlow({
   }
 
   const parsed = arratechSubmissionResponseSchema.parse(await response.json());
+  const answered = parsed.reportingStatus ?? null;
+  const reportingStatus = toKnownReportingStatus(answered);
   return {
     flowId: parsed.flowId,
     // A 200 is the partner's answer to a replayed reference; a 202 is a new event.
     duplicate: parsed.duplicate || response.status === 200,
     status: parsed.status ?? null,
-    reportingStatus: parsed.reportingStatus ?? null,
+    reportingStatus,
+    unknownReportingStatus: reportingStatus ? null : answered,
   };
 }
 

--- a/data/fr-reporting-submissions.ts
+++ b/data/fr-reporting-submissions.ts
@@ -4,14 +4,18 @@ import type { Logger } from "@recommand/lib/logger";
 import { Cron } from "croner";
 import { and, eq, inArray, isNotNull, lte } from "drizzle-orm";
 import {
+  describeFrenchReportEvent,
   FrenchReportingSubmissionError,
   getArratechSubmissionStatus,
+  toKnownReportingStatus,
   type FrenchReportingStatus,
   type FrenchReportingSubmissionStatus,
 } from "@peppol/data/at/fr-reporting";
 import type { FrenchReportingEnvironment } from "@peppol/data/fr-reporting-declarants";
 import { frReportingSubmissions, transmittedDocuments } from "@peppol/db/schema";
 import { isUniqueViolation } from "@peppol/utils/db-errors";
+import { readStoredFrenchReport } from "@peppol/utils/parsing/fr-reporting/duplicates";
+import { createAlertSuppressor } from "@peppol/utils/system-notifications/suppression";
 import { sendSystemAlert } from "@peppol/utils/system-notifications/telegram";
 import { isReportingDocumentTypeKey } from "@peppol/utils/type-repository/document-types/keys";
 
@@ -26,6 +30,8 @@ export const TERMINAL_REPORTING_STATUSES: ReadonlySet<FrenchReportingStatus> = n
 
 /** How long after its period's cutoff an event is still expected to reach a filing. */
 const STALE_AFTER_PERIOD_END_DAYS = 45;
+/** How long to wait before asking again about an event whose status is not understood. */
+const UNKNOWN_STATUS_RETRY_HOURS = 6;
 const HOUR = 60 * 60_000;
 const DAY = 24 * HOUR;
 
@@ -155,6 +161,95 @@ export async function getFrenchReportingSubmissionByDocument(
 }
 
 /**
+ * What a report needs to be followed, apart from what its own document already says.
+ * The event it was filed as is read back from the stored report rather than from the
+ * request at hand, because the two are only the same request when it is a retry.
+ */
+export type FrenchReportingSubmissionRecordInput = {
+  transmittedDocumentId: string;
+  /** The report as it was stored on the document, which is what was filed. */
+  storedReport: unknown;
+  declarantId: string | null;
+  teamId: string;
+  companyId: string;
+  environment: FrenchReportingEnvironment;
+  flowId: string;
+  simulated: boolean;
+  ledgerStatus: string | null;
+  reportingStatus: FrenchReportingStatus | null;
+};
+
+export type FrenchReportingSubmissionRecordOutcome =
+  | "present"
+  | "repaired"
+  | "unrecoverable";
+
+export type FrenchReportingSubmissionRecordDependencies = {
+  findByDocument: (
+    transmittedDocumentId: string,
+  ) => Promise<FrenchReportingSubmission | undefined>;
+  record: typeof recordFrenchReportingSubmission;
+  alert: typeof sendSystemAlert;
+};
+
+const defaultRecordDependencies: FrenchReportingSubmissionRecordDependencies = {
+  findByDocument: getFrenchReportingSubmissionByDocument,
+  record: recordFrenchReportingSubmission,
+  alert: sendSystemAlert,
+};
+
+/**
+ * Makes sure a report that was filed is also followed here. A report is recorded
+ * right after its document, and the two are written separately: when the second write
+ * fails, the report is filed and its document exists, but nothing polls it. The next
+ * retry of the same reference lands on the existing document, and that is where this
+ * repairs the missing record.
+ *
+ * Only what the earlier filing itself says is used. The reference and the event it was
+ * filed as come from the stored report, never from the request that happens to be
+ * retrying, so a reference reused for something else cannot rewrite history. When the
+ * stored report cannot be read, nothing is invented and support is told.
+ */
+export async function ensureFrenchReportingSubmissionRecord(
+  input: FrenchReportingSubmissionRecordInput,
+  dependencies: Partial<FrenchReportingSubmissionRecordDependencies> = {},
+): Promise<FrenchReportingSubmissionRecordOutcome> {
+  const { findByDocument, record, alert } = {
+    ...defaultRecordDependencies,
+    ...dependencies,
+  };
+
+  if (await findByDocument(input.transmittedDocumentId)) {
+    return "present";
+  }
+
+  const filed = readStoredFrenchReport(input.storedReport);
+  if (!filed) {
+    alert(
+      "French Reporting Record Missing",
+      `E-reporting event ${input.flowId} (company ${input.companyId}) has a document but no record to follow it by, and the stored report could not be read back to rebuild one. Its status will not be followed until support restores the record.`,
+      "error",
+    );
+    return "unrecoverable";
+  }
+
+  await record({
+    transmittedDocumentId: input.transmittedDocumentId,
+    declarantId: input.declarantId,
+    teamId: input.teamId,
+    companyId: input.companyId,
+    environment: input.environment,
+    flowId: input.flowId,
+    reference: filed.reference,
+    ...describeFrenchReportEvent(filed),
+    simulated: input.simulated,
+    ledgerStatus: input.ledgerStatus,
+    reportingStatus: input.reportingStatus,
+  });
+  return "repaired";
+}
+
+/**
  * Attaches the reporting status to the documents that are filed reports. Other
  * documents get null, so the field is always present on the API shape.
  */
@@ -191,6 +286,14 @@ function toDate(value: string | null | undefined): Date | null {
 /**
  * Applies what the partner reports about an event. Returns the row patch and
  * whether the reporting status moved, which is what the customer is told about.
+ *
+ * A status this integration does not know is not progress. The event keeps the status
+ * it had, so an unfamiliar value can never quietly retire an event or present it as
+ * filed, and `unknownStatus` carries the value on so it can be looked into. Such an
+ * event is looked at again on a fixed delay instead of on the normal cadence: the
+ * cadence is derived from a status, and the status is exactly what is not understood,
+ * so applying it could stop the event from being followed at all. Everything else the
+ * report says, including the raw ledger value, is still recorded.
  */
 export function applyStatusReport(
   submission: Pick<FrenchReportingSubmission, "reportingStatus" | "simulated">,
@@ -199,13 +302,17 @@ export function applyStatusReport(
 ): {
   patch: Partial<typeof frReportingSubmissions.$inferInsert>;
   changed: boolean;
+  unknownStatus: string | null;
 } {
-  const changed = report.reportingStatus !== submission.reportingStatus;
+  const known = toKnownReportingStatus(report.reportingStatus);
+  const reportingStatus = known ?? submission.reportingStatus;
+  const changed = reportingStatus !== submission.reportingStatus;
   return {
     changed,
+    unknownStatus: known ? null : report.reportingStatus,
     patch: {
       ledgerStatus: report.status,
-      reportingStatus: report.reportingStatus,
+      reportingStatus,
       receivedAt: toDate(report.receivedAt),
       operationDate: report.operationDate,
       periodStart: report.periodStart,
@@ -215,17 +322,46 @@ export function applyStatusReport(
       outcomeAt: toDate(report.outcomeAt),
       lastCheckedAt: now,
       checkAttempts: 0,
-      nextCheckAt: planNextStatusCheck(
-        {
-          reportingStatus: report.reportingStatus,
-          periodEnd: report.periodEnd,
-          simulated: submission.simulated,
-        },
-        now,
-      ),
+      nextCheckAt: known
+        ? planNextStatusCheck(
+            {
+              reportingStatus,
+              periodEnd: report.periodEnd,
+              simulated: submission.simulated,
+            },
+            now,
+          )
+        : submission.simulated
+          ? null
+          : new Date(now.getTime() + UNKNOWN_STATUS_RETRY_HOURS * HOUR),
     },
   };
 }
+
+/**
+ * How the same operational condition is recognised across the events it reaches. One
+ * answer about a filing reaches every event that filing carries, so the filing is what
+ * a message is about. Until a filing exists there is nothing to group by and the event
+ * speaks for itself, which is what keeps unrelated filings apart.
+ */
+export function operationalAlertKey(
+  kind: string,
+  submission: Pick<
+    FrenchReportingSubmission,
+    "id" | "environment" | "companyId" | "submissionId" | "outcomeCode"
+  >,
+): string {
+  const subject = submission.submissionId
+    ? `deposit:${submission.submissionId}:${submission.outcomeCode ?? "no-outcome"}`
+    : `event:${submission.id}`;
+  return `${kind}:${submission.environment}:${submission.companyId}:${subject}`;
+}
+
+/**
+ * Repeated operational alerts are thinned out per process (see the suppressor). It
+ * reduces noise; it does not promise a single message across instances or restarts.
+ */
+const operationalAlerts = createAlertSuppressor({ intervalMs: 6 * HOUR });
 
 async function publishStatusChange(
   submission: FrenchReportingSubmission,
@@ -290,6 +426,17 @@ export async function refreshFrenchReportingSubmission(
     logger.warn(
       `French reporting status check for ${submission.flowId} failed (attempt ${attempts}): ${error instanceof Error ? error.message : String(error)}`,
     );
+    // An answer that cannot be read at all is not a temporary outage: it repeats on
+    // every retry, and an answer this integration cannot read is rarely about one
+    // event. It is reported per environment rather than per event, so a change on the
+    // other side is one message and not one per event that ran into it.
+    if (!unavailable && operationalAlerts.shouldSend(`unreadable:${submission.environment}`, now)) {
+      sendSystemAlert(
+        "French Reporting Status Unreadable",
+        `The status of e-reporting event ${submission.flowId} (company ${submission.companyId}) could not be read: ${error instanceof Error ? error.message : String(error)}. Other events may be running into the same answer. They are all still being polled; their status is not moving until this is understood.`,
+        "warning",
+      );
+    }
     return;
   }
 
@@ -308,7 +455,7 @@ export async function refreshFrenchReportingSubmission(
     return;
   }
 
-  const { patch, changed } = applyStatusReport(submission, report, now);
+  const { patch, changed, unknownStatus } = applyStatusReport(submission, report, now);
   const updated = await db
     .update(frReportingSubmissions)
     .set(patch)
@@ -319,12 +466,31 @@ export async function refreshFrenchReportingSubmission(
     return;
   }
 
-  if (updated.nextCheckAt === null && !TERMINAL_REPORTING_STATUSES.has(updated.reportingStatus)) {
-    sendSystemAlert(
-      "French Reporting Event Stale",
-      `E-reporting event ${updated.flowId} (reference ${updated.reference}, company ${updated.companyId}) is still ${updated.reportingStatus} long after its period ended on ${updated.periodEnd}. Ask Arratech what happened to it.`,
-      "warning",
+  if (unknownStatus) {
+    logger.warn(
+      `French reporting event ${updated.flowId} came back with reporting status "${unknownStatus}", which this integration does not know; it keeps status ${updated.reportingStatus} and stays under review`,
     );
+    // A status this integration does not know is about the vocabulary rather than
+    // about one event, so it is reported per value and not per event that meets it.
+    if (
+      operationalAlerts.shouldSend(`vocabulary:${updated.environment}:${unknownStatus}`, now)
+    ) {
+      sendSystemAlert(
+        "French Reporting Status Not Recognised",
+        `E-reporting event ${updated.flowId} (company ${updated.companyId}) came back with reporting status "${unknownStatus}", which this integration does not know. Events keep the status they had and are still being polled, so nothing is lost, but the status list needs to be checked against the reporting service.`,
+        "warning",
+      );
+    }
+  }
+
+  if (updated.nextCheckAt === null && !TERMINAL_REPORTING_STATUSES.has(updated.reportingStatus)) {
+    if (operationalAlerts.shouldSend(operationalAlertKey("stale", updated), now)) {
+      sendSystemAlert(
+        "French Reporting Event Stale",
+        `E-reporting event ${updated.flowId} (reference ${updated.reference}, company ${updated.companyId}) is still ${updated.reportingStatus} long after its period ended on ${updated.periodEnd}. Ask the reporting service what happened to it.`,
+        "warning",
+      );
+    }
   }
 
   if (!changed) {
@@ -347,10 +513,15 @@ export async function refreshFrenchReportingSubmission(
     );
   }
 
-  if (updated.reportingStatus === "rejected") {
+  // The outcome is the filing's, so every event that filing carries turns rejected at
+  // the same moment. Support hears about the filing rather than about each event.
+  if (
+    updated.reportingStatus === "rejected" &&
+    operationalAlerts.shouldSend(operationalAlertKey("rejected", updated), now)
+  ) {
     sendSystemAlert(
-      "French Reporting Event Rejected",
-      `The tax administration rejected e-reporting event ${updated.flowId} (reference ${updated.reference}, company ${updated.companyId}, period ending ${updated.periodEnd}). Outcome code: ${updated.outcomeCode ?? "unknown"}. The customer needs help correcting it.`,
+      "French Reporting Filing Rejected",
+      `The tax administration rejected the filing carrying e-reporting event ${updated.flowId} (reference ${updated.reference}, company ${updated.companyId}, period ending ${updated.periodEnd}${updated.submissionId ? `, filing ${updated.submissionId}` : ""}). Outcome code: ${updated.outcomeCode ?? "unknown"}. Every event on the same filing carries this outcome, so check what the customer has to correct for that period.`,
       "error",
     );
   }

--- a/data/transmitted-documents.ts
+++ b/data/transmitted-documents.ts
@@ -553,14 +553,15 @@ export async function getAllTransmittedDocumentsInRange(
 
 /**
  * The document a filing was recorded as, by the reference the filing service gave
- * it. Used to answer a retried report with the document filed the first time.
+ * it. Used to answer a retried report with the document filed the first time, and to
+ * compare that report with the one being submitted now.
  */
 export async function findOutgoingDocumentByExternalReference(
   companyId: string,
   externalReferenceId: string,
-): Promise<{ id: string } | undefined> {
+): Promise<{ id: string; parsed: unknown } | undefined> {
   return await db
-    .select({ id: transmittedDocuments.id })
+    .select({ id: transmittedDocuments.id, parsed: transmittedDocuments.parsed })
     .from(transmittedDocuments)
     .where(
       and(

--- a/templates/france-b2bi-report.ts
+++ b/templates/france-b2bi-report.ts
@@ -47,6 +47,12 @@ export const FRANCE_B2BI_REPORT_TEMPLATE = `<!DOCTYPE html>
                 <dt class="text-xs text-slate-500">Issue date</dt>
                 <dd class="text-slate-700">{{issueDate}}</dd>
               </div>
+              {{#billingMode}}
+                <div>
+                  <dt class="text-xs text-slate-500">Invoicing framework</dt>
+                  <dd class="text-slate-700">{{billingMode}}</dd>
+                </div>
+              {{/billingMode}}
               {{#dueDate}}
                 <div>
                   <dt class="text-xs text-slate-500">Due date</dt>

--- a/test/b2bi-reporting.test.ts
+++ b/test/b2bi-reporting.test.ts
@@ -6,7 +6,9 @@ import {
 } from "../data/at/fr-reporting";
 import {
   frenchB2BiReportSchema,
+  frenchReportingBillingModes,
   getFrenchB2BiReportDocumentProfile,
+  storedFrenchB2BiReportSchema,
 } from "../utils/parsing/b2bi-reporting/france";
 import { getDocumentFilename } from "../utils/document-filename";
 
@@ -29,6 +31,7 @@ describe("French cross-border reporting", () => {
       reference: "acme-inv-2026-000431",
       type: "invoice",
       documentNumber: "INV-2026-000431",
+      billingMode: "B1",
       issueDate: "2026-01-15",
       dueDate: "2026-02-14",
       buyer: {
@@ -65,7 +68,8 @@ describe("French cross-border reporting", () => {
           typeCode: "380",
           currencyCode: "EUR",
           dueDate: "2026-02-14",
-          cadre: "S1",
+          // The framework the report names, not a fixed one.
+          cadre: "B1",
           seller,
           buyer: {
             companyId: "IT00987654321",
@@ -88,6 +92,82 @@ describe("French cross-border reporting", () => {
         },
       },
     });
+  });
+
+  it("files every accepted invoicing framework as the cadre of the event", () => {
+    for (const billingMode of frenchReportingBillingModes) {
+      const report = frenchB2BiReportSchema.parse({
+        reference: `acme-inv-${billingMode}`,
+        type: "invoice",
+        documentNumber: `INV-${billingMode}`,
+        billingMode,
+        issueDate: "2026-01-15",
+        buyer: { name: "Rossi", country: "IT", vatNumber: "IT00987654321" },
+        taxExclusiveAmount: "100.00",
+        taxAmount: "0.00",
+        vatBreakdown: [
+          { percentage: "0.00", taxableAmount: "100.00", taxAmount: "0.00", category: "K" },
+        ],
+      });
+
+      const payload = toArratechB2BiFlow(report, declarant, seller).event.payload as {
+        cadre: string;
+      };
+      expect(payload.cadre).toBe(billingMode);
+    }
+  });
+
+  it("refuses an invoice report without an invoicing framework, and unsupported ones", () => {
+    const base = {
+      reference: "acme-inv-2026-000450",
+      type: "invoice",
+      documentNumber: "INV-2026-000450",
+      issueDate: "2026-01-15",
+      buyer: { name: "Rossi", country: "IT", vatNumber: "IT00987654321" },
+      taxExclusiveAmount: "100.00",
+      taxAmount: "0.00",
+      vatBreakdown: [
+        { percentage: "0.00", taxableAmount: "100.00", taxAmount: "0.00", category: "K" },
+      ],
+    };
+
+    // The framework decides how the tax administration reads the invoice, so a report
+    // that does not name one is refused rather than filed under an assumed default.
+    const missing = frenchB2BiReportSchema.safeParse(base);
+    expect(missing.success).toBe(false);
+    expect(missing.success ? [] : missing.error.issues.map((issue) => issue.path.join("."))).toContain(
+      "billingMode",
+    );
+
+    // Codes an invoice can carry that are not confirmed for a report are refused here
+    // rather than sent on.
+    for (const billingMode of ["S3", "S5", "S6", "B7", "S7", "B8", "M8", "B9", "X1", "b1", ""]) {
+      expect(frenchB2BiReportSchema.safeParse({ ...base, billingMode }).success).toBe(false);
+    }
+  });
+
+  it("reads back a report that was filed before the framework was part of a report", () => {
+    // Reports already on file carry no framework. They stay readable, and the reading
+    // does not invent one for them.
+    const stored = {
+      reference: "acme-inv-2026-000200",
+      action: "submit",
+      type: "invoice",
+      documentNumber: "INV-2026-000200",
+      documentType: "invoice",
+      issueDate: "2026-01-15",
+      currency: "EUR",
+      buyer: { name: "Rossi", country: "IT", vatNumber: "IT00987654321" },
+      taxExclusiveAmount: "100.00",
+      taxAmount: "0.00",
+      vatBreakdown: [
+        { percentage: "0.00", taxableAmount: "100.00", taxAmount: "0.00", category: "K" },
+      ],
+    };
+
+    expect(frenchB2BiReportSchema.safeParse(stored).success).toBe(false);
+    const legacy = storedFrenchB2BiReportSchema.parse(stored);
+    expect(legacy.type === "invoice" && legacy.billingMode).toBeUndefined();
   });
 
   it("identifies buyers the way the tax administration does, not by ICD scheme", () => {
@@ -144,6 +224,7 @@ describe("French cross-border reporting", () => {
       reference: "acme-inv-2026-000440",
       type: "invoice",
       documentNumber: "INV-2026-000440",
+      billingMode: "S1",
       issueDate: "2026-01-15",
       taxExclusiveAmount: "100.00",
       taxAmount: "0.00",
@@ -183,6 +264,7 @@ describe("French cross-border reporting", () => {
       type: "invoice",
       documentNumber: "CN-2026-000012",
       documentType: "creditNote",
+      billingMode: "S1",
       issueDate: "2026-01-20",
       currency: "USD",
       buyer: {

--- a/test/fr-reporting-duplicates.test.ts
+++ b/test/fr-reporting-duplicates.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import {
+  assessFrenchReportDuplicate,
+  readStoredFrenchReport,
+} from "../utils/parsing/fr-reporting/duplicates";
+import { frenchB2BiReportSchema } from "../utils/parsing/b2bi-reporting/france";
+import { frenchB2CReportSchema } from "../utils/parsing/b2c-reporting/france";
+
+const invoiceRequest = {
+  reference: "acme-inv-2026-000431",
+  type: "invoice",
+  documentNumber: "INV-2026-000431",
+  billingMode: "B1",
+  issueDate: "2026-01-15",
+  buyer: { name: "Rossi Forniture S.r.l.", country: "IT", vatNumber: "IT00987654321" },
+  taxExclusiveAmount: "10000.00",
+  taxAmount: "0.00",
+  vatBreakdown: [
+    { percentage: "0.00", taxableAmount: "10000.00", taxAmount: "0.00", category: "K" },
+  ],
+};
+
+const salesRequest = {
+  reference: "SALES-2026-07-01-GOODS",
+  type: "sales",
+  date: "2026-07-01",
+  category: "goods",
+  taxExclusiveAmount: "10000.00",
+  taxAmount: "2000.00",
+  transactionCount: 42,
+  vatBreakdown: [{ percentage: "20.00", taxableAmount: "10000.00", taxAmount: "2000.00" }],
+};
+
+const parseB2Bi = (report: unknown) => frenchB2BiReportSchema.parse(report);
+const parseB2C = (report: unknown) => frenchB2CReportSchema.parse(report);
+
+describe("Reports submitted under a reference that was already used", () => {
+  it("recognises a retry of the very same request", () => {
+    const filed = parseB2Bi(invoiceRequest);
+
+    expect(assessFrenchReportDuplicate({ stored: filed, submitted: filed })).toEqual({
+      kind: "retry",
+      warning: null,
+    });
+  });
+
+  it("recognises a retry written in a different but equivalent way", () => {
+    // The stored report carries the defaults and the normalised amounts it was stored
+    // with. A retry that leaves those out, spells amounts differently, or orders its
+    // fields differently is the same request.
+    const filed = parseB2Bi(invoiceRequest);
+    const retry = parseB2Bi({
+      vatBreakdown: [{ category: "K", taxAmount: 0, percentage: 0, taxableAmount: 10000 }],
+      taxAmount: "0.00",
+      taxExclusiveAmount: "10000.00",
+      buyer: {
+        vatNumber: "IT00987654321",
+        country: "it",
+        name: "Rossi Forniture S.r.l.",
+        enterpriseNumber: null,
+      },
+      issueDate: "2026-01-15",
+      billingMode: "B1",
+      documentNumber: "INV-2026-000431",
+      documentType: "invoice",
+      currency: "EUR",
+      action: "submit",
+      type: "invoice",
+      reference: "acme-inv-2026-000431",
+    });
+
+    expect(assessFrenchReportDuplicate({ stored: filed, submitted: retry }).kind).toBe("retry");
+  });
+
+  it("ignores stored fields that are not part of a report on either side", () => {
+    // Both sides are read through the same schema, so anything outside it cannot make
+    // two equal reports look different.
+    const stored = { ...parseB2Bi(invoiceRequest), storedAt: "2026-01-15T10:00:00Z" };
+
+    expect(
+      assessFrenchReportDuplicate({ stored, submitted: parseB2Bi(invoiceRequest) }).kind,
+    ).toBe("retry");
+  });
+
+  it("never presents a correction or cancellation as filed when the reference was a submission", () => {
+    const filed = parseB2Bi(invoiceRequest);
+
+    const cancellation = assessFrenchReportDuplicate({
+      stored: filed,
+      submitted: parseB2Bi({ ...invoiceRequest, action: "cancel" }),
+    });
+    expect(cancellation.kind).toBe("different_action");
+    expect(cancellation.warning).toContain("Nothing was filed for this request");
+    expect(cancellation.warning).toContain("cancellation");
+    expect(cancellation.warning).toContain("new reference");
+    // The earlier report was submitted; it must not be described as cancelled.
+    expect(cancellation.warning).not.toContain("was cancelled");
+
+    const correction = assessFrenchReportDuplicate({
+      stored: filed,
+      submitted: parseB2Bi({ ...invoiceRequest, action: "correct" }),
+    });
+    expect(correction.kind).toBe("different_action");
+    expect(correction.warning).toContain("correction");
+  });
+
+  it("describes the request that was made, not the one on file", () => {
+    // A plain submission under a reference that carried a correction is a report, not
+    // a correction of its own.
+    const assessment = assessFrenchReportDuplicate({
+      stored: parseB2Bi({ ...invoiceRequest, action: "correct" }),
+      submitted: parseB2Bi(invoiceRequest),
+    });
+
+    expect(assessment.kind).toBe("different_action");
+    expect(assessment.warning).toContain("corrected");
+    expect(assessment.warning).toContain("Send this report again under a new reference");
+  });
+
+  it("reports a reference reused for different figures", () => {
+    const assessment = assessFrenchReportDuplicate({
+      stored: parseB2C(salesRequest),
+      submitted: parseB2C({ ...salesRequest, taxAmount: "2500.00" }),
+    });
+
+    expect(assessment.kind).toBe("different_content");
+    expect(assessment.warning).toContain("different contents");
+  });
+
+  it("says the framework could not be compared with a report filed without one", () => {
+    // What the framework would have been cannot be derived from a report that was
+    // filed before it was asked for, so the retry is not confirmed as identical and
+    // the framework is not assumed to match.
+    const { billingMode: _billingMode, ...legacy } = invoiceRequest;
+
+    const assessment = assessFrenchReportDuplicate({
+      stored: { ...legacy, action: "submit", documentType: "invoice", currency: "EUR" },
+      submitted: parseB2Bi(invoiceRequest),
+    });
+
+    expect(assessment.kind).toBe("unverified_billing_mode");
+    expect(assessment.warning).toContain("without an invoicing framework");
+    expect(assessment.warning).toContain("could not be compared");
+  });
+
+  it("still reports different figures on a report filed without a framework", () => {
+    const { billingMode: _billingMode, ...legacy } = invoiceRequest;
+
+    const assessment = assessFrenchReportDuplicate({
+      stored: { ...legacy, action: "submit", documentType: "invoice", currency: "EUR" },
+      submitted: parseB2Bi({ ...invoiceRequest, taxExclusiveAmount: "12000.00" }),
+    });
+
+    expect(assessment.kind).toBe("different_content");
+  });
+
+  it("claims nothing when the earlier report cannot be read", () => {
+    for (const stored of [null, undefined, {}, { type: "invoice" }, "not a report"]) {
+      const assessment = assessFrenchReportDuplicate({
+        stored,
+        submitted: parseB2Bi(invoiceRequest),
+      });
+      expect(assessment.kind).toBe("unknown_original");
+      expect(assessment.warning).toContain("could not be read back");
+    }
+  });
+
+  it("reads a stored report back as it was stored", () => {
+    const { billingMode: _billingMode, ...legacy } = invoiceRequest;
+
+    const stored = readStoredFrenchReport({
+      ...legacy,
+      action: "submit",
+      documentType: "invoice",
+      currency: "EUR",
+    });
+    expect(stored?.type).toBe("invoice");
+    expect(stored && stored.type === "invoice" ? stored.billingMode : "set").toBeUndefined();
+
+    expect(readStoredFrenchReport(parseB2C(salesRequest))?.type).toBe("sales");
+    expect(readStoredFrenchReport({ type: "invoice" })).toBeNull();
+  });
+});

--- a/test/fr-reporting-record-repair.test.ts
+++ b/test/fr-reporting-record-repair.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, mock } from "bun:test";
+
+// The repair is exercised against its own gateway; no database and no messages.
+mock.module("@recommand/db", () => ({ db: {} }));
+mock.module("@core/data/rules/events", () => ({ publishEvent: async () => {} }));
+
+const { ensureFrenchReportingSubmissionRecord, recordFrenchReportingSubmission } = await import(
+  "../data/fr-reporting-submissions"
+);
+const { frenchB2BiReportSchema } = await import("../utils/parsing/b2bi-reporting/france");
+const { frenchB2CReportSchema } = await import("../utils/parsing/b2c-reporting/france");
+
+type RecordedSubmission = Parameters<typeof recordFrenchReportingSubmission>[0];
+
+/**
+ * A stand-in for the two writes a filed report needs: the document, which succeeded,
+ * and the record that follows it, which is the one that can fail.
+ */
+function gateway({ failFirstWrite = false }: { failFirstWrite?: boolean } = {}) {
+  const rows: RecordedSubmission[] = [];
+  const alerts: { title: string; message: string }[] = [];
+  let writes = 0;
+
+  return {
+    rows,
+    alerts,
+    deps: {
+      findByDocument: async (transmittedDocumentId: string) =>
+        rows.find((row) => row.transmittedDocumentId === transmittedDocumentId) as never,
+      record: async (values: RecordedSubmission) => {
+        writes += 1;
+        if (failFirstWrite && writes === 1) {
+          throw new Error("connection reset while recording the submission");
+        }
+        rows.push(values);
+      },
+      alert: async (title: string, message: string) => {
+        alerts.push({ title, message });
+      },
+    },
+  };
+}
+
+const filedCorrection = frenchB2BiReportSchema.parse({
+  reference: "acme-inv-2026-000431-c1",
+  action: "correct",
+  type: "invoice",
+  documentNumber: "INV-2026-000431",
+  billingMode: "B1",
+  issueDate: "2026-01-15",
+  buyer: { name: "Rossi Forniture S.r.l.", country: "IT", vatNumber: "IT00987654321" },
+  taxExclusiveAmount: "10000.00",
+  taxAmount: "0.00",
+  vatBreakdown: [
+    { percentage: "0.00", taxableAmount: "10000.00", taxAmount: "0.00", category: "K" },
+  ],
+});
+
+const repairInput = {
+  transmittedDocumentId: "doc_1",
+  storedReport: filedCorrection,
+  declarantId: "frd_1",
+  teamId: "team_1",
+  companyId: "comp_1",
+  environment: "PROD" as const,
+  flowId: "flow-1",
+  simulated: false,
+  ledgerStatus: "ACCEPTED",
+  reportingStatus: "accepted" as const,
+};
+
+describe("A report that was filed without the record that follows it", () => {
+  it("is repaired by the retry that lands on the existing document", async () => {
+    const { rows, alerts, deps } = gateway({ failFirstWrite: true });
+
+    // The report is filed and its document is written; the record that follows it is
+    // not, because the write failed.
+    await expect(
+      deps.record({ ...repairInput, reference: "x", subFlux: "10.1" } as never),
+    ).rejects.toThrow("connection reset");
+    expect(rows).toHaveLength(0);
+
+    // The customer retries under the same reference, which resolves to the same event
+    // and lands on the document that already exists.
+    const outcome = await ensureFrenchReportingSubmissionRecord(repairInput, deps);
+
+    expect(outcome).toBe("repaired");
+    expect(rows).toHaveLength(1);
+    expect(alerts).toHaveLength(0);
+    expect(rows[0]).toMatchObject({
+      transmittedDocumentId: "doc_1",
+      flowId: "flow-1",
+      // Read back from what was filed, so the record describes the earlier report.
+      reference: "acme-inv-2026-000431-c1",
+      subFlux: "10.1",
+      operation: "SUBMIT",
+      transmissionType: "RE",
+      ledgerStatus: "ACCEPTED",
+      reportingStatus: "accepted",
+    });
+  });
+
+  it("describes the report on file, not the request that happens to be retrying", async () => {
+    const { rows, deps } = gateway();
+
+    // A reference reused for something else must not rewrite what was filed under it.
+    await ensureFrenchReportingSubmissionRecord(
+      {
+        ...repairInput,
+        storedReport: frenchB2CReportSchema.parse({
+          reference: "SALES-2026-07-01-GOODS",
+          type: "sales",
+          date: "2026-07-01",
+          category: "goods",
+          taxExclusiveAmount: "100.00",
+          taxAmount: "20.00",
+          transactionCount: 1,
+          vatBreakdown: [
+            { percentage: "20.00", taxableAmount: "100.00", taxAmount: "20.00" },
+          ],
+        }),
+      },
+      deps,
+    );
+
+    expect(rows[0]).toMatchObject({
+      reference: "SALES-2026-07-01-GOODS",
+      subFlux: "10.3",
+      operation: "SUBMIT",
+      transmissionType: "IN",
+    });
+  });
+
+  it("reads a report filed before the invoicing framework and does not invent one", async () => {
+    const { rows, alerts, deps } = gateway();
+    const { billingMode: _billingMode, ...legacy } = filedCorrection as Record<string, unknown>;
+
+    const outcome = await ensureFrenchReportingSubmissionRecord(
+      { ...repairInput, storedReport: legacy },
+      deps,
+    );
+
+    expect(outcome).toBe("repaired");
+    expect(alerts).toHaveLength(0);
+    expect(rows[0]).toMatchObject({ reference: "acme-inv-2026-000431-c1", subFlux: "10.1" });
+    expect(rows[0]).not.toHaveProperty("billingMode");
+  });
+
+  it("leaves an existing record alone, so a genuine retry writes nothing twice", async () => {
+    const { rows, deps } = gateway();
+
+    expect(await ensureFrenchReportingSubmissionRecord(repairInput, deps)).toBe("repaired");
+    expect(await ensureFrenchReportingSubmissionRecord(repairInput, deps)).toBe("present");
+    expect(await ensureFrenchReportingSubmissionRecord(repairInput, deps)).toBe("present");
+    expect(rows).toHaveLength(1);
+  });
+
+  it("tells support when the report on file cannot be read, and invents nothing", async () => {
+    const { rows, alerts, deps } = gateway();
+
+    const outcome = await ensureFrenchReportingSubmissionRecord(
+      { ...repairInput, storedReport: null },
+      deps,
+    );
+
+    expect(outcome).toBe("unrecoverable");
+    expect(rows).toHaveLength(0);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]!.title).toBe("French Reporting Record Missing");
+    expect(alerts[0]!.message).toContain("flow-1");
+  });
+});

--- a/test/fr-reporting-submissions.test.ts
+++ b/test/fr-reporting-submissions.test.ts
@@ -4,9 +4,13 @@ import { describe, expect, it, mock } from "bun:test";
 mock.module("@recommand/db", () => ({ db: {} }));
 mock.module("@core/data/rules/events", () => ({ publishEvent: async () => {} }));
 
-const { applyStatusReport, planNextStatusCheck, TERMINAL_REPORTING_STATUSES } = await import(
-  "../data/fr-reporting-submissions"
-);
+const {
+  applyStatusReport,
+  operationalAlertKey,
+  planNextStatusCheck,
+  TERMINAL_REPORTING_STATUSES,
+} = await import("../data/fr-reporting-submissions");
+const { createAlertSuppressor } = await import("../utils/system-notifications/suppression");
 
 const HOUR = 60 * 60_000;
 const DAY = 24 * HOUR;
@@ -104,5 +108,125 @@ describe("French reporting status polling", () => {
       now,
     );
     expect(unchanged.changed).toBe(false);
+    expect(unchanged.unknownStatus).toBeNull();
+  });
+
+  it("keeps the status it knows when the service answers one it does not", () => {
+    const now = new Date("2026-10-03T10:00:00Z");
+    const report = {
+      flowId: "flow-1",
+      declarantSiren: "303265045",
+      clientOperationRef: "SALES-2026-09-01-GOODS",
+      subFlux: "10.3",
+      operation: "SUBMIT",
+      transmissionType: "IN",
+      status: "AWAITING_SOMETHING_NEW",
+      reportingStatus: "under_review_by_the_administration",
+      receivedAt: "2026-09-01T18:00:00Z",
+      operationDate: "2026-09-01",
+      periodStart: "2026-09-01",
+      // Long enough ago that the ordinary cadence would give up on the event.
+      periodEnd: "2026-09-30",
+      submissionId: "sub-9",
+      outcomeCode: "300",
+      outcomeAt: null,
+    };
+
+    const { patch, changed, unknownStatus } = applyStatusReport(
+      { reportingStatus: "accepted", simulated: false },
+      { ...report, periodEnd: "2026-06-30" },
+      now,
+    );
+
+    // The event is not moved to a status this integration cannot reason about, and the
+    // value is handed back so it can be reported rather than lost.
+    expect(unknownStatus).toBe("under_review_by_the_administration");
+    expect(changed).toBe(false);
+    expect(patch.reportingStatus).toBe("accepted");
+    // The raw ledger value is still kept as evidence of what was answered.
+    expect(patch.ledgerStatus).toBe("AWAITING_SOMETHING_NEW");
+    expect(patch.outcomeCode).toBe("300");
+    // Polling continues on a fixed delay instead of the cadence of a status that is
+    // not understood, which here would have stopped asking altogether.
+    expect(patch.nextCheckAt).toEqual(new Date("2026-10-03T16:00:00Z"));
+
+    // And it recovers on its own once a value it knows comes back.
+    const recovered = applyStatusReport(
+      { reportingStatus: "accepted", simulated: false },
+      { ...report, reportingStatus: "filed", status: "TRANSMITTED" },
+      now,
+    );
+    expect(recovered.unknownStatus).toBeNull();
+    expect(recovered.changed).toBe(true);
+    expect(recovered.patch.reportingStatus).toBe("filed");
+    expect(recovered.patch.nextCheckAt).toBeNull();
+  });
+});
+
+describe("Operational alerts about one filing", () => {
+  const submission = {
+    id: "frs_1",
+    environment: "PROD" as const,
+    companyId: "comp_1",
+    submissionId: "sub-9",
+    outcomeCode: "501",
+  };
+
+  it("recognises events of the same filing and outcome as one condition", () => {
+    const sibling = { ...submission, id: "frs_2" };
+
+    expect(operationalAlertKey("rejected", submission)).toBe(
+      operationalAlertKey("rejected", sibling),
+    );
+    // A later outcome on the same filing is something else to hear about.
+    expect(operationalAlertKey("rejected", { ...sibling, outcomeCode: "500" })).not.toBe(
+      operationalAlertKey("rejected", submission),
+    );
+    // As is the same filing in the other environment, or another company's filing.
+    expect(operationalAlertKey("rejected", { ...sibling, environment: "TEST" })).not.toBe(
+      operationalAlertKey("rejected", submission),
+    );
+    expect(operationalAlertKey("rejected", { ...sibling, companyId: "comp_2" })).not.toBe(
+      operationalAlertKey("rejected", submission),
+    );
+    // And a different condition on the same filing is not folded in either.
+    expect(operationalAlertKey("stale", submission)).not.toBe(
+      operationalAlertKey("rejected", submission),
+    );
+  });
+
+  it("keeps events apart while there is no filing to group them by", () => {
+    const first = { ...submission, submissionId: null };
+    const second = { ...first, id: "frs_2" };
+
+    expect(operationalAlertKey("stale", first)).not.toBe(operationalAlertKey("stale", second));
+  });
+
+  it("reports a condition once per interval and lets it through again afterwards", () => {
+    const suppressor = createAlertSuppressor({ intervalMs: 6 * HOUR });
+    const start = new Date("2026-10-03T10:00:00Z");
+    const key = operationalAlertKey("rejected", submission);
+
+    expect(suppressor.shouldSend(key, start)).toBe(true);
+    expect(suppressor.shouldSend(key, start)).toBe(false);
+    expect(suppressor.shouldSend(key, new Date(start.getTime() + 5 * HOUR))).toBe(false);
+    // Another condition is never suppressed by an unrelated one.
+    expect(suppressor.shouldSend(operationalAlertKey("stale", submission), start)).toBe(true);
+    // The condition can be reported again once the interval has passed, so a lasting
+    // problem does not fall silent for good.
+    expect(suppressor.shouldSend(key, new Date(start.getTime() + 7 * HOUR))).toBe(true);
+  });
+
+  it("does not grow without bound when many conditions are reported", () => {
+    const suppressor = createAlertSuppressor({ intervalMs: 6 * HOUR, maxEntries: 3 });
+    const start = new Date("2026-10-03T10:00:00Z");
+
+    for (let index = 0; index < 50; index += 1) {
+      expect(suppressor.shouldSend(`key-${index}`, start)).toBe(true);
+    }
+    // The oldest keys were dropped to stay within the bound, so they are reported
+    // again rather than suppressed for ever.
+    expect(suppressor.shouldSend("key-0", start)).toBe(true);
+    expect(suppressor.shouldSend("key-49", start)).toBe(false);
   });
 });

--- a/test/france-b2bi-report-render.test.ts
+++ b/test/france-b2bi-report-render.test.ts
@@ -8,12 +8,16 @@ import type { FrenchB2BiReport } from "../utils/parsing/b2bi-reporting/france";
 import { getDocumentType } from "../utils/type-repository/document-types";
 import { FRANCE_B2BI_REPORT_TEMPLATE } from "../templates/france-b2bi-report";
 import {
-  frenchB2BiReportSchema,
   getFrenchB2BiReportDocumentProfile,
+  storedFrenchB2BiReportSchema,
 } from "../utils/parsing/b2bi-reporting/france";
 
+/**
+ * Documents are read back through the stored shape, which is what rows on file carry:
+ * reports filed before the invoicing framework existed have none.
+ */
 function documentFor(report: unknown): PublicTransmittedDocument {
-  const parsed = frenchB2BiReportSchema.parse(report);
+  const parsed = storedFrenchB2BiReportSchema.parse(report);
   return {
     id: "doc_report",
     type: getFrenchB2BiReportDocumentProfile(parsed.type).type,
@@ -34,6 +38,7 @@ const invoiceDocument = documentFor({
   reference: "acme-inv-2026-000431",
   type: "invoice",
   documentNumber: "INV-2026-000431",
+  billingMode: "B1",
   issueDate: "2026-01-15",
   dueDate: "2026-02-14",
   buyer: {
@@ -98,6 +103,7 @@ describe("French cross-border report rendering", () => {
       buyerVatNumber: "IT00987654321",
       buyerCountry: "IT",
       currency: "EUR",
+      billingMode: "B1",
     });
     expect(data.invoiceVatBreakdown).toEqual([
       {
@@ -161,6 +167,27 @@ describe("French cross-border report rendering", () => {
       }
     }
     expect(opened).toEqual([]);
+  });
+
+  it("lays out a report filed before the invoicing framework without inventing one", () => {
+    const legacyDocument = documentFor({
+      reference: "acme-inv-2026-000200",
+      type: "invoice",
+      documentNumber: "INV-2026-000200",
+      issueDate: "2026-01-15",
+      buyer: { name: "Rossi Forniture S.r.l.", country: "IT", vatNumber: "IT00987654321" },
+      taxExclusiveAmount: "10000.00",
+      taxAmount: "0.00",
+      vatBreakdown: [
+        { percentage: "0.00", taxableAmount: "10000.00", taxAmount: "0.00", category: "K" },
+      ],
+    });
+
+    const data = templateDataFor(legacyDocument);
+    expect(data.documentNumber).toBe("INV-2026-000200");
+    expect(data.billingMode).toBeUndefined();
+    // The layout drops the row rather than showing an empty framework.
+    expect(FRANCE_B2BI_REPORT_TEMPLATE).toContain("{{#billingMode}}");
   });
 
   it("names no counterparty for a report, only the filing authority", () => {

--- a/utils/document-renderer.ts
+++ b/utils/document-renderer.ts
@@ -11,7 +11,7 @@ import type {
   FranceCdarStatusCode,
 } from "@peppol/utils/parsing/france-cdar/schemas";
 import type { MessageLevelResponse } from "@peppol/utils/parsing/message-level-response/schemas";
-import type { FrenchB2BiReport } from "@peppol/utils/parsing/b2bi-reporting/france";
+import type { StoredFrenchB2BiReport } from "@peppol/utils/parsing/b2bi-reporting/france";
 import type { FrenchB2CReport } from "@peppol/utils/parsing/b2c-reporting/france";
 import type { StoredDocumentType } from "@peppol/utils/type-repository/document-types/types";
 import { FRANCE_B2BI_REPORT_TEMPLATE } from "@peppol/templates/france-b2bi-report";
@@ -214,6 +214,8 @@ type FranceB2BiReportTemplateData = {
   currency: string;
   documentKindLabel?: string;
   documentNumber?: string;
+  /** Left out for reports filed before the invoicing framework was part of a report. */
+  billingMode?: string;
   invoiceNumber?: string;
   issueDate: string;
   dueDate?: string;
@@ -609,7 +611,7 @@ export function buildFranceB2CReportTemplateData(
 }
 
 export function buildFranceB2BiReportTemplateData(
-  parsed: FrenchB2BiReport,
+  parsed: StoredFrenchB2BiReport,
   context: DocumentRenderContext,
 ): FranceB2BiReportTemplateData {
   const isInvoice = parsed.type === "invoice";
@@ -639,6 +641,7 @@ export function buildFranceB2BiReportTemplateData(
         : "Invoice"
       : undefined,
     documentNumber: isInvoice ? parsed.documentNumber : undefined,
+    billingMode: (isInvoice && parsed.billingMode) || undefined,
     invoiceNumber: isInvoice ? undefined : parsed.invoiceNumber,
     dueDate: (isInvoice && parsed.dueDate) || undefined,
     buyerName: isInvoice ? parsed.buyer.name : undefined,
@@ -742,7 +745,7 @@ export async function renderFranceB2CReport<F extends "html" | "pdf">(
 }
 
 export async function renderFranceB2BiReport<F extends "html" | "pdf">(
-  parsed: FrenchB2BiReport,
+  parsed: StoredFrenchB2BiReport,
   options: { format: F; pdfa?: boolean },
   context: DocumentRenderContext,
 ): Promise<F extends "pdf" ? Buffer : string> {

--- a/utils/parsing/b2bi-reporting/france.ts
+++ b/utils/parsing/b2bi-reporting/france.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import "zod-openapi/extend";
 import { zCurrencies } from "@peppol/utils/currencies";
 import { zodValidIsoIcdSchemeIdentifiers } from "@peppol/utils/iso-icd-scheme-identifiers";
+import type { FrenchBillingMode } from "@peppol/utils/parsing/country-specific/france";
 import { vatCategoryEnum } from "@peppol/utils/parsing/invoice/schemas";
 import {
   f10ActionSchema,
@@ -18,6 +19,56 @@ const frenchB2BiReportBaseShape = {
   }),
   action: f10ActionSchema,
 };
+
+/**
+ * The invoicing framework the reported document belongs to, in the same codes and
+ * with the same meaning as the `billingMode` of a French regulated invoice. The code
+ * has to match what was actually invoiced: it is checked against the invoice when the
+ * reporting period is assembled, not when the report is submitted.
+ *
+ * These are the frameworks confirmed for cross-border reporting. Other `billingMode`
+ * codes an invoice can carry are not supported on a report by this integration.
+ */
+export const frenchReportingBillingModes = [
+  "B1",
+  "S1",
+  "M1",
+  "B2",
+  "S2",
+  "M2",
+  "B4",
+  "S4",
+  "M4",
+] as const;
+
+// Every reporting framework is one of the invoice frameworks; the compiler holds the
+// two lists together if either one changes.
+type ReportingBillingModesAreInvoiceBillingModes =
+  (typeof frenchReportingBillingModes)[number] extends FrenchBillingMode ? true : never;
+const _reportingBillingModesAreInvoiceBillingModes: ReportingBillingModesAreInvoiceBillingModes = true;
+
+export const frenchReportingBillingModeSchema = z
+  .enum(frenchReportingBillingModes)
+  .openapi({
+    example: "B1",
+    description: `The invoicing framework the reported document belongs to, in the same codes as the \`billingMode\` of a French regulated invoice. Use the code that matches the invoice.
+
+| Mode | Description |
+| --- | --- |
+| \`B1\` | Goods invoice. |
+| \`S1\` | Services invoice. |
+| \`M1\` | Mixed invoice containing goods and services that are not ancillary to each other. |
+| \`B2\` | Goods invoice that has already been paid. |
+| \`S2\` | Services invoice that has already been paid. |
+| \`M2\` | Mixed invoice that has already been paid. |
+| \`B4\` | Final goods invoice after an advance payment. |
+| \`S4\` | Final services invoice after an advance payment. |
+| \`M4\` | Final mixed invoice after an advance payment. |
+
+This code is checked against the invoice when the reporting period is assembled, which is after the report is accepted. A framework that does not match the invoice can cause the filing for that period to be rejected, so set it from the invoice rather than from a default.`,
+  });
+
+export type FrenchReportingBillingMode = z.infer<typeof frenchReportingBillingModeSchema>;
 
 /**
  * The tax administration identifies a foreign buyer by where it is established: EU
@@ -140,10 +191,9 @@ const frenchB2BiPaymentVatSchema = z
     description: "Received payment total for one VAT rate.",
   });
 
-export const frenchB2BiInvoiceReportSchema = z
-  .object({
-    ...frenchB2BiReportBaseShape,
-    type: z.literal("invoice").openapi({
+const frenchB2BiInvoiceReportShape = {
+  ...frenchB2BiReportBaseShape,
+  type: z.literal("invoice").openapi({
       description:
         "Choose `invoice` to report a single cross-border invoice or credit note issued to a business.",
     }),
@@ -152,6 +202,7 @@ export const frenchB2BiInvoiceReportSchema = z
       description:
         "The number of the invoice or credit note being reported. A payment report refers back to it, and a correction or cancellation is matched on it.",
     }),
+    billingMode: frenchReportingBillingModeSchema,
     documentType: z
       .enum(["invoice", "creditNote"])
       .default("invoice")
@@ -186,12 +237,33 @@ export const frenchB2BiInvoiceReportSchema = z
       description:
         "Breakdown of the document total by VAT rate. Include one entry for every VAT rate used.",
     }),
-  })
+} as const;
+
+const frenchB2BiInvoiceReportDescription =
+  "Reports one invoice or credit note issued to a business established outside France. These operations are not exchanged over the French e-invoicing network, so they are reported to the French tax administration instead. The reporting company must carry its own French VAT number as well as its SIREN; cross-border reports identify the seller by both.";
+
+export const frenchB2BiInvoiceReportSchema = z
+  .object(frenchB2BiInvoiceReportShape)
   .openapi({
     ref: "FrenchB2BiInvoiceReport",
     title: "French cross-border invoice report",
-    description:
-      "Reports one invoice or credit note issued to a business established outside France. These operations are not exchanged over the French e-invoicing network, so they are reported to the French tax administration instead. The reporting company must carry its own French VAT number as well as its SIREN; cross-border reports identify the seller by both.",
+    description: frenchB2BiInvoiceReportDescription,
+  });
+
+/**
+ * The same report as it was stored. Reports filed before the invoicing framework was
+ * asked for carry no `billingMode`, so a stored report is read without it; a new
+ * report is not accepted without it.
+ */
+export const storedFrenchB2BiInvoiceReportSchema = z
+  .object({
+    ...frenchB2BiInvoiceReportShape,
+    billingMode: frenchReportingBillingModeSchema.optional(),
+  })
+  .openapi({
+    ref: "StoredFrenchB2BiInvoiceReport",
+    title: "Stored French cross-border invoice report",
+    description: `${frenchB2BiInvoiceReportDescription} Reports filed before \`billingMode\` was introduced carry no invoicing framework.`,
   });
 
 export const frenchB2BiPaymentReportSchema = z
@@ -243,7 +315,21 @@ export const frenchB2BiReportSchema = z
       "Choose an invoice report for a cross-border invoice or credit note, and a payment report for a payment received on one.",
   });
 
+/** A cross-border report as it was stored, including reports filed before `billingMode`. */
+export const storedFrenchB2BiReportSchema = z
+  .discriminatedUnion("type", [
+    storedFrenchB2BiInvoiceReportSchema,
+    frenchB2BiPaymentReportSchema,
+  ])
+  .openapi({
+    ref: "StoredFrenchB2BiReport",
+    title: "Stored French cross-border report",
+    description:
+      "A cross-border report as it was filed. Invoice reports filed before the invoicing framework was asked for carry no `billingMode`.",
+  });
+
 export type FrenchB2BiReport = z.infer<typeof frenchB2BiReportSchema>;
+export type StoredFrenchB2BiReport = z.infer<typeof storedFrenchB2BiReportSchema>;
 
 type FrenchB2BiReportDocumentProfile = {
   type: ReportingDocumentTypeKey;

--- a/utils/parsing/country-specific/france.ts
+++ b/utils/parsing/country-specific/france.ts
@@ -70,6 +70,8 @@ export const frenchBillingModeSchema = z.enum([
   example: "S1",
 });
 
+export type FrenchBillingMode = z.infer<typeof frenchBillingModeSchema>;
+
 export const frenchCountrySpecificSchema = z.object({
   country: z.literal("FR").openapi({
     description:

--- a/utils/parsing/fr-reporting/duplicates.ts
+++ b/utils/parsing/fr-reporting/duplicates.ts
@@ -1,0 +1,149 @@
+import {
+  storedFrenchB2BiReportSchema,
+  type StoredFrenchB2BiReport,
+} from "@peppol/utils/parsing/b2bi-reporting/france";
+import {
+  frenchB2CReportSchema,
+  type FrenchB2CReport,
+} from "@peppol/utils/parsing/b2c-reporting/france";
+import type { FrenchB2BiReport } from "@peppol/utils/parsing/b2bi-reporting/france";
+
+/** A report as it was stored, which for invoice reports may predate `billingMode`. */
+export type StoredFrenchReport = FrenchB2CReport | StoredFrenchB2BiReport;
+
+/**
+ * What a report submitted under a reference that was already used turns out to be.
+ *
+ * The reference is the idempotency key, so a second use of it answers with the report
+ * filed the first time and files nothing. That is what a retry after a timeout needs.
+ * It is also what happens when a correction or a cancellation is sent under the
+ * reference of the report it means to act on, and then nothing changes. The cases are
+ * told apart by comparing this request with the report that was actually filed.
+ */
+export type FrenchReportDuplicateAssessment =
+  | { kind: "retry"; warning: null }
+  | { kind: "different_action"; warning: string }
+  | { kind: "different_content"; warning: string }
+  | { kind: "unverified_billing_mode"; warning: string }
+  | { kind: "unknown_original"; warning: string };
+
+/**
+ * The comparable form of a report: keys in a fixed order, and fields carrying no value
+ * left out, so an omitted field and an explicit null read alike. Array order is kept,
+ * because the order of a VAT breakdown is part of what was filed.
+ */
+function canonicalise(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalise);
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entry]) => entry !== null && entry !== undefined)
+    .map(([key, entry]) => [key, canonicalise(entry)] as const)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+  return Object.fromEntries(entries);
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalise(value));
+}
+
+/**
+ * The stored report, read back through the schema it was stored under so both sides of
+ * a comparison carry the same defaults. Fields outside the schema are dropped on both
+ * sides alike, so they cannot make two equal reports look different.
+ *
+ * Returns null when the stored data cannot be read as a report; nothing is then
+ * claimed about what was filed.
+ */
+export function readStoredFrenchReport(stored: unknown): StoredFrenchReport | null {
+  const b2c = frenchB2CReportSchema.safeParse(stored);
+  if (b2c.success) {
+    return b2c.data;
+  }
+  const b2bi = storedFrenchB2BiReportSchema.safeParse(stored);
+  if (b2bi.success) {
+    return b2bi.data;
+  }
+  return null;
+}
+
+const requestedActionWording = {
+  submit: "report",
+  correct: "correction",
+  cancel: "cancellation",
+} as const;
+
+const filedActionWording = {
+  submit: "submitted",
+  correct: "corrected",
+  cancel: "cancelled",
+} as const;
+
+function withoutBillingMode(record: Record<string, unknown>): Record<string, unknown> {
+  const { billingMode: _billingMode, ...rest } = record;
+  return rest;
+}
+
+/**
+ * Compares a report submitted under an already used reference with the report that
+ * reference filed. A correction or a cancellation is never presented as successful
+ * when the reference belonged to something else: nothing was filed for it.
+ *
+ * An invoice report filed before the invoicing framework was asked for carries none,
+ * and what it would have been cannot be derived from what was stored. The rest of the
+ * report is still compared, and the framework is reported as unverified rather than
+ * assumed to match.
+ */
+export function assessFrenchReportDuplicate({
+  stored,
+  submitted,
+}: {
+  stored: unknown;
+  submitted: FrenchB2CReport | FrenchB2BiReport;
+}): FrenchReportDuplicateAssessment {
+  const original = readStoredFrenchReport(stored);
+  if (!original) {
+    return {
+      kind: "unknown_original",
+      warning: `Reference "${submitted.reference}" was already used, so nothing was filed for this request. The earlier report could not be read back for comparison, so check the report returned here before treating this request as filed.`,
+    };
+  }
+
+  if (original.action !== submitted.action) {
+    return {
+      kind: "different_action",
+      warning: `Nothing was filed for this request. Reference "${submitted.reference}" was already used for a report that was ${filedActionWording[original.action]}, and a reference can only be used once. The report returned here is that earlier one, unchanged. Send this ${requestedActionWording[submitted.action]} again under a new reference.`,
+    };
+  }
+
+  const originalRecord = original as unknown as Record<string, unknown>;
+  const submittedRecord = submitted as unknown as Record<string, unknown>;
+  const billingModeUnverifiable =
+    originalRecord.billingMode === undefined && submittedRecord.billingMode !== undefined;
+
+  const comparableOriginal = billingModeUnverifiable
+    ? withoutBillingMode(originalRecord)
+    : originalRecord;
+  const comparableSubmitted = billingModeUnverifiable
+    ? withoutBillingMode(submittedRecord)
+    : submittedRecord;
+
+  if (canonicalJson(comparableOriginal) !== canonicalJson(comparableSubmitted)) {
+    return {
+      kind: "different_content",
+      warning: `Nothing was filed for this request. Reference "${submitted.reference}" was already used for a report with different contents, and the report returned here is the one filed the first time. Use a new reference for a report that is not a retry of an earlier one.`,
+    };
+  }
+
+  if (billingModeUnverifiable) {
+    return {
+      kind: "unverified_billing_mode",
+      warning: `Nothing was filed for this request: reference "${submitted.reference}" was already used, and the report returned here is the one filed the first time. That report was filed without an invoicing framework, so the \`billingMode\` sent now could not be compared with it and the framework on file is unknown. If the report on file needs a different framework, file a correction under a new reference.`,
+    };
+  }
+
+  return { kind: "retry", warning: null };
+}

--- a/utils/system-notifications/suppression.ts
+++ b/utils/system-notifications/suppression.ts
@@ -1,0 +1,56 @@
+/**
+ * Best-effort suppression of repeated operational alerts.
+ *
+ * Some conditions are reported by many rows at once: one filing carries many events,
+ * and a single answer about that filing reaches every one of them. Sending a message
+ * per row buries the one thing support has to act on.
+ *
+ * The state lives in the process. It bounds how often the same condition is reported
+ * by one instance, and it is not a record of what was sent: several instances each
+ * report once, and a restart lets the next occurrence through again. Anything that
+ * must be exactly once needs durable state, which this deliberately is not.
+ */
+export type AlertSuppressor = {
+  /** True when this key has not been reported within the interval, and claims the slot. */
+  shouldSend: (key: string, now?: Date) => boolean;
+};
+
+export function createAlertSuppressor({
+  intervalMs,
+  maxEntries = 500,
+}: {
+  intervalMs: number;
+  maxEntries?: number;
+}): AlertSuppressor {
+  const sentAt = new Map<string, number>();
+
+  return {
+    shouldSend(key: string, now: Date = new Date()): boolean {
+      const timestamp = now.getTime();
+      const last = sentAt.get(key);
+      if (last !== undefined && timestamp - last < intervalMs) {
+        return false;
+      }
+
+      // Entries older than the interval can never suppress anything again, so they are
+      // dropped before the map is allowed to grow.
+      for (const [entry, at] of sentAt) {
+        if (timestamp - at >= intervalMs) {
+          sentAt.delete(entry);
+        }
+      }
+      // A flood of distinct keys would otherwise keep every one of them. Oldest first,
+      // which is insertion order for a Map.
+      while (sentAt.size >= maxEntries) {
+        const oldest = sentAt.keys().next();
+        if (oldest.done) {
+          break;
+        }
+        sentAt.delete(oldest.value);
+      }
+
+      sentAt.set(key, timestamp);
+      return true;
+    },
+  };
+}


### PR DESCRIPTION
## Why

A French cross-border invoice report was filed under a fixed invoicing framework ("cadre de facturation") of `S1`, services. The framework is checked against the invoice when the filing for the reporting period is assembled, which happens after the report has been accepted. A goods invoice reported as services therefore passes submission and can cause the filing for that period to be rejected, well after the report was sent, and the outcome of a filing reaches every report that filing carries.

The framework cannot be derived from the figures on a report, so it has to be asked for.

## What changes

**`billingMode` is required on a cross-border invoice report.** It uses the same codes and the same meaning as the `billingMode` of a French regulated invoice, narrowed to the frameworks confirmed for reporting: `B1`/`S1`/`M1`, `B2`/`S2`/`M2` and `B4`/`S4`/`M4`. Other codes an invoice can carry are refused for a report today. A type-level check keeps the reporting list a subset of the invoice list.

This is a **breaking change to the request contract** of `POST /:companyId/reporting/fr/b2bi` for `type: "invoice"`, taken deliberately in preference to a default that is wrong for every goods invoice. The required field and accepted values are documented in the French reporting guide.

Reports already on file carry no framework. They stay readable, renderable and downloadable: the documents API and the renderer read a stored variant of the schema, and no framework is inferred for them.

Four further problems in the same lifecycle, all of which only surface late:

- **A reused reference reported success.** A correction or a cancellation sent under the reference of the report it means to act on is answered with that earlier report and files nothing, because the reference is the idempotency key. The stored report is now compared with the request in a canonical form, and a duplicate that is not a plain retry carries an optional `warning` in the response. A genuine retry is unaffected and carries no warning. A report filed before the framework existed cannot be compared on it, which the warning says rather than assuming a match.
- **A report could be filed and never followed.** The document and the record that polls it are two writes. When the second failed, the report was filed and no status was ever fetched. The retry that lands on the existing document now rebuilds the record from the stored report, never from the request that happens to be retrying, so a reference reused for something else cannot rewrite history. Support is told when the stored report cannot be read, and nothing is invented.
- **One refused filing raised one alert per report.** Alerts are grouped per filing and outcome. The grouping is best effort and per process, disclosed as such in the code: it bounds noise, it is not a record of what was sent. Before a filing exists, an event still speaks for itself so unrelated filings are never merged. Per-document customer webhooks are unchanged.
- **An unfamiliar status value stalled an event silently.** The two status vocabularies were closed lists, so a value outside them failed the parse and the event kept retrying with only a log line. Unknown values now keep the last known public status, are reported once per value per environment, keep the raw ledger value as evidence, and stay on a bounded retry instead of falling out of polling.

## Not in this change

Deliberately left for provider answers: no matching key is persisted and no repeated submission is blocked, no partial-payment behaviour is invented, no correction deadline is enforced locally, terminal status semantics are untouched, polling is not postponed to the period cutoff, and no event's status is copied to the others on its filing. There is no database migration.

## Tests

`bun test ./test/*.test.ts`: 438 pass, 0 fail. `tsc --noEmit`: clean. New: `test/fr-reporting-duplicates.test.ts`, `test/fr-reporting-record-repair.test.ts` (write failure after the report is filed, and recovery on retry, against an injected gateway rather than a mirror of the helper). Updated: the cross-border, render and submission suites, including a legacy report with no framework. No test contacts the reporting service or sends a message.

## Open with the reporting service

Answers that would change follow-up work: what a repeated submission on an existing key does (which decides how several payments on one invoice are reported), whether a report can move from deposited to a definitive outcome after it is already reported as filed, how to recover after a filing is refused, the exact error for a correction that arrives too late, and whether the other invoicing frameworks are accepted for reporting.

Docs: recommand/recommand-docs#23

